### PR TITLE
Accessibility: updated header home link aria label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 :wrench: **Fixes**
 
 - Remove duplicate entry from the XML sitemap
+- Accessibility: Updated home link aria label, it now reads as "NHS digital service manual homepage"
 
 ## 1.7.0 - 06 August 2019
 

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -3,6 +3,7 @@
 {%- if pageTitle == 'Search' %}
   {{ header({
     "homeHref": "/service-manual/",
+    "ariaLabel": "NHS digital service manual homepage",
     "service": {
       "name": "Digital service manual",
       "longName": "true"
@@ -15,6 +16,7 @@
 {% else %}
   {{ header({
     "homeHref": "/service-manual/",
+    "ariaLabel": "NHS digital service manual homepage",
     "service": {
       "name": "Digital service manual",
       "longName": "true"


### PR DESCRIPTION
The home link in the header was labelled as 'NHS homepage', causing confusion for users using screenreaders.

The aria label has been updated to 'NHS Digital service manual homepage'