### PR TITLE
Update 2 pages after last Style Council meeting

### DIFF
--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -169,6 +169,10 @@
       </div>
       <div class="nhsuk-a-z-list--results-items">
         <h2 id="B">B</h2>
+        <h3 id="baby">baby</h3>
+        <p>We use "baby" or "your baby" (not "unborn baby") in pregnancy content, from the early stages of pregnancy to birth and during the baby's first year. "Baby" is simpler than "embryo" or "foetus".</p>
+        <p>For example, in our medicines content, we talk about how medicines can "affect you and your baby in pregnancy".</p>
+        <p>The words we use depend on the context, however. In content about an unwanted pregnancy or abortion, for example, we use "pregnancy" and "ending the pregnancy". Test with users to make sure that the words you use are right for their circumstances.</p>
         <h3 id="back-passage">back passage</h3>
         <p>We do not use "back passage". Instead we use "<a href="#bottom">bottom</a>", "<a href="#anus">anus</a>" or, rarely, "<a href="#rectum">rectum</a>".</p>
         <h3 id="bacteria">bacteria</h3>
@@ -265,6 +269,13 @@
         <p>Also see "<a href="#specialist">specialist</a>".</p>
         <h3 id="dosage">dosage</h3>
         <p>See dosage on our <a href="/service-manual/content/numbers-measurements-dates-time#dosage">Numbers, measurements, dates and time</a> page.</p>
+        <h3 id="drowsy">drowsy</h3>
+        <p>Generally, we prefer the word "sleepy" to "drowsy" as people are more likely to search for "sleepy". But "drowsy" may be better if you're writing about feeling unusually sleepy in the daytime, particularly in the context of medicines.</p>
+        <p>In information about medicines, for example antihistamines, we prefer the terms:</p>
+        <ul>
+          <li>"drowsy (sedating)" to describe a medicine because these are the words people search for and see or hear in a GP or pharmacy setting</li>
+          <li>"feeling sleepy (drowsy)" to describe a side effect</li>
+        </ul>
         <h3 id="drugs">drugs</h3>
         <p>We use "medicines".</p>
         <p>We only use "drugs" for illegal drugs.</p>
@@ -315,6 +326,8 @@
         <h3 id="fever">fever</h3>
         <p>We prefer the words "high <a href="#temperature">temperature</a>" to "fever", for example in a list of symptoms. Our user research shows that "fever" is not a well understood word.</p>
         <p>But we still use it when we’re writing specifically about fever or different types of fever (such as scarlet fever).</p>
+        <h3 id="fit">fit</h3>
+        <p>See <a href="#seizure-or-fit">seizure or fit</a>.</p>
         <h3 id="flatulence">flatulence</h3>
         <p>We prefer "<a href="#fart">farting</a>" to "flatulence".</p>
         <p>We only use "flatulence" when we need to for clinical content (for example, in a health information page about flatulence). We explain that flatulence is the same as <a href="#wind">wind</a> or farting.</p>
@@ -324,6 +337,8 @@
         <p>We sometimes use "flu jab" for adults, because people search for this. But we use "flu vaccine" for children. (The child vaccine is a spray.)</p>
         <p>People who are looking for information about flu vaccination in pregnancy search for "jab".</p>
         <p>For the annual flu vaccination programme, we use the term "flu vaccine" as that covers children and adults.</p>
+        <h3 id="foetus">foetus</h3>
+        <p>We do not commonly use "foetus", except in the names of conditions like "foetal alcohol syndrome". We prefer "<a href="#baby">baby</a>".</p>
         <h3 id="foot-and-mouth-disease">foot and mouth disease</h3>
         <p>Lower case.</p>
         <h3 id="formula">formula</h3>
@@ -565,6 +580,9 @@
         <p>Note that a GP practice can have more than 1 surgery.</p>
         <h3 id="pre-school">pre-school</h3>
         <p>With a hyphen.</p>
+        <h3 id="preconception-care">preconception care</h3>
+        <p>We prefer "planning your pregnancy" or "thinking about your health before you get pregnant" or just "getting pregnant". This is the kind of language our users use.</p>
+        <p>Clinicians sometimes use "preconception care" when they're talking about women who need special care before they get pregnant - for example, changes to their medicine. We do not use "preconception care" as a topic. Instead we give specific advice where people need it, for example: "Talk to your doctor if you want to get pregnant. It's best to stop taking [name of medicine] at least 3 months before you start trying for a baby."</p>
         <h3 id="prognosis">prognosis</h3>
         <p>We prefer "outlook".</p>
         <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
@@ -611,6 +629,10 @@
         <p>See "<a href="#drowsy">drowsy</a>".</p>
         <h3 id="seek">seek</h3>
         <p>We say "ask for".</p>
+        <h3 id="seizure-or-fit">seizure or fit</h3>
+        <p>We use the term "seizure or fit" in content about epilepsy, brain cancer and brain tumours, and in other content, for example about possible side effects of some medicines.</p>
+        <p>We know that "seizure" is the word that people with epilepsy use, understand and prefer and that it’s not the same as a "fit" (which is about jerking and shaking uncontrollably). But some of our users don’t understand the word "seizure" and including the word "fit" helps them.</p>
+        <p>In general content, for example, with medicines that might make people jerk and shake uncontrollably as a side effect, we use the term "seizure or fit" and explain that this is what we mean.</p>
         <h3 id="service-user">service user</h3>
         <p>We prefer "<a href="#people-or-patients">people" or "patients</a>" - or in social services "people who use services".</p>
         <p>We haven't seen any evidence that people think of themselves as "service users", for example when they're searching for or using mental health services.</p>
@@ -633,7 +655,7 @@
         <p>We say that people may "get" or "have" side effects, not "develop" or "experience" them.</p>
         <p>Check a dictionary if you’re not sure of the difference between "affect" and "effect".</p>
         <h3 id="sleepy">sleepy</h3>
-        <p>Generally, we prefer the word "sleepy" to "drowsy" as people are more likely to search for "sleepy". But "<a href="#drowsy">drowsy</a>" may be better if you're writing about feeling unusually sleepy in the daytime, particularly in the context of medicines.</p>    
+        <p>Generally, we prefer the word "sleepy" to "drowsy" as people are more likely to search for "sleepy". But "<a href="#drowsy">drowsy</a>" may be better if you're writing about feeling unusually sleepy in the daytime, particularly in the context of medicines.</p>
         <h3 id="smear-test">smear test</h3>
         <p>We prefer "<a href="#cervical-screening">cervical screening</a>".</p>
         <h3 id="specialist">specialist</h3>
@@ -656,13 +678,16 @@
         <p>We don’t use "suffering from". We talk about people having or living with a disability or condition.</p>
         <p>Read more about how we talk about disabilities and conditions on the <a href="/service-manual/content/inclusive-language#disabilities-and-conditions">Inclusive language</a> page.</p>
         <h3 id="summary-care-record">summary care record</h3>
-        <p>Lower case. Also see <a href="#health-record">health record</a>.</p>
+        <p>Lower case.</p>
+        <p>For a professional audience (people who will know the abbreviation already), it’s OK to use SCR after the first mention of a summary care record. (It's "an", not "a", SCR.)</p>
+        <p>For the public, we avoid the abbreviation. Instead it may be better to say: "your <a href="#health-record">health record</a>" or "a summary of your health record".</p>
         <h3 id="surgery">surgery</h3>
         <p>When we’re writing for the public, we use "GP surgery" or "surgery" rather than "practice", because our research shows us that this is the word patients are more likely to search for and use.</p>
         <p>When we’re writing for healthcare staff, we may use the word "practice". For example, for "practice managers".</p>
         <p>Note that a practice can have more than 1 surgery.</p>
         <h3 id="symptoms">symptoms</h3>
         <p>We say that people may "get" or "have" symptoms, not "develop" or "experience" them.</p>
+
         <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
           <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
@@ -801,7 +826,7 @@
       <p>Please <a href="/service-manual/contribute">get in touch</a> if you have any evidence to share or changes to suggest.</p>
 
       <div class="nhsuk-review-date">
-        <p class="nhsuk-body-s">Updated: August 2019</p>
+        <p class="nhsuk-body-s">Updated: September 2019</p>
       </div>
 
     </div>

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -31,6 +31,16 @@
 </div>
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
+    <div class="app-page-contents">
+      <h2 class="app-page-contents__heading">On this page</h2>
+      <ul class="app-page-contents__list">
+        <li class="app-page-contents__item">Disabilities and conditions</li>
+        <li class="app-page-contents__item">Mental health</li>
+        <li class="app-page-contents__item">Race, ethnicity, religion and nationality</li>
+        <li class="app-page-contents__item">Sex, gender and sexuality</li>
+        <li class="app-page-contents__item">Age</li>
+      </ul>
+    </div>
     <h2 id="disabilities-and-conditions">Disabilities and conditions</h2>
     <p>We use positive language and don't label people when talking about disabilities and conditions.</p>
     <p>We do say things like:</p>
@@ -100,9 +110,8 @@
     <p>We use:</p>
     <ul>
       <li>fertilised egg: from conception to 14 days</li>
-      <li>embryo: from 2 to 9 weeks</li>
-      <li>unborn baby: from week 10 to birth</li>
-      <li>baby: 0 to 12 months</li>
+      <li>embryo: from 2 to 6 weeks</li>
+      <li>baby: during pregnancy, at birth and up to 1 year. (Read more about how we use <a href="/service-manual/content/a-to-z-of-NHS-health-writing#baby">"baby" in the A to Z of NHS health writing</a>.)</li>
       <li>toddler: 1 to 3 years</li>
       <li>child: 4 to 12 years</li>
       <li>teenager: 13 to 19 years</li>
@@ -122,7 +131,7 @@
     </ul>
 
     <div class="nhsuk-review-date">
-     <p class="nhsuk-body-s">Updated: August 2019</p>
+     <p class="nhsuk-body-s">Updated: September 2019</p>
     </div>
   </div>
   <aside class="nhsuk-grid-column-one-third">


### PR DESCRIPTION
Add mini-hub pattern at top of Inclusive language page
Change how we refer to baby in Inclusive language page and link to word "baby" in A to Z of NHS health writing
Add entries for "baby" and "foetus" to A to Z
Add words "drowsy", "sleepy" and "sedating" to the A to Z 
Update entry for "summary care record" in A to Z to cover use of abbreviation
Add new term "preconception care" to A to Z
Add term "seizure or fit" to A to Z with a link from "fit" to "seizure or fit"
Update dates on Inclusive language and A to Z pages to September 2019