### PR TITLE
Fix the broken homepage links for deployment to beta

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ env.addFilter('highlight', function(code, language) {
 })
 
 // Render standalone design examples
-app.get('/design-example/:example', function(req, res) {
+app.get('/service-manual/design-example/:example', function(req, res) {
   var example = req.params.example
   var examplePath = path.join(__dirname, `/app/components/${example}.njk`)
 

--- a/app/views/includes/design-example.njk
+++ b/app/views/includes/design-example.njk
@@ -1,7 +1,7 @@
 {% macro designExample(params) %}
 
 {% set examplePath = 'app/components/' + params.type + '.njk' %}
-{% set standaloneURL = '/design-example/' + params.type %}
+{% set standaloneURL = '/service-manual/design-example/' + params.type %}
 
 {# `showExample` is true, unless explicitly turned off with params #}
 {% set showExample = params.showExample !== false %}

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -1,6 +1,7 @@
 {% from 'components/header/macro.njk' import header %}
 
 {{ header({
+  "homeHref": "/service-manual/",
   "service": {
     "name": "Digital service manual",
     "longName": "true"

--- a/app/views/page-not-found.njk
+++ b/app/views/page-not-found.njk
@@ -8,7 +8,7 @@
   <div class="nhsuk-grid-column-two-thirds">
     <h1>We can’t find the page you’re looking for</h1>
     <p>If you entered a web address, please check it was correct.</p>
-    <p>You can also browse the <a href="/">NHS digital service manual homepage</a> to find the information you need.</p>
+    <p>You can also browse the <a href="/service-manual/">NHS digital service manual homepage</a> to find the information you need.</p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Links to the homepage should be `/service-manual` otherwise when we deploy to https://beta.nhs.uk `/` would link to the beta homepage rather than the service manual homepage.