### PR TITLE
Feature/no index

### DIFF
--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{% if pageDescription %}{{pageDescription}}{% else %}Design and build digital services for the NHS. Things you need to make consistent, usable services that put people first.{% endif %}" />
+    {% if noFollow %}<meta name="robots" content="noindex">{% endif %}
 
     <title>{% if pageTitle %}{{pageTitle}} - NHS digital service manual{% else %}NHS digital service manual{% endif %}</title>
 

--- a/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
+++ b/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '1. Understand users and their needs in the context of health and care' %}
+{% set noFollow = true %}
 {% set pageDescription = 'Take time to understand your users\' clinical, practical and emotional needs - and abilities - and how you can help them manage their own health better.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/2-work-towards-solving-the-whole-problem.njk
+++ b/app/views/service-standard/2-work-towards-solving-the-whole-problem.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '2. Work towards solving the whole problem' %}
+{% set noFollow = true %}
 {% set pageDescription = 'Consider where your service fits in your users\' healthcare journey and whether you could support or influence a wider solution.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/3-create-a-more-joined-up-experience.njk
+++ b/app/views/service-standard/3-create-a-more-joined-up-experience.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '3. Create a more joined up experience' %}
+{% set noFollow = true %}
 {% set pageDescription = 'TBD.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/4-make-the-service-easy-to-use.njk
+++ b/app/views/service-standard/4-make-the-service-easy-to-use.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '4. Make the service easy to use' %}
+{% set noFollow = true %}
 {% set pageDescription = 'TBD.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '5. Make sure everyone can use the service' %}
+{% set noFollow = true %}
 {% set pageDescription = 'TBD.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/6-define-what-success-looks-like-and-publish-performance-data.njk
+++ b/app/views/service-standard/6-define-what-success-looks-like-and-publish-performance-data.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '6. Define what success looks like and publish performance data' %}
+{% set noFollow = true %}
 {% set pageDescription = 'TBD.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/7-respect-and-protect-users-confidentiality-and-privacy.njk
+++ b/app/views/service-standard/7-respect-and-protect-users-confidentiality-and-privacy.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = '7. Respect and protect users’ confidentiality and privacy' %}
+{% set noFollow = true %}
 {% set pageDescription = 'TBD.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/about.njk
+++ b/app/views/service-standard/about.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = 'About the NHS service standard' %}
+{% set noFollow = true %}
 {% set pageDescription = 'The NHS service standard is currently a \'prototype\' - a first version. We\'re testing it with NHS teams.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/app/views/service-standard/index.njk
+++ b/app/views/service-standard/index.njk
@@ -1,4 +1,5 @@
 {% set pageTitle = 'NHS service standard' %}
+{% set noFollow = true %}
 {% set pageDescription = 'The NHS service standard is designed to help NHS digital teams build and run products or services which help improve health outcomes.' %}
 
 {% extends 'includes/layout.njk' %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NHS digital service manual",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Stop the service standards pages from being indexed by Google and other search engines.
 
Also bump the `package.json` for the next release of the service manual.