### PR TITLE
update the expired service manual Slack invite URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove the old basic cookie consent solution
 - Implement the new cookie consent solution
 - Remove feedback survey from the sitemap
+- Update the Slack workspace URL
 
 ## 1.10.3 - 19 September 2019
 

--- a/app/views/accessibility/partials/get-in-touch-accessibility.njk
+++ b/app/views/accessibility/partials/get-in-touch-accessibility.njk
@@ -1,4 +1,4 @@
 <div class="nhsuk-panel">
   <h2>Get in touch</h2>
-  <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS digital service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+  <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS digital service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
 </div>

--- a/app/views/accessibility/user-research.njk
+++ b/app/views/accessibility/user-research.njk
@@ -40,7 +40,7 @@
 
     <div class="nhsuk-panel">
       <h2>Get in touch</h2>
-      <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS digital service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+      <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS digital service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
     </div>
 
     <div class="nhsuk-review-date">

--- a/app/views/content/index.njk
+++ b/app/views/content/index.njk
@@ -59,7 +59,7 @@
     <p>It's meant as a guide, not a rulebook. You're welcome to adapt a style pattern if it does not meet your users' needs.</p>
     <h2 class="nhsuk-u-margin-top-8">In progress</h2>
     <p>The guide will grow and change as we learn more about the language and writing styles that work best for our users.</p>
-    <p>Join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a> to hear about and discuss changes.</p>
+    <p>Join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a> to hear about and discuss changes.</p>
     <p>Check the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style">GOV.UK A to Z style guide</a> and <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">GOV.UK content design guide</a> for any points of style that you do not find here. If it's not there, we recommend using the Oxford Dictionary for Writers and Editors.</p>
 
     <h2 class="nhsuk-u-margin-top-8">Contribute</h2>

--- a/app/views/contribute/index.njk
+++ b/app/views/contribute/index.njk
@@ -89,7 +89,7 @@
     <h3>Other things</h3>
     <p>We are working on this. Please get in touch with the service manual team:</p>
     <ul>
-      <li>Slack: <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>Slack: <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>Email: <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/frontend-library/index.njk
+++ b/app/views/frontend-library/index.njk
@@ -48,7 +48,7 @@
 
     <h2>Get in touch</h2>
     <p>You can <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/CONTRIBUTING.md">contribute</a> code via GitHub.</p>
-    <p>And you can contact us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net.</a></p>
+    <p>And you can contact us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net.</a></p>
 
     <div class="nhsuk-review-date">
       <p class="nhsuk-body-s">Updated: January 2019</p>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -83,7 +83,7 @@
           <h2>Get in touch</h2>
           <p>The manual is maintained by the service manual team at NHS Digital. Get in touch if you have any questions or feedback.</p>
           <ul>
-            <li>Slack: <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual public Slack workspace</a></li>
+            <li>Slack: <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual public Slack workspace</a></li>
             <li>Email: <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></li>
           </ul>
         </div>

--- a/app/views/prototyping-tools/index.njk
+++ b/app/views/prototyping-tools/index.njk
@@ -35,7 +35,7 @@
     <h2>Sketch file</h2>
     <p><a href="https://www.sketchapp.com/">Sketch</a> is a design tool. You can use the <a href="https://github.com/nhsuk/nhsuk-sketch-file">NHS.UK Sketch file</a> to create static mockups to test with users.
     <h2>Get in touch</h2>
-    <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS digital service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS digital service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
 
     <div class="nhsuk-review-date">
     <p class="nhsuk-body-s">Updated: January 2019</p>

--- a/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
+++ b/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
@@ -73,7 +73,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/10-iterate-and-improve-frequently.njk
+++ b/app/views/service-standard/10-iterate-and-improve-frequently.njk
@@ -54,7 +54,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/11-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
+++ b/app/views/service-standard/11-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
@@ -65,7 +65,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/12-make-your-service-interoperable.njk
+++ b/app/views/service-standard/12-make-your-service-interoperable.njk
@@ -68,7 +68,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/13-choose-the-right-tools-and-technology.njk
+++ b/app/views/service-standard/13-choose-the-right-tools-and-technology.njk
@@ -66,7 +66,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/14-make-new-source-code-open.njk
+++ b/app/views/service-standard/14-make-new-source-code-open.njk
@@ -63,7 +63,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/2-join-things-up-and-work-towards-solving-a-whole-problem.njk
+++ b/app/views/service-standard/2-join-things-up-and-work-towards-solving-a-whole-problem.njk
@@ -67,7 +67,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/3-make-the-service-easy-to-use.njk
+++ b/app/views/service-standard/3-make-the-service-easy-to-use.njk
@@ -58,7 +58,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/4-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/service-standard/4-make-sure-everyone-can-use-the-service.njk
@@ -69,7 +69,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/5-support-a-culture-of-care.njk
+++ b/app/views/service-standard/5-support-a-culture-of-care.njk
@@ -72,7 +72,7 @@
     </ul>
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/6-make-your-service-clinically-safe.njk
+++ b/app/views/service-standard/6-make-your-service-clinically-safe.njk
@@ -68,7 +68,7 @@
     </ul>
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
       <li>Contact the NHS Digital Clinical Safety team at <a href="mailto:assurance@nhs.net">assurance@nhs.net</a> or on 0300 303 5678.</li>
       <li>Take up NHS Digital <a href="https://digital.nhs.uk/services/solution-assurance/the-clinical-safety-team/clinical-risk-management-training">clinical risk management training</a>.</li>
     </ul>

--- a/app/views/service-standard/7-respect-and-protect-users-confidentiality-and-privacy.njk
+++ b/app/views/service-standard/7-respect-and-protect-users-confidentiality-and-privacy.njk
@@ -70,7 +70,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/8-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
+++ b/app/views/service-standard/8-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
@@ -56,7 +56,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/9-use-agile-ways-of-working.njk
+++ b/app/views/service-standard/9-use-agile-ways-of-working.njk
@@ -60,7 +60,7 @@
 
     <h3>Other help</h3>
     <ul>
-      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
+      <li>Talk to us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</li>
     </ul>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: April 2019</p>

--- a/app/views/service-standard/about.njk
+++ b/app/views/service-standard/about.njk
@@ -58,7 +58,7 @@
     <h2>How we're developing it</h2>
     <p>The NHS service standard is currently a 'prototype' - a first version. We're testing it with NHS teams and will be improving it over the next few months. We'll be adding guidance, examples and case studies to the <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a> to support the standard.</p>
     <p>Both the service standard and the service manual come from the experience of the teams at NHS Digital behind the NHS website (<a href="https://www.nhs.uk/">nhs.uk</a>).</p>
-    <p>We're very interested in hearing what you think about the standard and how it might, or might not, help you develop digital services in health. <a href="mailto:service-manual@nhs.net">Email us</a> or get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack channel</a>.</p>
+    <p>We're very interested in hearing what you think about the standard and how it might, or might not, help you develop digital services in health. <a href="mailto:service-manual@nhs.net">Email us</a> or get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack channel</a>.</p>
 
     <p class="nhsuk-body-s nhsuk-u-margin-top-8">Updated: March 2019</p>
 

--- a/app/views/styles-components-patterns/a-to-z.njk
+++ b/app/views/styles-components-patterns/a-to-z.njk
@@ -121,7 +121,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>Join us on <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">the service manual Slack workspace</a></li>
+      <li>Join us on <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">the service manual Slack workspace</a></li>
       <li>or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></li>
      </ul>
     <div class="nhsuk-review-date">

--- a/app/views/styles-components-patterns/action-link.njk
+++ b/app/views/styles-components-patterns/action-link.njk
@@ -64,7 +64,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/back-link.njk
+++ b/app/views/styles-components-patterns/back-link.njk
@@ -63,7 +63,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/breadcrumbs.njk
+++ b/app/views/styles-components-patterns/breadcrumbs.njk
@@ -60,7 +60,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
     <div class="nhsuk-review-date">

--- a/app/views/styles-components-patterns/buttons.njk
+++ b/app/views/styles-components-patterns/buttons.njk
@@ -111,7 +111,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
     <div class="nhsuk-review-date">

--- a/app/views/styles-components-patterns/care-cards.njk
+++ b/app/views/styles-components-patterns/care-cards.njk
@@ -145,7 +145,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/checkboxes.njk
+++ b/app/views/styles-components-patterns/checkboxes.njk
@@ -59,7 +59,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/contents-list.njk
+++ b/app/views/styles-components-patterns/contents-list.njk
@@ -78,7 +78,7 @@
   <h2>Get in touch</h2>
   <p>If you have a question:</p>
   <ul>
-    <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+    <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
     <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
   </ul>
 

--- a/app/views/styles-components-patterns/date-input.njk
+++ b/app/views/styles-components-patterns/date-input.njk
@@ -71,7 +71,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/details.njk
+++ b/app/views/styles-components-patterns/details.njk
@@ -59,7 +59,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/do-and-dont-list.njk
+++ b/app/views/styles-components-patterns/do-and-dont-list.njk
@@ -60,7 +60,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/error-message.njk
+++ b/app/views/styles-components-patterns/error-message.njk
@@ -80,7 +80,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/error-summary.njk
+++ b/app/views/styles-components-patterns/error-summary.njk
@@ -69,7 +69,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/expander.njk
+++ b/app/views/styles-components-patterns/expander.njk
@@ -75,7 +75,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/fieldset.njk
+++ b/app/views/styles-components-patterns/fieldset.njk
@@ -68,7 +68,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/footer.njk
+++ b/app/views/styles-components-patterns/footer.njk
@@ -41,11 +41,11 @@
     <h2 id="when-not-to-use-the-footer">When not to use the footer</h2>
     <p>Do not use this footer for transactional services.</p>
     <p>At the moment, we are only using it for the new NHS.UK website. We are considering how to use it on other NHS Digital sites and services on the NHS.UK domain including transactional journeys.</p>
-    <p>If your service is not part of NHS.UK, get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>If your service is not part of NHS.UK, get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
     <h2 id="research">How not to use the footer</h2>
     <p>Avoid adding more links to the footer. Keep them to a minimum.</p>
     <p>Product owners can decide whether or not to use all the links in the example.</p>
-    <p>If you have more information to add about how to use the footer, please let us know on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>If you have more information to add about how to use the footer, please let us know on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
 
     <h2 id="research">Research</h2>
     <p>Get in touch to <a href="/service-manual/contribute"> share your research findings</a> if you've used this pattern.</p>
@@ -56,7 +56,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/header.njk
+++ b/app/views/styles-components-patterns/header.njk
@@ -55,7 +55,7 @@
     <li>some NHS Digital sites and services, for example, the NHS App, the NHS login and the NHS digital service manual</li>
     </ul>
 
-    <p>If you want to use the header and your service is not part of NHS.UK, please get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>If you want to use the header and your service is not part of NHS.UK, please get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
 
     <h2 id="research">Research</h2>
     <h3>NHS.UK header</h3>
@@ -71,7 +71,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/hint-text.njk
+++ b/app/views/styles-components-patterns/hint-text.njk
@@ -50,7 +50,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/icons.njk
+++ b/app/views/styles-components-patterns/icons.njk
@@ -185,7 +185,7 @@
     <p class="rich-text">Some older browsers like Internet Explorer 8 can't display SVG. So every SVG icon has a PNG fallback. The fallback images have a class, such as <code>.nhsuk-icon__search—fallback</code>, which you can use to modify their sizing and spacing.</p>
     <h3>Accessibility</h3>
     <p>SVG icons must be accessible. For example, they need to meet accessible colour contrast standards. Our recommended tool to test colour combinations is the <a href="https://webaim.org/resources/contrastchecker/">WebAIM contrast checker</a>. Read more about <a href="https://css-tricks.com/accessible-svgs/">accessible SVGs on CSS Tricks website</a>.</p>
-    <p>If you have any research or experience to share, please get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>If you have any research or experience to share, please get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
     <h2 id="research">Research</h2>
     <p>These icons seem to be universally recognisable. When we tested them, we found that people understood them. We tested them in context - not on their own, but in components on a full page.</p>
     <p>Get in touch to <a href="/service-manual/contribute">share your research findings</a> if you've used these icons or want to explore other icons.</p>
@@ -195,7 +195,7 @@
       <li><a href="https://css-tricks.com/a-complete-guide-to-svg-fallbacks/">CSS Tricks - a complete guide to SVG fallbacks</a></li>
     </ul>
     <h2>Discuss</h2>
-    <p>Discuss icons on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>Discuss icons on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email the standards team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
     <div class="nhsuk-review-date">
     <p class="nhsuk-body-s">Updated: March 2019</p>
     </div>

--- a/app/views/styles-components-patterns/images.njk
+++ b/app/views/styles-components-patterns/images.njk
@@ -62,7 +62,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/index.njk
+++ b/app/views/styles-components-patterns/index.njk
@@ -63,7 +63,7 @@
 
 
     <h2>Designing new components</h2>
-    <p>These components are well tested and ready to use. Before you design a new one, please test an existing component. Check with us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS digital service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a> as we may already be working on what you need.</p>
+    <p>These components are well tested and ready to use. Before you design a new one, please test an existing component. Check with us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS digital service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a> as we may already be working on what you need.</p>
     <p>If you decide you need a new component, make sure that:</p>
     <ul>
       <li>you have good evidence that it's the best way of meeting the user need</li>
@@ -79,7 +79,7 @@
   <div class="nhsuk-grid-column-two-thirds">
     <h2 class="nhsuk-u-margin-top-8">Contribute</h2>
     <p>Help improve the manual by contributing to <a href="https://github.com/nhsuk/nhsuk-frontend/tree/master/app/components">components on GitHub</a>.</p>
-    <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></p>
+    <p>Join us on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></p>
     <div class="nhsuk-review-date">
     <p class="nhsuk-body-s">Updated: July 2019</p>
     </div>

--- a/app/views/styles-components-patterns/inset-text.njk
+++ b/app/views/styles-components-patterns/inset-text.njk
@@ -65,7 +65,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/mini-hub.njk
+++ b/app/views/styles-components-patterns/mini-hub.njk
@@ -107,7 +107,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the NHS.UK <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the NHS.UK <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></li>
      </ul>
     <div class="nhsuk-review-date">

--- a/app/views/styles-components-patterns/pagination.njk
+++ b/app/views/styles-components-patterns/pagination.njk
@@ -67,7 +67,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/radios.njk
+++ b/app/views/styles-components-patterns/radios.njk
@@ -107,7 +107,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/review-date.njk
+++ b/app/views/styles-components-patterns/review-date.njk
@@ -59,7 +59,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/select.njk
+++ b/app/views/styles-components-patterns/select.njk
@@ -50,7 +50,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/skip-link.njk
+++ b/app/views/styles-components-patterns/skip-link.njk
@@ -55,7 +55,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/table.njk
+++ b/app/views/styles-components-patterns/table.njk
@@ -73,7 +73,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/text-input.njk
+++ b/app/views/styles-components-patterns/text-input.njk
@@ -88,7 +88,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 

--- a/app/views/styles-components-patterns/textarea.njk
+++ b/app/views/styles-components-patterns/textarea.njk
@@ -81,7 +81,7 @@
       <h2>Get in touch</h2>
       <p>If you have a question:</p>
       <ul>
-        <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+        <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
         <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
       </ul>
 

--- a/app/views/styles-components-patterns/warning-callout.njk
+++ b/app/views/styles-components-patterns/warning-callout.njk
@@ -66,7 +66,7 @@
     <h3>Accessibility</h3>
     <p>The heading and background contrast ratio is 11.92:1 and the content and background contrast ratio is 13.69:1. These go beyond AAA guidelines.</p>
     <p class="rich-text">We recommend adding an aria label, for example: <code>aria-label="Important"</code>. This will help users with screen readers understand that the information is important. We still need to test this with users with access needs.</p>
-    <p>If you can help with this, please get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ"> NHS.UK service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+    <p>If you can help with this, please get in touch on the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE"> NHS.UK service manual Slack workspace</a> or email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
 
     <h2>Research</h2>
     <p>In testing, users noticed the yellow callouts and understood them as a warning.</p>
@@ -85,7 +85,7 @@
     <h2>Get in touch</h2>
     <p>If you have a question:</p>
     <ul>
-      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLWUwOWM5MWY5MGRhYTYxZmY4ZWI0NDA1N2NhNTRiMGY3MTQxNjk5YTc3ZTAzMTA4YmE3ZDAxYmQ3MTQxNDgzOTQ">NHS.UK service manual Slack workspace</a></li>
+      <li>join the <a href="https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE">NHS.UK service manual Slack workspace</a></li>
       <li>email <a href="mailto: service-manual@nhs.net">service-manual@nhs.net</a></li>
     </ul>
 


### PR DESCRIPTION
## Description

The invite URL for the service manual Slack workspace had expired so people could no longer join the workspace using the link. A new invite URL has been generated.