### PR TITLE
use the correct paths for importing nunjuck macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Publish new contribution pages for proposing and working on new features with contribution criteria
 - Publish new pattern; Mini-hub
 
+:wrench: **Fixes**
+
+- Use the correct paths in the component code snippets for importing Nunjucks macros
+
 ## 1.1.1 - 4 March 2019
 
 :wrench: **Fixes**

--- a/app.js
+++ b/app.js
@@ -34,7 +34,7 @@ app.set('view engine', 'njk');
 // Nunjucks configuration
 var appViews = [
   path.join(__dirname, '/app/views/'),
-  path.join(__dirname, '/node_modules/nhsuk-frontend/packages')
+  path.join(__dirname, '/node_modules/nhsuk-frontend/packages/components')
 ]
 
 var env = nunjucks.configure(appViews, {

--- a/app/components/action-link.njk
+++ b/app/components/action-link.njk
@@ -1,4 +1,4 @@
-{% from 'components/action-link/macro.njk' import actionLink %}
+{% from 'action-link/macro.njk' import actionLink %}
 
 {{ actionLink({
   "text": "Find a minor injuries unit",

--- a/app/components/back-link.njk
+++ b/app/components/back-link.njk
@@ -1,4 +1,4 @@
-{% from 'components/back-link/macro.njk' import backLink %}
+{% from 'back-link/macro.njk' import backLink %}
 
 {{ backLink({
   "href": "#",

--- a/app/components/breadcrumb.njk
+++ b/app/components/breadcrumb.njk
@@ -1,4 +1,4 @@
-{% from 'components/breadcrumb/macro.njk' import breadcrumb %}
+{% from 'breadcrumb/macro.njk' import breadcrumb %}
 
 {{ breadcrumb({
   items: [

--- a/app/components/button-reverse.njk
+++ b/app/components/button-reverse.njk
@@ -1,4 +1,4 @@
-{% from 'components/button/macro.njk' import button %}
+{% from 'button/macro.njk' import button %}
 
 {{ button({
   "text": "Save and continue",

--- a/app/components/button-secondary.njk
+++ b/app/components/button-secondary.njk
@@ -1,4 +1,4 @@
-{% from 'components/button/macro.njk' import button %}
+{% from 'button/macro.njk' import button %}
 
 {{ button({
   "text": "Find my location",

--- a/app/components/button.njk
+++ b/app/components/button.njk
@@ -1,4 +1,4 @@
-{% from 'components/button/macro.njk' import button %}
+{% from 'button/macro.njk' import button %}
 
 {{ button({
   "text": "Save and continue"

--- a/app/components/care-card-immediate.njk
+++ b/app/components/care-card-immediate.njk
@@ -1,4 +1,4 @@
-{% from 'components/care-card/macro.njk' import careCard %}
+{% from 'care-card/macro.njk' import careCard %}
 
 {{ careCard({
   "type": "immediate",

--- a/app/components/care-card-non-urgent.njk
+++ b/app/components/care-card-non-urgent.njk
@@ -1,4 +1,4 @@
-{% from 'components/care-card/macro.njk' import careCard %}
+{% from 'care-card/macro.njk' import careCard %}
 
 {{ careCard({
   "type": "non-urgent",

--- a/app/components/care-card-urgent.njk
+++ b/app/components/care-card-urgent.njk
@@ -1,4 +1,4 @@
-{% from 'components/care-card/macro.njk' import careCard %}
+{% from 'care-card/macro.njk' import careCard %}
 
 {{ careCard({
   "type": "urgent",

--- a/app/components/checkboxes.njk
+++ b/app/components/checkboxes.njk
@@ -1,4 +1,4 @@
-{% from 'components/checkboxes/macro.njk' import checkboxes %}
+{% from 'checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
   "idPrefix": "nationality",

--- a/app/components/contents-list.njk
+++ b/app/components/contents-list.njk
@@ -1,4 +1,4 @@
-{% from 'components/contents-list/macro.njk' import contentsList %}
+{% from 'contents-list/macro.njk' import contentsList %}
 
 {{ contentsList({
   items: [

--- a/app/components/date-input-errors.njk
+++ b/app/components/date-input-errors.njk
@@ -1,4 +1,4 @@
-{% from 'components/date-input/macro.njk' import dateInput %}
+{% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
   "id": "dob-errors",

--- a/app/components/date-input.njk
+++ b/app/components/date-input.njk
@@ -1,4 +1,4 @@
-{% from 'components/date-input/macro.njk' import dateInput %}
+{% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
   "id": "dob",

--- a/app/components/details.njk
+++ b/app/components/details.njk
@@ -1,4 +1,4 @@
-{% from 'components/details/macro.njk' import details %}
+{% from 'details/macro.njk' import details %}
 
 {{ details({
   "text": "Where can I find my NHS number?",

--- a/app/components/do-dont-list.njk
+++ b/app/components/do-dont-list.njk
@@ -1,4 +1,4 @@
-{% from 'components/do-dont-list/macro.njk' import list %}
+{% from 'do-dont-list/macro.njk' import list %}
 
 {{ list({
   "title": "Do",

--- a/app/components/error-message-in-context.njk
+++ b/app/components/error-message-in-context.njk
@@ -1,5 +1,5 @@
-{% from 'components/error-message/macro.njk' import errorMessage %}
-{% from 'components/date-input/macro.njk' import dateInput %}
+{% from 'error-message/macro.njk' import errorMessage %}
+{% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
       "id": "dob-day-error",

--- a/app/components/error-message.njk
+++ b/app/components/error-message.njk
@@ -1,4 +1,4 @@
-{% from 'components/error-message/macro.njk' import errorMessage %}
+{% from 'error-message/macro.njk' import errorMessage %}
 
 {{ errorMessage({
   "text": "Date of birth must be in the past"

--- a/app/components/error-summary.njk
+++ b/app/components/error-summary.njk
@@ -1,4 +1,4 @@
-{% from 'components/error-summary/macro.njk' import errorSummary %}
+{% from 'error-summary/macro.njk' import errorSummary %}
 
 {{ errorSummary({
   "titleText": "There is a problem",

--- a/app/components/expander-group.njk
+++ b/app/components/expander-group.njk
@@ -1,4 +1,4 @@
-{% from 'components/details/macro.njk' import details %}
+{% from 'details/macro.njk' import details %}
 
 <div class="nhsuk-expander-group">
   {{ details({

--- a/app/components/expander.njk
+++ b/app/components/expander.njk
@@ -1,4 +1,4 @@
-{% from 'components/details/macro.njk' import details %}
+{% from 'details/macro.njk' import details %}
 
 {{ details({
   "classes": "nhsuk-expander",

--- a/app/components/feedback-banner.njk
+++ b/app/components/feedback-banner.njk
@@ -1,4 +1,4 @@
-{% from 'components/feedback-banner/macro.njk' import feedbackBanner %}
+{% from 'feedback-banner/macro.njk' import feedbackBanner %}
 
 {{ feedbackBanner({
   "title": "Help us make the NHS website better",

--- a/app/components/fieldset-as-heading.njk
+++ b/app/components/fieldset-as-heading.njk
@@ -1,4 +1,4 @@
-{% from 'components/fieldset/macro.njk' import fieldset %}
+{% from 'fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
   "legend": {

--- a/app/components/fieldset.njk
+++ b/app/components/fieldset.njk
@@ -1,4 +1,4 @@
-{% from 'components/fieldset/macro.njk' import fieldset %}
+{% from 'fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
   "legend": {

--- a/app/components/footer.njk
+++ b/app/components/footer.njk
@@ -1,4 +1,4 @@
-{% from 'components/footer/macro.njk' import footer %}
+{% from 'footer/macro.njk' import footer %}
 
 {{ footer({
   "links": [

--- a/app/components/header.njk
+++ b/app/components/header.njk
@@ -1,4 +1,4 @@
-{% from 'components/header/macro.njk' import header %}
+{% from 'header/macro.njk' import header %}
 
 {{ header({
     "showNav": "true",

--- a/app/components/hint-text.njk
+++ b/app/components/hint-text.njk
@@ -1,4 +1,4 @@
-{% from 'components/hint/macro.njk' import hint %}
+{% from 'hint/macro.njk' import hint %}
 
 {{ hint({
   "text": "This is a 10 digit number, like 485 777 3456."

--- a/app/components/images.njk
+++ b/app/components/images.njk
@@ -1,4 +1,4 @@
-{% from 'components/images/macro.njk' import image %}
+{% from 'images/macro.njk' import image %}
 
 {{ image({
   "src": "https://assets.nhs.uk/prod/images/S_1017_allergic-conjunctivitis_M15.2e16d0ba.fill-320x213.jpg",

--- a/app/components/input-fixed-width.njk
+++ b/app/components/input-fixed-width.njk
@@ -1,4 +1,4 @@
-{% from 'components/input/macro.njk' import input %}
+{% from 'input/macro.njk' import input %}
 
 {{ input({
   "label": {

--- a/app/components/input-hint-text.njk
+++ b/app/components/input-hint-text.njk
@@ -1,6 +1,4 @@
-{% from 'components/input/macro.njk' import input %}
-
-{% from 'components/input/macro.njk' import input %}
+{% from 'input/macro.njk' import input %}
 
 {{ input({
   "label": {

--- a/app/components/input.njk
+++ b/app/components/input.njk
@@ -1,10 +1,10 @@
-{% from 'components/input/macro.njk' import input %}
+{% from 'input/macro.njk' import input %}
 
 {{ input({
   "label": {
     "text": "NHS number"
   },
-    "id": "input-width-10",
+  "id": "input-width-10",
   "name": "test-width-10",
   "classes": "nhsuk-input--width-10"
 }) }}

--- a/app/components/inset-text.njk
+++ b/app/components/inset-text.njk
@@ -1,4 +1,4 @@
-{% from 'components/inset-text/macro.njk' import insetText %}
+{% from 'inset-text/macro.njk' import insetText %}
 
 {{ insetText({
   "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"

--- a/app/components/pagination.njk
+++ b/app/components/pagination.njk
@@ -1,4 +1,4 @@
-{% from 'components/pagination/macro.njk' import pagination %}
+{% from 'pagination/macro.njk' import pagination %}
 
 {{ pagination({
   "previousUrl": "/section/treatments",

--- a/app/components/radios-divider.njk
+++ b/app/components/radios-divider.njk
@@ -1,4 +1,4 @@
-{% from 'components/radios/macro.njk' import radios %}
+{% from 'radios/macro.njk' import radios %}
 
 {{ radios({
   "idPrefix": "example-divider",

--- a/app/components/radios-error.njk
+++ b/app/components/radios-error.njk
@@ -1,4 +1,4 @@
-{% from 'components/radios/macro.njk' import radios %}
+{% from 'radios/macro.njk' import radios %}
 
 {{ radios({
   "idPrefix": "example",

--- a/app/components/radios-hints.njk
+++ b/app/components/radios-hints.njk
@@ -1,4 +1,4 @@
-{% from 'components/radios/macro.njk' import radios %}
+{% from 'radios/macro.njk' import radios %}
 
 {{ radios({
   "idPrefix": "gov",

--- a/app/components/radios-inline.njk
+++ b/app/components/radios-inline.njk
@@ -1,4 +1,4 @@
-{% from 'components/radios/macro.njk' import radios %}
+{% from 'radios/macro.njk' import radios %}
 
 {{ radios({
   "idPrefix": "example",

--- a/app/components/radios.njk
+++ b/app/components/radios.njk
@@ -1,4 +1,4 @@
-{% from 'components/radios/macro.njk' import radios %}
+{% from 'radios/macro.njk' import radios %}
 
 {{ radios({
   "idPrefix": "example",

--- a/app/components/review-date.njk
+++ b/app/components/review-date.njk
@@ -1,4 +1,4 @@
-{% from 'components/review-date/macro.njk' import reviewDate %}
+{% from 'review-date/macro.njk' import reviewDate %}
 
 {{ reviewDate({
   "lastReview": "12 February 2017",

--- a/app/components/select.njk
+++ b/app/components/select.njk
@@ -1,4 +1,4 @@
-{% from 'components/select/macro.njk' import select %}
+{% from 'select/macro.njk' import select %}
 
 {{ select({
   "id": "select-1",

--- a/app/components/skip-link.njk
+++ b/app/components/skip-link.njk
@@ -1,6 +1,6 @@
 <p>To view the skip link, tab to this example, or click inside this example and press tab.</p>
 
-{% from 'components/skip-link/macro.njk' import skipLink %}
+{% from 'skip-link/macro.njk' import skipLink %}
 
 {{ skipLink({
   "href": "#maincontent",

--- a/app/components/table.njk
+++ b/app/components/table.njk
@@ -1,4 +1,4 @@
-{% from 'components/tables/macro.njk' import table %}
+{% from 'tables/macro.njk' import table %}
 
 {{ table({
   panel: false,

--- a/app/components/textarea-error.njk
+++ b/app/components/textarea-error.njk
@@ -1,4 +1,4 @@
-{% from 'components/textarea/macro.njk' import textarea %}
+{% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
   "name": "no-ni-reason",

--- a/app/components/textarea-longer.njk
+++ b/app/components/textarea-longer.njk
@@ -1,4 +1,4 @@
-{% from 'components/textarea/macro.njk' import textarea %}
+{% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
   "name": "more-detail",

--- a/app/components/textarea.njk
+++ b/app/components/textarea.njk
@@ -1,4 +1,4 @@
-{% from 'components/textarea/macro.njk' import textarea %}
+{% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
   "name": "more-detail",

--- a/app/components/warning-callout.njk
+++ b/app/components/warning-callout.njk
@@ -1,4 +1,4 @@
-{% from 'components/warning-callout/macro.njk' import warningCallout %}
+{% from 'warning-callout/macro.njk' import warningCallout %}
 
 {{ warningCallout({
   "heading": "School, nursery or work",

--- a/app/views/content/a-to-z-of-NHS-health-writing.njk
+++ b/app/views/content/a-to-z-of-NHS-health-writing.njk
@@ -3,7 +3,7 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/nav-a-z/macro.njk' import azNav %}
+{% from 'nav-a-z/macro.njk' import azNav %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/content/formatting-and-punctuation.njk
+++ b/app/views/content/formatting-and-punctuation.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/inset-text/macro.njk' import insetText %}
-{% from 'components/tables/macro.njk' import table %}
+{% from 'inset-text/macro.njk' import insetText %}
+{% from 'tables/macro.njk' import table %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/content/how-we-write.njk
+++ b/app/views/content/how-we-write.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/tables/macro.njk' import table %}
-{% from 'components/inset-text/macro.njk' import insetText %}
+{% from 'tables/macro.njk' import table %}
+{% from 'inset-text/macro.njk' import insetText %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/inset-text/macro.njk' import insetText %}
-{% from 'components/review-date/macro.njk' import reviewDate %}
+{% from 'inset-text/macro.njk' import insetText %}
+{% from 'review-date/macro.njk' import reviewDate %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/content/links-and-pdfs.njk
+++ b/app/views/content/links-and-pdfs.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/tables/macro.njk' import table %}
-{% from 'components/review-date/macro.njk' import reviewDate %}
+{% from 'tables/macro.njk' import table %}
+{% from 'review-date/macro.njk' import reviewDate %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/content/voice-and-tone.njk
+++ b/app/views/content/voice-and-tone.njk
@@ -3,7 +3,7 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/inset-text/macro.njk' import insetText %}
+{% from 'inset-text/macro.njk' import insetText %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/content/writing-for-accessibility.njk
+++ b/app/views/content/writing-for-accessibility.njk
@@ -3,7 +3,7 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/inset-text/macro.njk' import insetText %}
+{% from 'inset-text/macro.njk' import insetText %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/cookies.njk
+++ b/app/views/cookies.njk
@@ -2,8 +2,9 @@
 {% set pageDescription = 'The NHS digital service manual puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.' %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/tables/macro.njk' import table %}
-{% from 'components/review-date/macro.njk' import reviewDate %}
+
+{% from 'tables/macro.njk' import table %}
+{% from 'review-date/macro.njk' import reviewDate %}
 
 {% block body %}
 <div class="nhsuk-grid-row">

--- a/app/views/includes/feedback-banner.njk
+++ b/app/views/includes/feedback-banner.njk
@@ -1,4 +1,4 @@
-{% from 'components/feedback-banner/macro.njk' import feedbackBanner %}
+{% from 'feedback-banner/macro.njk' import feedbackBanner %}
 
 {{ feedbackBanner({
   "title": "This is a new service",

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -1,4 +1,4 @@
-{% from 'components/header/macro.njk' import header %}
+{% from 'header/macro.njk' import header %}
 
 {{ header({
   "homeHref": "/service-manual/",

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -1,4 +1,4 @@
-{% from 'components/breadcrumb/macro.njk' import breadcrumb %}
+{% from 'breadcrumb/macro.njk' import breadcrumb %}
 <!DOCTYPE html>
   <!--[if lt IE 9]><html class="ie8" lang="en"><![endif]--><!--[if IE 9]><html class="ie9" lang="en"><![endif]--><!--[if gt IE 9]><!--><html lang="en"><!--<![endif]-->
   <head>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -1,8 +1,9 @@
 {% set pageDescription = 'Design and build digital services for the NHS. Things you need to make consistent, usable services that put people first.' %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/hero/macro.njk' import hero %}
-{% from 'components/promo/macro.njk' import promo%}
+
+{% from 'hero/macro.njk' import hero %}
+{% from 'promo/macro.njk' import promo%}
 
 {% block breadcrumb %}{% endblock %}
 

--- a/app/views/practices/create-content-for-users-with-low-health-literacy/index.njk
+++ b/app/views/practices/create-content-for-users-with-low-health-literacy/index.njk
@@ -3,7 +3,7 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/review-date/macro.njk' import reviewDate %}
+{% from 'review-date/macro.njk' import reviewDate %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/practices/create-content-for-users-with-low-health-literacy/use-a-readability-tool-to-prioritise-content.njk
+++ b/app/views/practices/create-content-for-users-with-low-health-literacy/use-a-readability-tool-to-prioritise-content.njk
@@ -3,10 +3,10 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/tables/macro.njk' import table %}
-{% from 'components/inset-text/macro.njk' import insetText %}
-{% from 'components/action-link/macro.njk' import actionLink %}
-{% from 'components/review-date/macro.njk' import reviewDate %}
+{% from 'tables/macro.njk' import table %}
+{% from 'inset-text/macro.njk' import insetText %}
+{% from 'action-link/macro.njk' import actionLink %}
+{% from 'review-date/macro.njk' import reviewDate %}
 
 {% block breadcrumb %}
 {{ breadcrumb({

--- a/app/views/styles-components-patterns/action-link.njk
+++ b/app/views/styles-components-patterns/action-link.njk
@@ -2,8 +2,9 @@
 {% set pageDescription = 'Use action links to help users get to the next stage of a journey quickly by signposting the start of a digital service.' %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/action-link/macro.njk' import actionLink %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'action-link/macro.njk' import actionLink %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/back-link.njk
+++ b/app/views/styles-components-patterns/back-link.njk
@@ -1,8 +1,10 @@
 {% set pageTitle = 'Back link' %}
 {% set pageDescription = 'Use back links to help users go back to the previous page in a multi-page transaction' %}
+
 {% extends 'includes/layout.njk' %}
-{% from 'components/back-link/macro.njk' import backLink %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'back-link/macro.njk' import backLink %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/breadcrumbs.njk
+++ b/app/views/styles-components-patterns/breadcrumbs.njk
@@ -1,8 +1,10 @@
 {% set pageTitle = 'Breadcrumbs' %}
 {% set pageDescription = 'Use breadcrumbs to help users understand where they are in the website.' %}
+
 {% extends 'includes/layout.njk' %}
-{% from 'components/breadcrumb/macro.njk' import breadcrumb %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'breadcrumb/macro.njk' import breadcrumb %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/buttons.njk
+++ b/app/views/styles-components-patterns/buttons.njk
@@ -1,8 +1,10 @@
 {% set pageTitle = 'Buttons' %}
 {% set pageDescription = 'Use buttons to help users carry out an action on a page like starting an application or saving their progress.'%}
+
 {% extends 'includes/layout.njk' %}
-{% from 'components/button/macro.njk' import button %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'button/macro.njk' import button %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/care-cards.njk
+++ b/app/views/styles-components-patterns/care-cards.njk
@@ -2,8 +2,9 @@
 {% set pageDescription = 'Use care cards to help users identify and understand the sort of care they need, who to contact and how quickly.' %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/care-card/macro.njk' import careCard %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'care-card/macro.njk' import careCard %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/checkboxes.njk
+++ b/app/views/styles-components-patterns/checkboxes.njk
@@ -1,8 +1,10 @@
 {% set pageTitle = 'Checkboxes' %}
 {% set pageDescription = 'Use checkboxes to let users select one or more options on a form.' %}
+
 {% extends 'includes/layout.njk' %}
-{% from 'components/checkboxes/macro.njk' import checkboxes %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'checkboxes/macro.njk' import checkboxes %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/contents-list.njk
+++ b/app/views/styles-components-patterns/contents-list.njk
@@ -2,8 +2,9 @@
 {% set pageDescription = 'Use contents lists to allow users to navigate between related pages, for example about a single condition.' %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/breadcrumb/macro.njk' import breadcrumb %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'breadcrumb/macro.njk' import breadcrumb %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}
@@ -77,7 +78,7 @@
               <p class="nhsuk-body-s">Updated: February 2019</p>
             </div>
 
-            {% from 'components/panel/macro.njk' import panel %}
+            {% from 'panel/macro.njk' import panel %}
 
             {{ panel({
             "label": "Similar components",

--- a/app/views/styles-components-patterns/date-input.njk
+++ b/app/views/styles-components-patterns/date-input.njk
@@ -1,8 +1,10 @@
 {% set pageTitle = 'Date input' %}
 {% set pageDescription = 'Use date input to help users enter a memorable date, like their date of birth.' %}
+
 {% extends 'includes/layout.njk' %}
-{% from 'components/date-input/macro.njk' import dateInput %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'date-input/macro.njk' import dateInput %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/details.njk
+++ b/app/views/styles-components-patterns/details.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = 'Details' %}
 {% set pageDescription = 'Make a page easier to scan by letting users reveal more detailed information only if they need it.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/details/macro.njk' import details %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'details/macro.njk' import details %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/do-and-dont-list.njk
+++ b/app/views/styles-components-patterns/do-and-dont-list.njk
@@ -2,8 +2,9 @@
 {% set pageDescription = "Use Do and Don't lists to help users understand more easily what they should and shouldn't do." %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/do-dont-list/macro.njk' import list %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'do-dont-list/macro.njk' import list %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/draft/feedback-banner.njk
+++ b/app/views/styles-components-patterns/draft/feedback-banner.njk
@@ -1,10 +1,11 @@
 {% set pageTitle = 'Feedback banner' %}
 {% set pageDescription = 'Ask users for feedback, it makes your service better.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/pagination/macro.njk' import pagination %}
-{% from 'components/review-date/macro.njk' import reviewDate %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'pagination/macro.njk' import pagination %}
+{% from 'review-date/macro.njk' import reviewDate %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/error-message.njk
+++ b/app/views/styles-components-patterns/error-message.njk
@@ -1,10 +1,11 @@
 {% set pageTitle = "Error message" %}
 {% set pageDescription = "Use an error message when there is a validation error. Explain what went wrong and how to fix it." %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/error-message/macro.njk' import errorMessage %}
-{% from 'components/date-input/macro.njk' import dateInput %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'error-message/macro.njk' import errorMessage %}
+{% from 'date-input/macro.njk' import dateInput %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/error-summary.njk
+++ b/app/views/styles-components-patterns/error-summary.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = "Error summary" %}
 {% set pageDescription = "Include an error summary at the top of a page to summarise any mistakes a user has made." %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/error-summary/macro.njk' import errorSummary %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'error-summary/macro.njk' import errorSummary %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/expander.njk
+++ b/app/views/styles-components-patterns/expander.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = 'Expander' %}
 {% set pageDescription = 'Make a complex topic easier to digest by letting users reveal more detailed information only if they need it.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/details/macro.njk' import details %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'details/macro.njk' import details %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/fieldset.njk
+++ b/app/views/styles-components-patterns/fieldset.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = "Fieldset" %}
 {% set pageDescription = "Use a fieldset to group related form inputs."%}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/fieldset/macro.njk' import fieldset %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'fieldset/macro.njk' import fieldset %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/footer.njk
+++ b/app/views/styles-components-patterns/footer.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/footer/macro.njk' import footer %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'footer/macro.njk' import footer %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/header.njk
+++ b/app/views/styles-components-patterns/header.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/header/macro.njk' import header %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'header/macro.njk' import header %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/hint-text.njk
+++ b/app/views/styles-components-patterns/hint-text.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = "Hint text" %}
 {% set pageDescription = "Use hint text to help users understand a question."%}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/hint/macro.njk' import hint %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'hint/macro.njk' import hint %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/images.njk
+++ b/app/views/styles-components-patterns/images.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = 'Images' %}
 {% set pageDescription = 'Use images only if there is a real user need. Avoid unnecessary decoration.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/images/macro.njk' import image %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'images/macro.njk' import image %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/inset-text.njk
+++ b/app/views/styles-components-patterns/inset-text.njk
@@ -3,8 +3,8 @@
 
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/inset-text/macro.njk' import insetText %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'inset-text/macro.njk' import insetText %}
+{% from 'panel/macro.njk' import panel %}
 
 {% from 'includes/design-example.njk' import designExample %}
 

--- a/app/views/styles-components-patterns/pagination.njk
+++ b/app/views/styles-components-patterns/pagination.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = 'Pagination' %}
 {% set pageDescription = 'Use pagination to allow users to navigate between related pages, for example about a single condition.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/pagination/macro.njk' import pagination %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'pagination/macro.njk' import pagination %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/radios.njk
+++ b/app/views/styles-components-patterns/radios.njk
@@ -2,8 +2,8 @@
 {% set pageDescription = "Use radios when you want users to select only 1 option from a list."%}
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/radios/macro.njk' import radios %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'radios/macro.njk' import radios %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/review-date.njk
+++ b/app/views/styles-components-patterns/review-date.njk
@@ -2,8 +2,8 @@
 {% set pageDescription = 'Use review dates to reassure users that our information is up-to-date.' %}
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/review-date/macro.njk' import reviewDate %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'review-date/macro.njk' import reviewDate %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/select.njk
+++ b/app/views/styles-components-patterns/select.njk
@@ -2,8 +2,8 @@
 {% set pageDescription = "Use select to let users choose an option from a long list but only use it as a last resort." %}
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/select/macro.njk' import select %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'select/macro.njk' import select %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/skip-link.njk
+++ b/app/views/styles-components-patterns/skip-link.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = 'Skip link' %}
 {% set pageDescription = 'Use a skip link to help keyboard-only users skip to the main content on a page.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/skip-link/macro.njk' import skipLink %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'skip-link/macro.njk' import skipLink %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/table.njk
+++ b/app/views/styles-components-patterns/table.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = 'Table' %}
 {% set pageDescription = 'Use a table to make it easier for users to compare and scan information.' %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/tables/macro.njk' import table %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'tables/macro.njk' import table %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/text-input.njk
+++ b/app/views/styles-components-patterns/text-input.njk
@@ -1,9 +1,10 @@
 {% set pageTitle = "Text input" %}
 {% set pageDescription = "Use text input to let users enter a single line of text." %}
+
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/input/macro.njk' import input %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'input/macro.njk' import input %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/textarea.njk
+++ b/app/views/styles-components-patterns/textarea.njk
@@ -2,8 +2,8 @@
 {% set pageDescription = "Use textarea to let users enter more than 1 line of text." %}
 {% extends 'includes/layout.njk' %}
 
-{% from 'components/textarea/macro.njk' import textarea %}
-{% from 'components/panel/macro.njk' import panel %}
+{% from 'textarea/macro.njk' import textarea %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}

--- a/app/views/styles-components-patterns/warning-callout.njk
+++ b/app/views/styles-components-patterns/warning-callout.njk
@@ -2,8 +2,9 @@
 {% set pageDescription = 'Use a warning callout to help users identify and understand warning content on the page, even if they do noticedt read the whole page.' %}
 
 {% extends 'includes/layout.njk' %}
-{% from 'components/warning-callout/macro.njk' import warningCallout %}
-{% from 'components/panel/macro.njk' import panel %}
+
+{% from 'warning-callout/macro.njk' import warningCallout %}
+{% from 'panel/macro.njk' import panel %}
 {% from 'includes/design-example.njk' import designExample %}
 
 {% block breadcrumb %}


### PR DESCRIPTION
The macro paths don't need to include the `/components/` folder in the path to import them. This matches the nhsuk-prototype-kit which is the primary use of nunjucks macros.

#151 