### PR TITLE
Remove extra nhsuk-width-container causing extra padding on mobile

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -69,19 +69,15 @@
 
 {% block body %}
 <section class="nhsuk-section">
-  <div class="nhsuk-width-container">
-
-    <div class="nhsuk-grid-row">
-      <div class="nhsuk-grid-column-one-half">
-        <h2>Community</h2>
-        <p>The NHS digital service manual comes from the experience of the teams at NHS Digital behind the <a href="http://nhs.uk">NHS website</a>. It is maintained by the standards team. <a href="mailto:service-manual@nhs.net">Email us</a> or get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> if you have any questions.</p>
-      </div>
-      <div class="nhsuk-grid-column-one-half">
-        <h2>Contribute</h2>
-        <p>The manual is always evolving as we learn more. Help us to improve and grow it: <a href="/service-manual/contribute">discuss patterns, give feedback and submit new work</a>.</p>
-      </div>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-one-half">
+      <h2>Community</h2>
+      <p>The NHS digital service manual comes from the experience of the teams at NHS Digital behind the <a href="http://nhs.uk">NHS website</a>. It is maintained by the standards team. <a href="mailto:service-manual@nhs.net">Email us</a> or get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> if you have any questions.</p>
     </div>
-
+    <div class="nhsuk-grid-column-one-half">
+      <h2>Contribute</h2>
+      <p>The manual is always evolving as we learn more. Help us to improve and grow it: <a href="/service-manual/contribute">discuss patterns, give feedback and submit new work</a>.</p>
+    </div>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
There was extra padding on mobile devices around the Community and Contribute sections of the Service Manual homepage. This was caused by an extra `nhsuk-width-container` being used, there is already a `nhsuk-width-container` wrapping the page around the `<main>` element.

```
<div class="nhsuk-width-container">
  <main class="nhsuk-main-wrapper" id="maincontent">
    
  </main>
</div>
```