### PR TITLE
Iterate component pages for good questions guidance

### DIFF
--- a/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
@@ -79,7 +79,9 @@
 
   <p>Be especially careful with "Other" or "Mixed" ethnicity in the context of health information. Do not use these categories to provide health information.</p>​
 
-    <h2>Read more in the GOV.UK design system</h2>
+    <h2>Use tested patterns</h2>
+    <p>We do not yet have NHS patterns for collecting this kind of data. Use these GOV.UK patterns for now.</p>
+    <h3>GOV.UK Design System patterns</h3>
 
     <ul>
       <li><a href="https://design-system.service.gov.uk/patterns/addresses/">addresses</a></li>

--- a/app/views/content/how-to-write-good-questions-for-forms/index.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/index.njk
@@ -61,7 +61,7 @@
     <ul>
       <li>Caroline Jarrett, an expert in forms design, was our subject matter expert.</li>
       <li>We've tested the guidance with a number of digital teams in the NHS and have learnt from their work.</li>
-      <li>We've built on the GOV.UK service manual and the GDS design system.</li>
+      <li>We've built on the GOV.UK service manual and the GDS Design System.</li>
       <li>We've used Tourangeau, Rips and Rasinski's model of how people respond to survey questions.</li>
     </ul>
     <h2>Help us improve this guidance</h2>

--- a/app/views/content/how-to-write-good-questions-for-forms/use-yes-no-questions-but-be-careful.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/use-yes-no-questions-but-be-careful.njk
@@ -124,7 +124,10 @@
             "text": "Do you know your NHS number?",
             "classes": "nhsuk-fieldset__legend--m"
           }
-        },
+        },"hint": {
+          "text": "Your NHS number is a 10 digit number, like 485 777 3456.
+          You can find this on any letter sent to you by the NHS, on a prescription or by logging in to a GP practice online service."
+        ],
         "items": [
           {
             "value": "yes",
@@ -142,16 +145,40 @@
       }) }}
     </div>
 
-    <p>Having the 3rd option means that you can give people some extra help with finding their number.</p>
+    <p>Having the 3rd option means that you can give people some extra help with finding their number. (We'll be publishing on a pattern for the NHS number soon.)</p>
     <p>Sometimes "Other" is a useful option, but <a href="/service-manual/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions#think-before-you-use-other">be careful of using "Other" with personal or sensitive information</a>.</p>
     <p>If you're drafting a Yes No question, it can help to test it by leaving a space for people to type in something different.</p>
 
 
 
   <h2>Offer people other ways to do things</h2>
-     <p>If you need people to enter details to continue with their online journey and they can't do this, for example, because they don't have key informaton to hand, consider whether you could add information to the "No" option to reassure them that there is an alternative.</p>
-     <p>For example: "No, try another way".</p>
+     <p>If you need people to enter details to continue and they can't do this, for example, because they don't have key information to hand, consider whether you could add information to the "No" option to reassure them that there is an alternative.</p>
 
+
+     <div class="app-example nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-7">
+      <strong class="nhsuk-tag nhsuk-tag--dark-grey app-example__heading">Example</strong>
+      {{ radios({
+        "idPrefix": "example",
+        "name": "example",
+        "fieldset": {
+          "legend": {
+            "text": "Do you have your registration details?",
+            "classes": "nhsuk-fieldset__legend--m"
+          }
+        },
+        "items": [
+          {
+            "value": "yes",
+            "text": "Yes"
+          },
+          {
+            "value": "no",
+            "text": "No, try another way"
+          }
+        ]
+      }) }}
+    </div>
+     <p>The current version of the <a href="https://www.nhs.uk/apps-library/nhs-app/">NHS App</a> does something like this. If users don't have registration details from their GP practice, they can still register by entering some personal details and uploading a photo ID and a short video they make about themselves.</p>
 
 <div class="nhsuk-inset-text">
   <span class="nhsuk-u-visually-hidden">Information: </span>

--- a/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
@@ -49,19 +49,12 @@
     <p>Focus on the task, on what the user wants to do.</p>
 
     <h2>Introduce the form</h2>
-    <p>Use a <a href="/service-manual/styles-components-patterns/start-page">start page</a> to help users understand:
-    <ul>
-      <li>who the service is for</li>
-      <li>what the service helps them do</li>
-      <li>what they need to do to use it</li>
-      <li>whether there are alternative ways to do it</li>
-    </ul>
-    <p>This is your chance to stop the wrong people filling in the form and to set expectations.<p>
-    <p>Think about the users who don't meet the requirements. How can you help them?</p>
+    <p>Use a <a href="/service-manual/styles-components-patterns/start-page">start page</a> to introduce and explain your service to users. This is your chance to stop the wrong people filling in the form and to set expectations.<p>
 
-    <p>Read more about writing content for <a href="/service-manual/styles-components-patterns/start-page">start pages</a>. Be aware that people often ignore text under the "Start" button (and any "Continue" buttons.)</p>
 
-    <h2 id="help-text">Provide help in context</h2>
+    <p>Read more about <a href="/service-manual/styles-components-patterns/start-page#how-to-use-a-start-page">how to use a start page</a>. Be aware that people often ignore text under the start button (and any "Continue" buttons.)</p>
+
+    <h2 id="help-text">Give users help in context</h2>
     <p>If users need help or guidance with filling in a question, put just enough help text where they need it - and only if you see in research that they need it.</p>
     <p>For example, users do not usually need to be told to "Select the answer that applies to you" with <a href="/service-manual/styles-components-patterns/radios">radios</a>, but they may need telling to "Select all the options that are relevant to you" with <a href="/service-manual/styles-components-patterns/checkboxes">checkboxes</a>.</p>
     <div class="app-example nhsuk-u-margin-top-7 nhsuk-u-margin-bottom-7">

--- a/app/views/styles-components-patterns/confirmation-page.njk
+++ b/app/views/styles-components-patterns/confirmation-page.njk
@@ -47,7 +47,7 @@
   <div class="nhsuk-grid-column-two-thirds">
 
     <h2 id="when-to-use-this-pattern">When to use a confirmation page</h2>
-    <p>The <a href="https://design-system.service.gov.uk/patterns/confirmation-pages/">GOV.UK design system</a> recommends using a confirmation page at the end of a transaction.</p>
+    <p>The <a href="https://design-system.service.gov.uk/patterns/confirmation-pages/">GOV.UK Design System</a> recommends using a confirmation page at the end of a transaction.</p>
 
     <h2 id="how-it-works">How to use a confirmation page</h2>
     <p>Confirmation pages reassure users that they have completed a transaction and help them understand what to expect next.</p>
@@ -55,9 +55,9 @@
     <ul>
       <li>a reference number, if there is one</li>
       <li>details of what happens next and when</li>
-      <li>contact details for the service and signposting to support services</li>
+      <li>contact details for the service plus signposting to support services</li>
       <li>links to information or services that users are likely to need next</li>
-      <li>information about how they can change their details and how they can find out how you store and manage their information</li>
+      <li>information about how users can change their details and find out how you store and manage their information</li>
       <li>a way for users to save a record of the transaction, for example, as a PDF</li>
       <li>a link to your feedback page</li>
     </ul>
@@ -70,14 +70,14 @@
       <li>starting a new application</li>
       <li>what to do or who to contact if they have a problem with their application</li>
     </ul>
-      <p>Read a GOV.UK post <a href="https://designnotes.blog.gov.uk/2015/12/10/do-users-return-to-your-service-after-finishing/">Do users return to your service after finishing?</a> about users who bookmark confirmation pages.</p>
+      <p>Read a GOV.UK post <a href="https://designnotes.blog.gov.uk/2015/12/10/do-users-return-to-your-service-after-finishing/">Do users return to your service after finishing?</a></p>
 
     <h2>Research</h2>
-    <p>Our confirmation page is based on the one in the <a href="https://design-system.service.gov.uk/patterns/confirmation-pages/">GOV.UK design system</a>.</p>
+    <p>Our confirmation page is based on the one in the <a href="https://design-system.service.gov.uk/patterns/confirmation-pages/">GOV.UK Design System</a>.</p>
     <p>GOV.UK say that they need more research about the best way to confirm transactions that are part of a wider user task.</p>
 
     <h2>Discuss</h2>
-    <p><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/144">Discuss the Confirmation page pattern on GitHub</a>.</p>
+    <p><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/144">Discuss the confirmation page pattern on GitHub</a>.</p>
 
     <h2>Get in touch</h2>
     <p>If you have a question:</p>

--- a/app/views/styles-components-patterns/error-message.njk
+++ b/app/views/styles-components-patterns/error-message.njk
@@ -47,10 +47,10 @@
   <div class="nhsuk-grid-column-two-thirds">
     <h2>When to use error messages </h2>
     <p>Show an error message next to the field - as well as in the <a href="patterns/error-summary/">error summary</a> - when there is a validation error.</p>
-    <p>Follow our guidance on <a href="/service-manual/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>. Make things easy to use and understand so users never see an error message. Consider instead whether you need to change your back-end processes.</p>
-    <p>The GOV.UK design system has more information about <a href="https://design-system.service.gov.uk/components/error-message/#how-it-works">how error messages work</a>.
+    <p>Follow our guidance on <a href="/service-manual/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a> and make them easy to use so that users never see an error message. If you're still getting errors, consider instead whether you need to change your back-end processes.</p>
+
     <h2>When not to use error messages</h2>
-    <p>As the <a href="https://design-system.service.gov.uk/components/error-message/">GOV.UK design system</a> says, only display an error when someone tries to move to the next part of the service. Do not show error messages:</p>
+    <p>As the GOV.UK Design System says, only display an error when someone tries to move to the next part of the service. Do not show error messages:</p>
     <ul>
       <li>when users select or tab to a field</li>
       <li>as they are typing</li>
@@ -63,9 +63,10 @@
       <li>includes a way to leave the transaction</li>
     </ul>
     <h2>How to use error messages</h2>
-    <p>Focus on telling users how to fix the problem rather than describing what’s gone wrong. Read more about <a href="https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise">writing good error messages</a> on GOV.UK.</p>
-    <p>Use standard messages for different components. GOV.UK have some good <a href="https://design-system.service.gov.uk/components/error-message/#use-error-message-templates">error message templates for common errors</a>.</p>
-   <p>You may need to write more than 1 error message for each field.</p>
+    <p>Focus on telling users how to fix the problem rather than describing what's gone wrong. You may need to write more than 1 error message for each field. Read more about <a href="https://design-system.service.gov.uk/components/error-message/#be-clear-and-concise">writing good error messages</a> on GOV.UK.</p>
+    <p>Use standard messages for different components. The GOV.UK Design System has some good <a href="https://design-system.service.gov.uk/components/error-message/#use-error-message-templates">error message templates for common errors</a>.</p>
+
+    <p>The GOV.UK Design System also has more information about <a href="https://design-system.service.gov.uk/components/error-message/#how-it-works">how error messages work</a>.
 
     <h2>Research</h2>
 

--- a/app/views/styles-components-patterns/start-page.njk
+++ b/app/views/styles-components-patterns/start-page.njk
@@ -48,45 +48,42 @@
 
     <h2 id="when-to-use-this-pattern">When to use a start page</h2>
 
-    <p>Use a start page to introduce your service.</p>
+    <p>Use a start page to introduce and briefly explain your service.</p>
 
-    <p>It helps users understand:</p>
+    <h2 id="how-to-use-a-start-page">How to use a start page</h2>
+    <p>Help users understand:</p>
     <ul>
     <li>who the service is for</li>
-    <li>what the service helps them do</li>
-    <li>what they need to do to use it</li>
-    <li>whether there are alternative ways to do it</li>
+    <li>what the service will help them do - explain it in their words</li>
+    <li>what they need to do to use the service and any details they need to have, such as their NHS number</li>
+    <li>whether there are alternative ways to get the service</li>
     </ul>
+    <h3>Set expectations</h3>
+    <p>Explain how long it will take users to fill in the form and to get the service.</p>
+    <p>Tell them if they'll be able to check their answers at the end, for example with a <a href="https://design-system.service.gov.uk/components/summary-list/">summary list pattern</a> like one in the the GOV.UK Design System. </p>
 
-    <h2>How to use a start page</h2>
+    <h3>Let users know if they are eligible</h3>
+    <p>If you have simple eligibility criteria, explain them here. Or check eligibility as part of the form (especially if you have complicated requirements) with the GOV.UK <a href="https://design-system.service.gov.uk/patterns/check-a-service-is-suitable/">Check a service is suitable</a> pattern.</p>
+    <p>What about the users who don't meet the requirements? Can you help them?</p>
 
-    <p>Say what the form does in your users' words.</p>
-
-    <p>Set expectations. For example:</p>
-    <ul>
-      <li>tell users what they need in order to fill the form in. Do they need any identity details, such as their NHS number?</li>
-      <li>if you're going to let them check their answers at the end, for example with a <a href="https://design-system.service.gov.uk/components/summary-list/">summary list pattern like the GOV.UK one</a>, tell them early on</li>
-    </ul>
-
-    <p>Rather than explaining eligibility criteria, it's often better to check eligibility as part of the form. See the <a href="https://design-system.service.gov.uk/patterns/check-a-service-is-suitable/">Check a service is suitable pattern on the GOV.UK design system</a>.</p>
-
-    <h3>Be careful with start pages</h3>
-    <p>People usually want to get to the questions quickly. They often ignore text on this page.</p>
+    <h3>Avoid putting content under the start button</h3>
+    <p>Research has shown than people often miss information under the start button.</p>
 
     <p>If you have any introductory content:</p>
     <ul>
-      <li>keep it brief</li>
-      <li>make it easy for users to scan, select and move on</li>
+      <li>keep it brief - and, if possible, above the button</li>
       <li>use headings to break up your content - users may at least read the headings</li>
-      <li>consider instead giving users help where they need it (read about <a href="/service-manual/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#help-text">contextual help in our guidance on writing good questions for forms</a>)</li>
+      <li>make it easy for users to scan, select and move on</li>
     </ul>
+    <p>Instead of putting content on the start page, give users help where they need it. Read about <a href="/service-manual/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#help-text">giving users contextual help</a> in our guidance on writing good questions for forms.</p>
+
 
     <h2>Research</h2>
-    <p>Our start page is based on the pattern in the <a href="https://design-system.service.gov.uk/patterns/start-pages/">GOV.UK design system</a>.</p>
-    <p>User research has shown that users often miss any information under the Start button.</p>
+    <p>Our start page is based on the pattern in the <a href="https://design-system.service.gov.uk/patterns/start-pages/">GOV.UK Design System</a>.</p>
+    <p>User research has shown that users often miss any information under the start button.</p>
 
     <h2>Discuss</h2>
-    <p><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/169">Discuss the Start page pattern on GitHub</a>.</p>
+    <p><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/169">Discuss the start page pattern on GitHub</a>.</p>
 
     <h2>Get in touch</h2>
     <p>If you have a question:</p>


### PR DESCRIPTION
Iterate start page, errors page, and confirmation page
Add help text to NHS number on supporting content page - hint text still needs line break
Added example of another way on Yes No page
Uppercased GOV.UK Design System throughout.