### PR TITLE
Update the inclusive language page

### DIFF
--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -63,7 +63,7 @@
     {{ insetText({
       "HTML": "<p>You're more at risk of developing type 2 diabetes if you are over 40 - or 25 for south Asian people.</p>"
     }) }}
-    <h2>Gender and sexuality</h2>
+    <h2>Sex, gender and sexuality</h2>
     <p>We make content gender neutral wherever possible.</p>
     <p>We do not label people with their gender identity or sexuality. Instead we say:</p>
     <ul>


### PR DESCRIPTION
#139 updated the H2 to now read 'Sex, gender and sexuality' instead of 'Gender and sexuality'