### PR TITLE
Make the grid examples visible

### DIFF
--- a/app/components/grid.njk
+++ b/app/components/grid.njk
@@ -1,54 +1,54 @@
 
 <h4 class="nhsuk-u-margin-bottom-0">Full width (100%)</h4>
-<div class="nhsuk-grid-row nhsuk-o-grid--example">
-  <div class="nhsuk-o-grid__item nhsuk-o-grid__item--full">
-    <p>nhsuk-grid-row</p>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <p>.nhsuk-grid-column-full</p>
   </div>
 </div>
 <h4 class="nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4 ">Halves (50%)</h4>
-<div class="nhsuk-grid-row nhsuk-o-grid--example">
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-half">
-    <p>nhsuk-grid-column-one-half</p>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-one-half">
+    <p>.nhsuk-grid-column-one-half</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-half">
-    <p>nhsuk-grid-column-one-half</p>
+  <div class="nhsuk-grid-column-one-half">
+    <p>.nhsuk-grid-column-one-half</p>
   </div>
 </div>
 <h4 class="nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4 ">Thirds (33%)</h4>
-<div class="nhsuk-grid-row nhsuk-o-grid--example">
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-two-thirds">
-    <p>nhsuk-grid-column-two-thirds</p>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+    <p>.nhsuk-grid-column-two-thirds</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-third">
-    <p>nhsuk-grid-column-one-third</p>
+  <div class="nhsuk-grid-column-one-third">
+    <p>.nhsuk-grid-column-one-third</p>
   </div>
 </div>
-<div class="nhsuk-grid-row nhsuk-o-grid--example">
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-third">
-    <p>nhsuk-grid-column-one-third</p>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-one-third">
+    <p>.nhsuk-grid-column-one-third</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-two-thirds">
-    <p>nhsuk-grid-column-two-thirds</p>
+  <div class="nhsuk-grid-column-two-thirds">
+    <p>.nhsuk-grid-column-two-thirds</p>
   </div>
 </div>
 <h4 class="nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4 ">Quarters (25%)</h4>
-<div class="nhsuk-grid-row nhsuk-o-grid--example">
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-three-quarters">
-    <p>nhsuk-grid-column-three-quarters</p>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-three-quarters">
+    <p>.nhsuk-grid-column-three-quarters</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-quarter">
-    <p>nhsuk-grid-column-one-quarter</p>
+  <div class="nhsuk-grid-column-one-quarter">
+    <p>.nhsuk-grid-column-one-quarter</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-quarter">
-    <p>nhsuk-grid-column-one-quarter</p>
+  <div class="nhsuk-grid-column-one-quarter">
+    <p>.nhsuk-grid-column-one-quarter</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-quarter">
-    <p>nhsuk-grid-column-one-quarter</p>
+  <div class="nhsuk-grid-column-one-quarter">
+    <p>.nhsuk-grid-column-one-quarter</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-quarter">
-    <p>nhsuk-grid-column-one-quarter</p>
+  <div class="nhsuk-grid-column-one-quarter">
+    <p>.nhsuk-grid-column-one-quarter</p>
   </div>
-  <div class="nhsuk-o-grid__item nhsuk-grid-column-one-quarter">
-    <p>nhsuk-grid-column-one-quarter</p>
+  <div class="nhsuk-grid-column-one-quarter">
+    <p>.nhsuk-grid-column-one-quarter</p>
   </div>
 </div>

--- a/app/styles/design-example-overrides.scss
+++ b/app/styles/design-example-overrides.scss
@@ -1,0 +1,27 @@
+/*
+ * WARNING: This file is intended for adding extra styles to the code snippet
+ * examples and standalone examples.
+ * Beware of adding too much in to this file, we should aim for our example
+ * code to look as close to the unmodified nhsuk-frontend library as possible.
+ */
+
+html {
+ background-color: #f0f4f5;
+}
+
+/* Component examples need a bit of space around them */
+body {
+ margin: 64px 16px 32px 16px;
+}
+
+/*
+  In order to show how the grid works, we need to have an element inside the
+  grid that is visible and fills the available space with a background color.
+*/
+.nhsuk-grid-row > div > p {
+   background-color: #004ba4;
+   color: #fff;
+   text-align: center;
+   margin: 30px 0 0;
+   padding: 20px;
+}

--- a/app/views/includes/design-example-wrapper.njk
+++ b/app/views/includes/design-example-wrapper.njk
@@ -13,16 +13,7 @@
     <link rel="icon" href="/nhsuk-frontend/assets/favicons/favicon.png">
 
     <link rel="stylesheet" href="/nhsuk-frontend/nhsuk.css">
-
-    <style>
-      html {
-        background-color: #f0f4f5;
-      }
-      body {
-        margin: 64px 16px 32px 16px;
-      }
-
-    </style>
+    <link rel="stylesheet" href="/css/design-example-overrides.min.css">
 
     <script src="/nhsuk-frontend/nhsuk.min.js" defer></script>
   </head>


### PR DESCRIPTION
- Move nhsuk-frontend library overrides into it's own .scss file.
  Any styles that affect the code examples should go into the `design-example-override.scss` file.
  This file is only served in the code examples and not the rest of the service manual, so it will help us 
  isolate any code that makes examples look different to the "vanilla" frontend library.

- Add some CSS to make the grid example visible. (blue-box styles taken from the old service manual)