### PR TITLE
Remove the caret icon for close snippet

### DIFF
--- a/app/views/includes/design-example.njk
+++ b/app/views/includes/design-example.njk
@@ -69,7 +69,7 @@
               </code></pre>
               {% if snippets|length > 1 %}
               <button class="app-link--close" href="#close" aria-live="assertive">
-                  <svg><use xlink:href="#caret-right"></use></svg>Close
+                Close
               </button>
               {% endif %}
           </div>


### PR DESCRIPTION
Using caret icon to convey close does not follow our icon guidelines.