### PR TITLE
Fix link from 'breadcrumbs' to 'footer'

### DIFF
--- a/app/views/styles-components-patterns/breadcrumbs.njk
+++ b/app/views/styles-components-patterns/breadcrumbs.njk
@@ -58,7 +58,7 @@
     {{ panel({
       "label": "Similar patterns",
       "HTML": "<ul>
-                  <li><a href='/serivce-manual/styles-components-patterns/footer'>Footer</a></li>
+                  <li><a href='/service-manual/styles-components-patterns/footer'>Footer</a></li>
                   <li><a href='/service-manual/styles-components-patterns/header'>Header</a></li>
               </ul>"
     }) }}


### PR DESCRIPTION
The link from 'breadcrumbs' to 'footer' worked locally, but had a typo and didn't work in the live site.