### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 :wrench: **Fixes**
 
 - Remove duplicate entry from the XML sitemap
+- Accessibility: Updated home link aria label, it now reads as "NHS digital service manual homepage"
 
 ## 1.7.0 - 06 August 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :new: **New functionality**
 
 - Add search functionality to the service manual
+- Add more guidance for content designers to care card page 
 - Add entries to A to Z of NHS health writing, including health records
 
 :wrench: **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 2.0.0 - Unreleased
+
+:new: **New functionality**
+
+- Add search functionality to the service manual
+
 ## 1.7.0 - 06 August 2019
 
 :new: **New content**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,17 @@
 # NHS digital service manual Changelog
 
-## 2.0.0 - Unreleased
+## 1.8.0 - 09 August 2019
 
-:new: **New functionality**
+:new: **New content**
 
-- Add search functionality to the service manual
-- Add more guidance for content designers to care card page 
-- Add entries to A to Z of NHS health writing, including health records
+- Add entries to A to Z of NHS health writing: health record and related terms
 
 :wrench: **Fixes**
 
 - Remove duplicate entry from the XML sitemap
 - Accessibility: Updated home link aria label, it now reads as "NHS digital service manual homepage"
-- Remove curly apostrophes and replace with straight apostrophes
-- Update the description of the Slack workspace from NHS.UK to service manual
+- Fix a few minor content formatting issues, like apostrophes
+- Update package dependencies to latest versions
 
 ## 1.7.0 - 06 August 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Remove duplicate entry from the XML sitemap
 - Accessibility: Updated home link aria label, it now reads as "NHS digital service manual homepage"
+- Remove curly apostrophes and replace with straight apostrophes
+- Update the description of the Slack workspace from NHS.UK to service manual
 
 ## 1.7.0 - 06 August 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add search functionality to the service manual
 
+:wrench: **Fixes**
+
+- Remove duplicate entry from the XML sitemap
+
 ## 1.7.0 - 06 August 2019
 
 :new: **New content**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :new: **New functionality**
 
 - Add search functionality to the service manual
+- Add entries to A to Z of NHS health writing, including health records
 
 :wrench: **Fixes**
 

--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ var pageIndex = new PageIndex(config);
 const app = express();
 
 // Authentication middleware
-app.use(authentication);
+// app.use(authentication);
 
 // Use local variables
 app.use(locals(config));

--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ app.get('/service-manual/design-example/:example', (req, res) => {
   res.render('includes/design-example-wrapper.njk', { body: exampleHtml });
 });
 
+/*
 app.get('/service-manual/search', (req, res) => {
   var query = req.query['search-field'] || '';
   res.render('includes/search.njk', { results: pageIndex.search(query), query: query });
@@ -84,6 +85,7 @@ app.get('/service-manual/suggestions', (req, res) => {
   res.set({ 'Content-Type': 'application/json' });
   res.send(JSON.stringify(pageIndex.search(req.query.search)));
 });
+*/
 
 app.get('/', (req, res) => {
   res.redirect('/service-manual');

--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ var pageIndex = new PageIndex(config);
 const app = express();
 
 // Authentication middleware
-// app.use(authentication);
+app.use(authentication);
 
 // Use local variables
 app.use(locals(config));

--- a/app/views/accessibility/how-to-make-digital-services-accessible.njk
+++ b/app/views/accessibility/how-to-make-digital-services-accessible.njk
@@ -30,12 +30,12 @@
 
     <h2 id="consider-accessibility-at-every-stage">Consider accessibility at every stage</h2>
     <p>Think about how you are going to address accessibility at the beginning and at every stage of your project.</p>
-    <p>It’s much harder to make a service accessible if you only address it later on.</p>
+    <p>It's much harder to make a service accessible if you only address it later on.</p>
     <ul>
       <li><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#what-to-do-in-discovery">Making your service accessible: an introduction</a> (GOV.UK service manual) explains what to do at different stages.</li>
     </ul>
 
-    <h2 id="make-it-the-whole-teams-responsibility">Make it the whole team’s responsibility</h2>
+    <h2 id="make-it-the-whole-teams-responsibility">Make it the whole team's responsibility</h2>
     <p>Every member of the team should contribute to making your service inclusive.</p>
     <p>You should all:</p>
     <ul>

--- a/app/views/accessibility/partials/look-after-your-team.njk
+++ b/app/views/accessibility/partials/look-after-your-team.njk
@@ -1,6 +1,6 @@
 <h2 id="look-after-your-team">Look after your team</h2>
 <p class="nhsuk-body-s">For: <a href="/service-manual/accessibility/user-research">User research</a></p>
 <p>It's important that the team supports one another. User research in health can be tiring and emotional. Sometimes users might tell you stories that are hard to hear or you might see them struggle.</p>
-<p>It’s OK to take some time out during a day of research or, as a user researcher, to ask for someone to stand in for you.</p>
+<p>It's OK to take some time out during a day of research or, as a user researcher, to ask for someone to stand in for you.</p>
 <p>Check in with your team mates during and after research and take time to reflect together.</p>
 <hr>

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -538,6 +538,8 @@
         <p>See our guidance on <a href="/service-manual/content/numbers-measurement-dates-time">numbers, measurement, dates and time</a>.</p>
         <h3 id="persist">persist</h3>
         <p>We use "carry on" or "keep going".</p>
+        <h3 id=personal-child-health-record-(red-book)>personal child health record (red book)</h3>
+        <p>We include the phrase "red book" in brackets the first time we mention "personal child health record". We usually call it the "red book" after the first mention.
         <h3 id="poo">poo</h3>
         <p>We mostly use "poo", rather than "stool". We know that everyone can understand "poo", including people who find reading difficult.</p>
         <p>We don’t use "opening your bowels" or "bowel movements".</p>

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -357,6 +357,9 @@
         <h3 id="haemorrhage">haemorrhage</h3>
         <p>We often use the words "a very heavy bleed" instead of "haemorrhage".</p>
         <p>If you need to use the word "haemorrhage", for example, in the name of a condition like a subarachnoid haemorrhage, explain what it is.</p>
+        <h3 id="health-record">health record</h3>
+        <p>We use "health record" rather than "medical record". "Health record" is more accurate as someone's record may cover social care as well as medical content. In our user research, we haven’t seen anyone confused by "health record". People see it as the same as a "medical record".</p>
+        <p>In some contexts, for example in forms, rather than asking about someone's "health record", we ask about "your health, and any health problems or treatments you've had in the past".</p>
         <h3 id="healthcare">healthcare</h3>
         <p>One word.</p>
         <h3 id="home-help">home help</h3>
@@ -426,6 +429,8 @@
         <p>We use "<a href="#CJD">CJD</a>".</p>
         <h3 id="measurement">measurement</h3>
         <p>See our guidance on <a href="/service-manual/content/numbers-measurement-dates-time">numbers, measurement, dates and time</a>.</p>
+        <h3 id="medical-record">medical record</h3>
+        <p>We prefer "<a href="#health-record">health record</a>".</p>
         <h3 id="medication">medication</h3>
         <p>We use "medicine".</p>
         <h3 id="metric-measurements">metric measurements</h3>

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -538,8 +538,9 @@
         <p>See our guidance on <a href="/service-manual/content/numbers-measurement-dates-time">numbers, measurement, dates and time</a>.</p>
         <h3 id="persist">persist</h3>
         <p>We use "carry on" or "keep going".</p>
-        <h3 id=personal-child-health-record-(red-book)>personal child health record (red book)</h3>
-        <p>We include the phrase "red book" in brackets the first time we mention "personal child health record". We usually call it the "red book" after the first mention.
+        <h3 id="personal-child-health-record-(red-book)">personal child health record (red book)</h3>
+        <p>All lower case. We include the phrase "red book" in brackets the first time we mention "personal child health record". Then we usually call it the "red book" after the first mention.</p>
+        <p>Also see <a href="#health-record">health record</a>.</p>
         <h3 id="poo">poo</h3>
         <p>We mostly use "poo", rather than "stool". We know that everyone can understand "poo", including people who find reading difficult.</p>
         <p>We don’t use "opening your bowels" or "bowel movements".</p>
@@ -635,8 +636,8 @@
         <h3 id="suffering-from">suffering from</h3>
         <p>We don’t use "suffering from". We talk about people having or living with a disability or condition.</p>
         <p>See the section on <a href="/service-manual/content/inclusive-language">disabilities and conditions in Inclusive language.</a></p>
-        <h3 id="summary-care-record">summary care record<h3>
-        <p>Lower case.</p>
+        <h3 id="summary-care-record">summary care record</h3>
+        <p>Lower case. Also see <a href="#health-record">health record</a>.</p>
         <h3 id="surgery">surgery</h3>
         <p>When we’re writing for the public, we use "GP surgery" or "surgery" rather than "practice", because our research shows us that this is the word patients are more likely to search for and use.</p>
         <p>When we’re writing for healthcare staff, we may use the word "practice". For example, for "practice managers".</p>

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -633,6 +633,8 @@
         <h3 id="suffering-from">suffering from</h3>
         <p>We don’t use "suffering from". We talk about people having or living with a disability or condition.</p>
         <p>See the section on <a href="/service-manual/content/inclusive-language">disabilities and conditions in Inclusive language.</a></p>
+        <h3 id="summary-care-record">summary care record<h3>
+        <p>Lower case.</p>
         <h3 id="surgery">surgery</h3>
         <p>When we’re writing for the public, we use "GP surgery" or "surgery" rather than "practice", because our research shows us that this is the word patients are more likely to search for and use.</p>
         <p>When we’re writing for healthcare staff, we may use the word "practice". For example, for "practice managers".</p>

--- a/app/views/content/how-we-write.njk
+++ b/app/views/content/how-we-write.njk
@@ -32,9 +32,9 @@
     <h2>Accurate</h2>
     <p>Qualified clinicians check our clinical information and check that it is accurate, clinically safe and has been developed using relevant evidence-based guidance.</p>
     <p>Our content is factual, neutral and unambiguous. We do not use metaphors - we say what we mean.</p>
-    <p>We avoid making subjective statements. Use words like "good", "bad", or "easy" with care. For example, don’t talk about "a good chance of recovery".</p>
+    <p>We avoid making subjective statements. Use words like "good", "bad", or "easy" with care. For example, don't talk about "a good chance of recovery".</p>
     <p>We do use "good" and "bad" where our users do to describe their symptoms, for example "bad pain" or "bad breath".</p>
-    <p>We also use them when there’s a good evidence base. For example, we talk about "a good source of iron" or "lack of sleep is bad for your health".</p>
+    <p>We also use them when there's a good evidence base. For example, we talk about "a good source of iron" or "lack of sleep is bad for your health".</p>
     {{ table({
       panel: false,
       firstCellIsHeader: false,
@@ -92,7 +92,7 @@
       <h3>Research insight</h3>
       <p>Research has shown that <a href=\"https://gds.blog.gov.uk/2014/02/17/guest-post-clarity-is-king-the-evidence-that-reveals-the-desperate-need-to-re-think-the-way-we-write/\" title=\"External website\">most people prefer to read plain English</a>, and that the more specialist a person's knowledge is, the greater their preference."
     }) }}
-    <p>Read <a href="/service-manual/content/health-literacy">our guidance on health literacy</a> to see why it’s important to create content that’s simple to read.</p>
+    <p>Read <a href="/service-manual/content/health-literacy">our guidance on health literacy</a> to see why it's important to create content that’s simple to read.</p>
     <h2>Concise</h2>
     <p>We keep content to the point.</p>
     <p>We use short words. For example, we prefer "have" or "get" to "experience" in phrases like "if you experience headaches".</p>

--- a/app/views/content/how-we-write.njk
+++ b/app/views/content/how-we-write.njk
@@ -92,7 +92,7 @@
       <h3>Research insight</h3>
       <p>Research has shown that <a href=\"https://gds.blog.gov.uk/2014/02/17/guest-post-clarity-is-king-the-evidence-that-reveals-the-desperate-need-to-re-think-the-way-we-write/\" title=\"External website\">most people prefer to read plain English</a>, and that the more specialist a person's knowledge is, the greater their preference."
     }) }}
-    <p>Read <a href="/service-manual/content/health-literacy">our guidance on health literacy</a> to see why it's important to create content that’s simple to read.</p>
+    <p>Read <a href="/service-manual/content/health-literacy">our guidance on health literacy</a> to see why it's important to create content that's simple to read.</p>
     <h2>Concise</h2>
     <p>We keep content to the point.</p>
     <p>We use short words. For example, we prefer "have" or "get" to "experience" in phrases like "if you experience headaches".</p>

--- a/app/views/content/index.njk
+++ b/app/views/content/index.njk
@@ -59,7 +59,7 @@
     <p>It's meant as a guide, not a rulebook. You're welcome to adapt a style pattern if it does not meet your users' needs.</p>
     <h2 class="nhsuk-u-margin-top-8">In progress</h2>
     <p>The guide will grow and change as we learn more about the language and writing styles that work best for our users.</p>
-    <p>Join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a> to hear about and discuss changes.</p>
+    <p>Join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a> to hear about and discuss changes.</p>
     <p>Check the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style">GOV.UK A to Z style guide</a> and <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">GOV.UK content design guide</a> for any points of style that you do not find here. If it's not there, we recommend using the Oxford Dictionary for Writers and Editors.</p>
 
     <h2 class="nhsuk-u-margin-top-8">Contribute</h2>

--- a/app/views/design-principles/index.njk
+++ b/app/views/design-principles/index.njk
@@ -58,7 +58,7 @@
             <div class="featured-item__number nhsuk-heading-xl">4</div>
             Design for context
           </h2>
-          <p>Don’t just design your part of a service. Consider people's entire experience, and the infrastructure and processes involved. Think about how people begin and end their time with what you are designing.</p>
+          <p>Don't just design your part of a service. Consider people's entire experience, and the infrastructure and processes involved. Think about how people begin and end their time with what you are designing.</p>
         </div>
       </li>
 

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -20,7 +20,7 @@
       "longName": "true"
     },
     "showNav": "false",
-    "showSearch": "false",
+    "showSearch": "true",
     "searchAction": "/service-manual/search/"
     })
   }}

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -22,7 +22,7 @@
       "longName": "true"
     },
     "showNav": "false",
-    "showSearch": "true",
+    "showSearch": "false",
     "searchAction": "/service-manual/search/"
     })
   }}

--- a/app/views/includes/header.njk
+++ b/app/views/includes/header.njk
@@ -3,6 +3,7 @@
 {%- if pageTitle == 'Search' %}
   {{ header({
     "homeHref": "/service-manual/",
+    "ariaLabel": "NHS digital service manual homepage",
     "service": {
       "name": "Digital service manual",
       "longName": "true"
@@ -15,6 +16,7 @@
 {% else %}
   {{ header({
     "homeHref": "/service-manual/",
+    "ariaLabel": "NHS digital service manual homepage",
     "service": {
       "name": "Digital service manual",
       "longName": "true"

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -52,17 +52,17 @@
     <meta name="twitter:creator" content="@nhsuk">
     <meta name="twitter:image:alt" content="nhs.uk">
 
-    <!-- Hotjar Tracking Code for https://nhsuk-service-manual-staging.azurewebsites.net/ -->
-    <script>
-        (function(h,o,t,j,a,r){
-            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-            h._hjSettings={hjid:1434152,hjsv:6};
-            a=o.getElementsByTagName('head')[0];
-            r=o.createElement('script');r.async=1;
-            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-            a.appendChild(r);
-        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    <!-- Begin Inspectlet Asynchronous Code -->
+    <script type="text/javascript">
+    (function() {
+    window.__insp = window.__insp || [];
+    __insp.push(['wid', 23083206]);
+    var ldinsp = function(){
+    if(typeof window.__inspld != "undefined") return; window.__inspld = 1; var insp = document.createElement('script'); insp.type = 'text/javascript'; insp.async = true; insp.id = "inspsync"; insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://cdn.inspectlet.com/inspectlet.js?wid=23083206&r=' + Math.floor(new Date().getTime()/3600000); var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(insp, x); };
+    setTimeout(ldinsp, 0);
+    })();
     </script>
+    <!-- End Inspectlet Asynchronous Code -->
 
   </head>
 

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -51,6 +51,19 @@
     <meta name="twitter:site" content="@nhsuk">
     <meta name="twitter:creator" content="@nhsuk">
     <meta name="twitter:image:alt" content="nhs.uk">
+
+    <!-- Hotjar Tracking Code for https://nhsuk-service-manual-staging.azurewebsites.net/ -->
+    <script>
+        (function(h,o,t,j,a,r){
+            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+            h._hjSettings={hjid:1434152,hjsv:6};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
+
   </head>
 
   <body>

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -52,18 +52,6 @@
     <meta name="twitter:creator" content="@nhsuk">
     <meta name="twitter:image:alt" content="nhs.uk">
 
-    <!-- Begin Inspectlet Asynchronous Code -->
-    <script type="text/javascript">
-    (function() {
-    window.__insp = window.__insp || [];
-    __insp.push(['wid', 23083206]);
-    var ldinsp = function(){
-    if(typeof window.__inspld != "undefined") return; window.__inspld = 1; var insp = document.createElement('script'); insp.type = 'text/javascript'; insp.async = true; insp.id = "inspsync"; insp.src = ('https:' == document.location.protocol ? 'https' : 'http') + '://cdn.inspectlet.com/inspectlet.js?wid=23083206&r=' + Math.floor(new Date().getTime()/3600000); var x = document.getElementsByTagName('script')[0]; x.parentNode.insertBefore(insp, x); };
-    setTimeout(ldinsp, 0);
-    })();
-    </script>
-    <!-- End Inspectlet Asynchronous Code -->
-
   </head>
 
   <body>

--- a/app/views/includes/search.njk
+++ b/app/views/includes/search.njk
@@ -4,4 +4,45 @@
 {% extends 'includes/layout.njk' %}
 
 {% block body %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-4">Search</h1>
+      <form class="nhsuk-header__search-form nhsuk-header__search-form--search-results" id="search" action="/service-manual/search/" method="get" role="search">
+        <label class="nhsuk-u-visually-hidden" for="search-results-field">Search the NHS digital service manual</label>
+        <input class="nhsuk-search__input" id="search-results-field" name="search-field" type="search" value="{{query}}" autocomplete="off">
+        <button class="nhsuk-search__submit" type="submit">
+          <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+          </svg>
+          <span class="nhsuk-u-visually-hidden">Search</span>
+        </button>
+      </form>
+    </div>
+  </div>
+  <article>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        {% if results | length > 0 %}
+          <ul class="nhsuk-list nhsuk-list--border">
+            {% for item in results %}
+              <li>
+                <a href="{{item.url}}" class="app-search-results-item">{{item.title}}</a>
+                <p class="nhsuk-body-s nhsuk-u-margin-top-1 nhsuk-u-secondary-text-color">{{item.description}}</p>
+              </li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          {% if query != "" %}
+            <p>Your search - <span class="nhsuk-u-font-weight-bold">{{query}}</span> - had no matching results.</p>
+            <p>Improve your search results by:</p>
+            <ul>
+              <li>double-checking your spelling</li>
+              <li>using fewer keywords</li>
+              <li>searching for something less specific</li>
+            </ul>
+          {% endif %}
+        {% endif %}
+        </div>
+    </div>
+  </article>
 {% endblock %}

--- a/app/views/sitemap.xml
+++ b/app/views/sitemap.xml
@@ -209,9 +209,6 @@
     <loc>https://beta.nhs.uk/service-manual/contribute/work-new-thing</loc>
   </url>
   <url>
-    <loc>https://beta.nhs.uk/service-manual/content/a-to-z-of-nhs-health-writing</loc>
-  </url>
-  <url>
     <loc>https://beta.nhs.uk/service-manual/content/health-literacy/</loc>
   </url>
   <url>

--- a/app/views/styles-components-patterns/care-cards.njk
+++ b/app/views/styles-components-patterns/care-cards.njk
@@ -84,10 +84,10 @@
     <h3>When to use care cards</h3>
     <p>Use care cards to tell users to take action to get medical advice or help.</p>
     <h3>When not to use care cards</h3>
-    <p>Do not use care cards:</p>
+    <p>Don't use care cards:</p>
     <ul>
       <li>in forms or transactions</li>
-      <li>for actions which do not help users get 1 of the 3 levels of care</li>
+      <li>for actions which don't help users get one of the 3 levels of care</li>
     </ul>
     <p>If you want:</p>
     <ul>
@@ -102,30 +102,10 @@
     <p>If you use more than 1 care card - or a care card and a warning callout close to each other, be aware that users often overlook text between them.</p>
 
     <h2>Care card content</h2>
-    <h3>Give the card a short heading using "if"</h3>
-    <p>The heading should be 1 clear call to action. Use the format: "Call 111 if:" or "Speak to a GP if:" followed by a bulleted list in the body of the card.</p>
-    <h3>Put the detail in the body of the card</h3>
-    <p>Do not overload the header. Use the space in the body of the card but keep it concise.</p>
-    <p>It's OK to use a single bullet point after the "if" in the header. It's clearer than including a stand-alone sentence in the card.</p>
-    <p>It's also OK to have 2 colons (1 in the header and 1 in the body of the card), for example:</p>
-    <div class="nhsuk-care-card nhsuk-care-card--urgent">
-      <div class="nhsuk-care-card__heading-container">
-      <h3 class="nhsuk-care-card__heading"><span role="text"><span class="nhsuk-u-visually-hidden">Urgent advice: </span>Get advice from 111 now if:</span></h3>
-      <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
-      </div>
-      <div class="nhsuk-care-card__content">
-      <p>you take too much furosemide and you:
-      <ul>
-        <li>are over 65 (even if you feel well)</li>
-        <li>have kidney, heart or liver failure (even if you feel well)</li>
-      </ul>
-      </div>
-    </div>
+    <p>Give the card a short heading. It should be 1 clear call to action, for example "Speak to a GP".</p>
+    <p>If the card includes more than one condition, use the format: "Call 111 if:" or "Speak to a GP if:" followed by a bulleted list.</p>
+    <p>Make sure the care card is concise, specific and self-contained. Don't say: "Contact your GP if this happens." Explain in the care card in what circumstances users should contact their GP.</p>
 
-    <h3>Make the care card self-contained</h3>
-    <p>Care cards should be specific and include the information the user needs. Do not say: "Contact your GP if this happens." Explain in the care card in what circumstances users should contact their GP.</p>
-    <h3>Keep signposting simple</h3>
-    <p>Ideally you should signpost to just 1 service in the header but you can signpost to 2 (the top 2 services). If you need to, add more services at the end of the body of the care card.<p>
     <h2 id="accessibility">Accessibility</h2>
     <p>People with visual disabilities may not be able to recognise care cards by their colour. Use clearly worded headings to help them.</p>
     <p>We also add hidden text to the care card header to make the level of urgency clear to people who use screen readers. This also helps people who use headings to navigate the page as the text is part of the heading.</p>
@@ -135,7 +115,7 @@
     <h2>Research</h2>
     <p>The care card design has tested well in long content pages. We've tested it in content in lots of labs and users scanning the page have stopped to read the cards.</p>
     <p>We haven't tested care cards in transactional services and do not recommend using them. If you use a care card in a transactional service, please test it with users and let us know what you find.</p>
-    <p>We've tested care cards with 1 call to action, for example "Speak to a GP if:". If you use more than 1 action, please test it and share your research findings with us.</p>
+    <p>We've tested care cards with 1 call to action, for example "Speak to a GP". If you use more than 1 action, please test it and share your research findings with us.</p>
     <p>We found that users overlook text between care cards, or between care cards and warning callouts, when they are close to each other.</p>
     <p>Accessibility testing showed up some issues around communicating the importance of the cards with hidden text, which we've dealt with. <a href="#accessibility">See the Accessibility section.</a></p>
 
@@ -145,12 +125,12 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 
     <div class="nhsuk-review-date">
-    <p class="nhsuk-body-s">Updated: August 2019</p>
+    <p class="nhsuk-body-s">Updated: January 2019</p>
     </div>
 
     {{ panel({

--- a/app/views/styles-components-patterns/care-cards.njk
+++ b/app/views/styles-components-patterns/care-cards.njk
@@ -84,10 +84,10 @@
     <h3>When to use care cards</h3>
     <p>Use care cards to tell users to take action to get medical advice or help.</p>
     <h3>When not to use care cards</h3>
-    <p>Don't use care cards:</p>
+    <p>Do not use care cards:</p>
     <ul>
       <li>in forms or transactions</li>
-      <li>for actions which don't help users get one of the 3 levels of care</li>
+      <li>for actions which do not help users get 1 of the 3 levels of care</li>
     </ul>
     <p>If you want:</p>
     <ul>
@@ -102,10 +102,30 @@
     <p>If you use more than 1 care card - or a care card and a warning callout close to each other, be aware that users often overlook text between them.</p>
 
     <h2>Care card content</h2>
-    <p>Give the card a short heading. It should be 1 clear call to action, for example "Speak to a GP".</p>
-    <p>If the card includes more than one condition, use the format: "Call 111 if:" or "Speak to a GP if:" followed by a bulleted list.</p>
-    <p>Make sure the care card is concise, specific and self-contained. Don't say: "Contact your GP if this happens." Explain in the care card in what circumstances users should contact their GP.</p>
+    <h3>Give the card a short heading using "if"</h3>
+    <p>The heading should be 1 clear call to action. Use the format: "Call 111 if:" or "Speak to a GP if:" followed by a bulleted list in the body of the card.</p>
+    <h3>Put the detail in the body of the card</h3>
+    <p>Do not overload the header. Use the space in the body of the card but keep it concise.</p>
+    <p>It's OK to use a single bullet point after the "if" in the header. It's clearer than including a stand-alone sentence in the card.</p>
+    <p>It's also OK to have 2 colons (1 in the header and 1 in the body of the card), for example:</p>
+    <div class="nhsuk-care-card nhsuk-care-card--urgent">
+      <div class="nhsuk-care-card__heading-container">
+      <h3 class="nhsuk-care-card__heading"><span role="text"><span class="nhsuk-u-visually-hidden">Urgent advice: </span>Get advice from 111 now if:</span></h3>
+      <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
+      </div>
+      <div class="nhsuk-care-card__content">
+      <p>you take too much furosemide and you:
+      <ul>
+        <li>are over 65 (even if you feel well)</li>
+        <li>have kidney, heart or liver failure (even if you feel well)</li>
+      </ul>
+      </div>
+    </div>
 
+    <h3>Make the care card self-contained</h3>
+    <p>Care cards should be specific and include the information the user needs. Do not say: "Contact your GP if this happens." Explain in the care card in what circumstances users should contact their GP.</p>
+    <h3>Keep signposting simple</h3>
+    <p>Ideally you should signpost to just 1 service in the header but you can signpost to 2 (the top 2 services). If you need to, add more services at the end of the body of the care card.<p>
     <h2 id="accessibility">Accessibility</h2>
     <p>People with visual disabilities may not be able to recognise care cards by their colour. Use clearly worded headings to help them.</p>
     <p>We also add hidden text to the care card header to make the level of urgency clear to people who use screen readers. This also helps people who use headings to navigate the page as the text is part of the heading.</p>
@@ -115,7 +135,7 @@
     <h2>Research</h2>
     <p>The care card design has tested well in long content pages. We've tested it in content in lots of labs and users scanning the page have stopped to read the cards.</p>
     <p>We haven't tested care cards in transactional services and do not recommend using them. If you use a care card in a transactional service, please test it with users and let us know what you find.</p>
-    <p>We've tested care cards with 1 call to action, for example "Speak to a GP". If you use more than 1 action, please test it and share your research findings with us.</p>
+    <p>We've tested care cards with 1 call to action, for example "Speak to a GP if:". If you use more than 1 action, please test it and share your research findings with us.</p>
     <p>We found that users overlook text between care cards, or between care cards and warning callouts, when they are close to each other.</p>
     <p>Accessibility testing showed up some issues around communicating the importance of the cards with hidden text, which we've dealt with. <a href="#accessibility">See the Accessibility section.</a></p>
 
@@ -125,12 +145,12 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 
     <div class="nhsuk-review-date">
-    <p class="nhsuk-body-s">Updated: January 2019</p>
+    <p class="nhsuk-body-s">Updated: August 2019</p>
     </div>
 
     {{ panel({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "2.0.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8093,9 +8093,9 @@
       "dev": true
     },
     "js-beautify": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.1.tgz",
-      "integrity": "sha512-4y8SHOIRC+/YQ2gs3zJEKBUraQerq49FJYyXRpdzUGYQzCq8q9xtIh0YXial1S5KmonVui4aiUb6XaGyjE51XA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
+      "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
       "dev": true,
       "requires": {
         "config-chain": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "2.0.0",
+  "version": "1.8.0",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {
@@ -53,7 +53,7 @@
     "highlight.js": "^9.15.9",
     "iframe-resizer": "^3.6.6",
     "jest": "^24.8.0",
-    "js-beautify": "^1.10.1",
+    "js-beautify": "^1.10.2",
     "nhsuk-frontend": "^2.3.0",
     "node-sass": "^4.12.0",
     "nodemon": "^1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## 1.8.0 - 09 August 2019

:new: **New content**

- Add entries to A to Z of NHS health writing: health record and related terms

:wrench: **Fixes**

- Remove duplicate entry from the XML sitemap
- Accessibility: Updated home link aria label, it now reads as "NHS digital service manual homepage"
- Fix a few minor content formatting issues, like apostrophes
- Update package dependencies to latest versions