### PR TITLE
Add an IE11 polyfill for forEach on nodelists

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,3 +1,5 @@
+import './polyfills'
+
 import cookieConsent from './cookieConsent';
 import digitalData from './digitalData';
 import DesignExample from './design-example';

--- a/app/scripts/polyfills.js
+++ b/app/scripts/polyfills.js
@@ -1,0 +1,12 @@
+/**
+ * Polyfill for IE11 so that we can do document.querySelectorAll().forEach()
+ * https://gist.github.com/raindrop-ua/a87cf43349b0cf4ee7a512f3b87529b9#file-polyfill-ie11-nodelist-foreach-js
+ */
+if ('NodeList' in window && !NodeList.prototype.forEach) {
+  NodeList.prototype.forEach = function (callback, thisArg) {
+    thisArg = thisArg || window;
+    for (var i = 0; i < this.length; i++) {
+      callback.call(thisArg, this[i], i, this);
+    }
+  };
+}


### PR DESCRIPTION
We had javascript errors due to lack of `forEach` support on `NodeList` objects, which meant that the code snippet button wasn't working. This polyfill adds `forEach` support.