### PR TITLE
Use full URL for the social media image cards

### DIFF
--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -39,14 +39,14 @@
     <meta name="twitter:site" content="@nhsuk" />
     <meta name="twitter:title" content="{% if pageTitle %}{{pageTitle}} - NHS digital service manual{% else %}NHS digital service manual{% endif %}" />
     <meta name="twitter:description" content="{% if pageDescription %}{{pageDescription}}{% else %}Design and build digital services for the NHS. Things you need to make consistent, usable services that put people first.{% endif %}" />
-    <meta name="twitter:image" content="/service-manual/assets/open-graph.png" />
+    <meta name="twitter:image" content="https://beta.nhs.uk/service-manual/assets/open-graph.png" />
 
     <!-- https://developers.facebook.com/docs/sharing/webmasters/ -->
     <meta property="og:url" content="https://beta.nhs.uk/service-manual/" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{% if pageTitle %}{{pageTitle}} - NHS digital service manual{% else %}NHS digital service manual{% endif %}" />
     <meta property="og:description" content="{% if pageDescription %}{{pageDescription}}{% else %}Design and build digital services for the NHS. Things you need to make consistent, usable services that put people first.{% endif %}" />
-    <meta property="og:image" content="/service-manual/assets/open-graph.png" />
+    <meta property="og:image" content="https://beta.nhs.uk/service-manual/assets/open-graph.png" />
 
   </head>
 


### PR DESCRIPTION
Local image paths don't work for the social media image cards, the path needs to be the full URL.