### PR TITLE
[refs #117] Set status code 404 on page not found pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ app.get(/^([^.]+)$/, function (req, res, next) {
 })
 
 app.get('*', function(req, res){
+  res.statusCode = 404;
   res.render('page-not-found');
 });
 


### PR DESCRIPTION
The "page not found" page is being served as a valid http response (200 OK). It now returns a 404 status code.