### PR TITLE
update package dependencies to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # NHS digital service manual Changelog
 
-## 1.6.2 - 23 July 2019
+## 1.6.2 - 30 July 2019
 
 :wrench: **Fixes**
 
 - Use the latest version of the NHS.UK frontend library (v2.3.0)
 - Use the latest NHS website Open Graph assets and metadata
+- Update package dependencies to latest versions
 
 ## 1.6.1 - 22 July 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Use the latest version of the NHS.UK frontend library (v2.3.0)
 - Use the latest NHS website Open Graph assets and metadata
 - Update package dependencies to latest versions
+- Accessibility guidance pages grammar and content updates
+- Add 'homeless' to the A-Z of NHS health writing
+- Add external links to the links and PDF guidance pages
 
 ## 1.6.1 - 22 July 2019
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11020,9 +11020,9 @@
       }
     },
     "webpack": {
-      "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.36.1.tgz",
-      "integrity": "sha512-Ej01/N9W8DVyhEpeQnbUdGvOECw0L46FxS12cCOs8gSK7bhUlrbHRnWkjiXckGlHjUrmL89kDpTRIkUk6Y+fKg==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
+      "integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node-sass": "^4.12.0",
     "nodemon": "^1.19.1",
     "sass-lint": "^1.13.1",
-    "webpack": "^4.36.1",
+    "webpack": "^4.38.0",
     "webpack-cli": "^3.3.6"
   }
 }


### PR DESCRIPTION
- Accessibility guidance pages grammar and content updates
- Add 'homeless' to the A-Z of NHS health writing
- Add external links to the links and PDF guidance pages