### PR TITLE
Split out terraform build from standard pipelines build.

### DIFF
--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -54,7 +54,7 @@ steps:
       
       terraform init -backend-config="key=nhs-service-manual.$ENVIRONMENT.terraform.tfstate" -backend-config="access_key=$STORAGE_ACCOUNT_KEY" -reconfigure
       
-      terraform plan -input=false | tee terraform.plan
+      terraform plan -input=false -out=terraform.plan
   env:
     TF_VAR_manual_username: $(MANUAL_USERNAME)
     TF_VAR_manual_password: $(MANUAL_PASSWORD)

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -1,0 +1,27 @@
+---
+trigger:
+  branches:
+    include:
+    - master
+    - develop
+  paths:
+    include:
+    - deploy/terraform/*
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+- bash: |
+    terraform plan > terraform.plan
+  displayName: 'terraform plan'
+  cwd:  '$(System.DefaultWorkingDirectory)/deploy/terraform'
+
+- task: ArchiveFiles@2
+  displayName: 'Archive files'
+  inputs:
+    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/deploy/terraform'
+    includeRootFolder: false
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish artifacts: drop'

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -73,7 +73,6 @@ steps:
 - task: Bash@3
   displayName: 'Encrypt zip file'
   inputs:
-    failOnStderr: true
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -77,8 +77,9 @@ steps:
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |
-      sudo apt install pgp --yes
+      sudo apt install gnupg --yes
       gpg --batch --yes --passphrase $GPG_ENCRYPT_PASSWORD -c $BUILD_BUILDID.zip -o $BUILD_BUILDID.zip.gpg
+      rm $BUILD_BUILDID.zip
   env:
     GPG_ENCRYPT_PASSWORD: $(GPG_ENCRYPT_PASSWORD)
 

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -16,6 +16,18 @@ pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
+- task: Bash@3
+  displayName: 'Set environment'
+  inputs:
+    failOnStderr: true
+    targetType: inline
+    script: |
+      ENVIRONMENT=staging
+      if [ "$BUILD_SOURCEBRANCH" = "refs/heads/master" ]; then
+        ENVIRONMENT=production
+      fi
+      echo "##vso[task.setvariable variable=ENVIRONMENT]$ENVIRONMENT"
+
 - task: AzureCLI@1
   displayName: 'Get storage account key'
   inputs:

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -8,14 +8,43 @@ trigger:
     include:
     - deploy/terraform/*
 
+variables:
+  MANUAL_USERNAME: $(SECRET_MANUAL_USERNAME)
+  MANUAL_PASSWORD: $(SECRET_MANUAL_PASSWORD)
+
 pool:
   vmImage: 'Ubuntu-16.04'
 
 steps:
-- bash: |
-    terraform plan > terraform.plan
+- task: AzureCLI@1
+  displayName: 'Get storage account key'
+  inputs:
+    azureSubscription: 'www.nhs.uk (1e543650-5458-44ea-a3b1-35a6d0d92cc9)'
+    scriptLocation: inlineScript
+    inlineScript: |
+      access_key=$(az storage account keys list -g tfbackends -n tfbackends --subscription www.nhs.uk | jq -r '.[0].value')
+      echo "##vso[task.setvariable variable=STORAGE_ACCOUNT_KEY]$access_key"
+
+- task: AzureCLI@1
   displayName: 'terraform plan'
-  workingDirectory: '$(System.DefaultWorkingDirectory)/deploy/terraform'
+  inputs:
+    azureSubscription: 'Beta.nhs.uk (d29bb595-46d1-4c56-82c4-9f2e0062c2da)'
+    workingDirectory: '$(System.DefaultWorkingDirectory)/deploy/terraform'
+    addSpnToEnvironment: true
+    scriptLocation: inlineScript
+    inlineScript: |
+      export ARM_CLIENT_ID="$servicePrincipalId"
+      export ARM_CLIENT_SECRET="$servicePrincipalKey"
+      export ARM_TENANT_ID=$(az account show | jq -r '.tenantId')
+      export ARM_SUBSCRIPTION_ID=$(az account show | jq -r '.id')
+      
+      terraform init -backend-config="key=nhs-service-manual.$ENVIRONMENT.terraform.tfstate" -backend-config="access_key=$STORAGE_ACCOUNT_KEY" -reconfigure
+      
+      terraform plan -input=false | tee terraform.plan
+  env:
+    TF_VAR_manual_username: $(MANUAL_USERNAME)
+    TF_VAR_manual_password: $(MANUAL_PASSWORD)
+    TF_VAR_environment: $(ENVIRONMENT)
 
 - task: ArchiveFiles@2
   displayName: 'Archive files'

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -73,10 +73,11 @@ steps:
 - task: Bash@3
   displayName: 'Encrypt zip file'
   inputs:
+    failOnStandardError: true
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |
-      gpg --yes --passphrase "$GPG_ENCRYPT_PASSWORD" --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip 
+      gpg --quiet --yes --passphrase "$GPG_ENCRYPT_PASSWORD" --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip 
       rm $BUILD_BUILDID.zip
   env:
     GPG_ENCRYPT_PASSWORD: "$(GPG_ENCRYPT_PASSWORD)"

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -15,7 +15,7 @@ steps:
 - bash: |
     terraform plan > terraform.plan
   displayName: 'terraform plan'
-  cwd:  '$(System.DefaultWorkingDirectory)/deploy/terraform'
+  workingDirectory: '$(System.DefaultWorkingDirectory)/deploy/terraform'
 
 - task: ArchiveFiles@2
   displayName: 'Archive files'

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -77,8 +77,7 @@ steps:
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |
-      sudo apt install gnupg --yes
-      gpg --batch --yes --passphrase $GPG_ENCRYPT_PASSWORD -c $BUILD_BUILDID.zip -o $BUILD_BUILDID.zip.gpg
+      echo $GPG_ENCRYPT_PASSWORD | gpg --yes --passphrase-fd 0 --symmetric $BUILD_BUILDID.zip --output $BUILD_BUILDID.zip.gpg
       rm $BUILD_BUILDID.zip
   env:
     GPG_ENCRYPT_PASSWORD: $(GPG_ENCRYPT_PASSWORD)

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -73,11 +73,10 @@ steps:
 - task: Bash@3
   displayName: 'Encrypt zip file'
   inputs:
-    failOnStandardError: true
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |
-      gpg --quiet --yes --passphrase "$GPG_ENCRYPT_PASSWORD" --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip 
+      gpg --yes --passphrase "$GPG_ENCRYPT_PASSWORD" --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip
       rm $BUILD_BUILDID.zip
   env:
     GPG_ENCRYPT_PASSWORD: "$(GPG_ENCRYPT_PASSWORD)"

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -77,7 +77,7 @@ steps:
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |
-      echo $GPG_ENCRYPT_PASSWORD | gpg --yes --passphrase-fd 0 --symmetric $BUILD_BUILDID.zip --output $BUILD_BUILDID.zip.gpg
+      gpg --yes --passphrase $GPG_ENCRYPT_PASSWORD --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip 
       rm $BUILD_BUILDID.zip
   env:
     GPG_ENCRYPT_PASSWORD: $(GPG_ENCRYPT_PASSWORD)

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -22,11 +22,13 @@ steps:
     failOnStderr: true
     targetType: inline
     script: |
-      ENVIRONMENT=staging
       if [ "$BUILD_SOURCEBRANCH" = "refs/heads/master" ]; then
         ENVIRONMENT=production
+      else
+        ENVIRONMENT=staging
       fi
       echo "##vso[task.setvariable variable=ENVIRONMENT]$ENVIRONMENT"
+      echo "##vso[build.addbuildtag]$ENVIRONMENT"
 
 - task: AzureCLI@1
   displayName: 'Get storage account key'

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -77,10 +77,10 @@ steps:
     workingDirectory: '$(Build.ArtifactStagingDirectory)/'
     targetType: inline
     script: |
-      gpg --yes --passphrase $GPG_ENCRYPT_PASSWORD --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip 
+      gpg --yes --passphrase "$GPG_ENCRYPT_PASSWORD" --output $BUILD_BUILDID.zip.gpg --symmetric $BUILD_BUILDID.zip 
       rm $BUILD_BUILDID.zip
   env:
-    GPG_ENCRYPT_PASSWORD: $(GPG_ENCRYPT_PASSWORD)
+    GPG_ENCRYPT_PASSWORD: "$(GPG_ENCRYPT_PASSWORD)"
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts: drop'

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -19,6 +19,7 @@ steps:
 - task: AzureCLI@1
   displayName: 'Get storage account key'
   inputs:
+    failOnStandardError: true
     azureSubscription: 'www.nhs.uk (1e543650-5458-44ea-a3b1-35a6d0d92cc9)'
     scriptLocation: inlineScript
     inlineScript: |
@@ -28,6 +29,7 @@ steps:
 - task: AzureCLI@1
   displayName: 'terraform plan'
   inputs:
+    failOnStandardError: true
     azureSubscription: 'Beta.nhs.uk (d29bb595-46d1-4c56-82c4-9f2e0062c2da)'
     workingDirectory: '$(System.DefaultWorkingDirectory)/deploy/terraform'
     addSpnToEnvironment: true

--- a/azure-pipelines.terraform.yml
+++ b/azure-pipelines.terraform.yml
@@ -11,6 +11,7 @@ trigger:
 variables:
   MANUAL_USERNAME: $(SECRET_MANUAL_USERNAME)
   MANUAL_PASSWORD: $(SECRET_MANUAL_PASSWORD)
+  GPG_ENCRYPT_PASSWORD: $(SECRET_GPG_ENCRYPT_PASSWORD)
 
 pool:
   vmImage: 'Ubuntu-16.04'
@@ -67,6 +68,19 @@ steps:
   inputs:
     rootFolderOrFile: '$(System.DefaultWorkingDirectory)/deploy/terraform'
     includeRootFolder: false
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+
+- task: Bash@3
+  displayName: 'Encrypt zip file'
+  inputs:
+    failOnStderr: true
+    workingDirectory: '$(Build.ArtifactStagingDirectory)/'
+    targetType: inline
+    script: |
+      sudo apt install pgp --yes
+      gpg --batch --yes --passphrase $GPG_ENCRYPT_PASSWORD -c $BUILD_BUILDID.zip -o $BUILD_BUILDID.zip.gpg
+  env:
+    GPG_ENCRYPT_PASSWORD: $(GPG_ENCRYPT_PASSWORD)
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish artifacts: drop'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,14 @@
-# Node.js
-# Build a general Node.js project with npm.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
-
+---
 trigger:
-- master
-- develop
+  branches:
+    include:
+    - master
+    - develop
+  paths:
+    include:
+    - /
+    exclude:
+    - deploy/terraform/*
 
 pool:
   vmImage: 'Ubuntu-16.04'
@@ -16,7 +19,7 @@ steps:
     versionSpec: '10.x'
   displayName: 'Install Node.js'
 
-- script: |
+- bash: |
     mkdir src
     find . -maxdepth 1 -not \( -name deploy -or -name 'azure-pipelines.yml' -or -name .git -or -name .gitignore -or -name README.md -or -name src -or -name . \) -exec mv '{}' './src/' \;
     npm install --prefix src && npm test --prefix src


### PR DESCRIPTION
This should make it so that terraform changes do a new terraform plan / apply, but non-terraform changes don't.