### PR TITLE
move mini-hub pattern to drafts and remove links to page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 :new: **New features**
 
 - Publish new contribution pages for proposing and working on new features with contribution criteria
-- Publish new pattern; Mini-hub
 
 :wrench: **Fixes**
 

--- a/app/views/styles-components-patterns/draft/mini-hub.njk
+++ b/app/views/styles-components-patterns/draft/mini-hub.njk
@@ -1,6 +1,6 @@
 {% set pageTitle = 'Mini-hub' %}
 {% set pageDescription = 'Mini-hubs are a way of presenting a number of pages about one topic on NHS.UK.' %}
-
+{% set noFollow = true %}
 {% extends 'includes/layout.njk' %}
 
 {% from 'panel/macro.njk' import panel %}

--- a/app/views/styles-components-patterns/index.njk
+++ b/app/views/styles-components-patterns/index.njk
@@ -53,9 +53,6 @@
     </ul>
     <h2>Patterns</h2>
     <p>You can combine components in different patterns for different contexts. We’re still working on patterns and will publish them here.</p>
-    <ul class="nhsuk-list">
-    <li><a href="/service-manual/styles-components-patterns/mini-hub">Mini-hub</a></li>
-    </ul>
   </div>
 </div>
 <div class="nhsuk-grid-row">


### PR DESCRIPTION
The Mini-Hub pattern still needs to be removed so isn't ready to be released.