### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## 2.0.2 - 6 January 2020
+## 2.1.0 - 6 January 2020
 
 :new: **New features**
 - Add entries for "pharmacy", "chemist" and "sex assigned or registered at birth" to the A to Z of NHS health writing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 2.0.2 - 6 January 2020
 
+:new: **New features**
+- Add entries for "pharmacy", "chemist" and "sex assigned or registered at birth" to the A to Z of NHS health writing
+
 :wrench: **Fixes**
 
-- Add more detail about interoperability standards to section 14 of NHS service standard 
+- Add more detail about interoperability standards to section 17 of NHS service standard 
+- Amend guidance on using the number 1 in Numbers, measurements, dates and time after December Style Council meeting
 - Update inclusive language page, especially the section on sex, gender and sexuality
 - Update package dependencies to latest versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS digital service manual Changelog
 
+## 2.0.2 - 6 January 2020
+
+:wrench: **Fixes**
+
+- Add more detail about interoperability standards to section 14 of NHS service standard 
+- Update inclusive language page, especially the section on sex, gender and sexuality
+
 ## 2.0.1 - 17 December 2019
 
 :wrench: **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add more detail about interoperability standards to section 14 of NHS service standard 
 - Update inclusive language page, especially the section on sex, gender and sexuality
+- Update package dependencies to latest versions
 
 ## 2.0.1 - 17 December 2019
 

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -139,6 +139,7 @@
       <p>User testing showed that people understand "bottom" better than "anus". They do search for "anus" in Google, however.</p>
       <h3 id="apply">apply</h3>
       <p>If we are talking about a medicine, we prefer "use", "put on" or "rub in".</p>
+
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
         <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
@@ -641,6 +642,9 @@
       <p>Instead of "community setting", we mention the place, for example, "in school", "in a clinic" or "at home".</p>
       <h3 id="sex-and-sexuality">sex and sexuality</h3>
       <p>Read about how we talk about sex, gender and sexuality on the <a href="/service-manual/content/inclusive-language#sex-gender-sexuality">Inclusive language</a> page.</p>
+      <h3 id="sex-assigned-at-birth">sex assigned or registered at birth</h3>
+      <p>Find out where we use "sex assigned at birth" and where we use "sex registered at birth" on the <a href="/service-manual/content/inclusive-language#sex-assigned-or-registered-at-birth">Inclusive language</a> page.</p>
+
       <h3 id="sexual-health-clinic">sexual health clinic</h3>
       <p>We use "sexual health clinic", not "STI clinic".</p>
       <p>Sexual health clinics can offer different services. So, when we mention them for the first time and are talking about STIs, we sometimes add that they may also be called "GUM clinics". When we are talking about contraception, we sometimes add that they may also be called "family planning or contraception clinics".</p>

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -201,6 +201,8 @@
       <p>We prefer the term "cervical screening" to "smear test". But we add "smear test" in brackets the first time we mention cervical screening.</p>
       <p>"Smear test" is a dated term and the cervical screening programme no longer uses it. The invitation and results letters use "cervical screening" and our content reflects that.</p>
       <p>We've seen anecdotal evidence from Public Health England, cervical screening service providers and smear takers that some users find the word "smear" off-putting.</p>
+      <h3 id="chemist">chemist</h3>
+      <p>We use "pharmacy", not "chemist". Our users are more likely to look for the word "pharmacy".</p>
       <h3 id="CJD">CJD</h3>
       <p>We use "CJD" – or "variant CJD (vCJD)" as the human form of BSE.</p>
       <p>Use full name "Creutzfeldt-Jakob disease" when you first mention CJD.</p>
@@ -562,6 +564,8 @@
       <h3 id="personal-child-health-record-(red-book)">personal child health record (red book)</h3>
       <p>All lower case. We include the phrase "red book" in brackets the first time we mention "personal child health record". Then we usually call it the "red book" after the first mention.</p>
       <p>Also see <a href="#health-record">health record</a>.</p>
+      <h3 id="pharmacy">pharmacy</h3>
+      <p>We use "pharmacy", not "chemist". Our users are more likely to look for the word "pharmacy".</p>
       <h3 id="PMS-(premenstrual-syndrome)">PMS (premenstrual syndrome)</h3>
       <p>We prefer "PMS" instead of "premenstrual syndrome". PMS is a commonly understood term and it is used more often than "premenstrual syndrome". But we should write it as "PMS (premenstrual syndrome)" at the first mention to make it clear what PMS stands for.</p>
       <p>We do not say "premenstrual tension" or "PMT" as these terms are more dated and users do not search for these as much as PMS.</p>
@@ -642,9 +646,8 @@
       <p>Instead of "community setting", we mention the place, for example, "in school", "in a clinic" or "at home".</p>
       <h3 id="sex-and-sexuality">sex and sexuality</h3>
       <p>Read about how we talk about sex, gender and sexuality on the <a href="/service-manual/content/inclusive-language#sex-gender-sexuality">Inclusive language</a> page.</p>
-      <h3 id="sex-assigned-at-birth">sex assigned or registered at birth</h3>
-      <p>Find out where we use "sex assigned at birth" and where we use "sex registered at birth" on the <a href="/service-manual/content/inclusive-language#sex-assigned-or-registered-at-birth">Inclusive language</a> page.</p>
-
+      <h3 id="sex-assigned-or-registered-at-birth">sex assigned or registered at birth</h3>
+      <p>We use the phrase "sex assigned at birth" when we're talking about trans health and gender dysphoria, as this is the language our audience uses. In other cases, we use "the sex someone was registered with at birth" because user research shows that most people understand this better as it refers to an actual event.</p>
       <h3 id="sexual-health-clinic">sexual health clinic</h3>
       <p>We use "sexual health clinic", not "STI clinic".</p>
       <p>Sexual health clinics can offer different services. So, when we mention them for the first time and are talking about STIs, we sometimes add that they may also be called "GUM clinics". When we are talking about contraception, we sometimes add that they may also be called "family planning or contraception clinics".</p>

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -834,7 +834,7 @@
     <p>Please <a href="/service-manual/contribute">get in touch</a> if you have any evidence to share or changes to suggest.</p>
 
     <div class="nhsuk-review-date">
-      <p class="nhsuk-body-s">Updated: December 2019</p>
+      <p class="nhsuk-body-s">Updated: January 2020</p>
     </div>
 
 {% endblock %}

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -57,39 +57,47 @@
   }) }}
 
   <h2 id="sex-gender-sexuality">Sex, gender and sexuality</h2>
-  <p>Only mention sex, gender or sexuality if relevant.</p>
-  <h3>Gender neutral language</h3>
-  <p>We make content gender neutral wherever possible. Avoid gender markers, such as Mr, Miss, Mrs, or Ms.</p>
-  <p>We do not label people with their gender identity or sexuality. Instead we say:</p>
+  <p>The language around sex, gender and sexuality changes all the time and it's an area that people hold strong and differing opinions about. We try to make sure that we are in touch with the communities we are writing for and we update this guidance regularly. This section should help you get started but the best thing is to test your content and services with the people who use them.</p>
+  <p>Only mention sex, gender or sexuality if they’re relevant, for example, to signpost people and help them get the health information and access to treatment they need.</p>
+  <h3>When to use "sex" and when to use "gender"</h3>
+  <p>In general, people understand sex and gender to be the same thing. But sometimes it’s important to be clear about the difference.​</p>
+  <h3>Sex</h3>
+  <p>Sex is biological – male or female.</p>
+  <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
+  <h3>Gender</h3>
+  <p>Gender is more complex. It refers to our internal sense of who we are and how we see ourselves. Someone may see themselves as a man, a woman or neither (non-binary), for example somewhere between or beyond “man” or “woman” (for example agender). They may identify with a gender opposite to the sex they were registered with.​</p>
+  <p>We use "gender" when we're:​</p>
   <ul>
-    <li>trans woman</li>
-    <li>trans man</li>
-    <li>lesbian woman</li>
-    <li>gay man</li>
-    <li>men who have sex with men</li>
+    <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender​</li>
+    <li>writing about a survey or report based on gender, such as gender diversity​</li>
+    <li>writing about the results of a national census, where there is a question about gender identity as well as sex to identify the trans (including non-binary) population​</li>
   </ul>
-  <p>We use "trans woman" for someone who was assigned male at birth and "trans man" for someone who was assigned female at birth. We use "trans woman" or "trans man" in content about the particular health needs of trans people - for example, screening or treatments that trans people need to be aware of, like advising a trans man about cervical and breast screening.</p>
-  <p>Otherwise we use "trans" as an umbrella term to cover the diverse range of identities outside the traditional male/female definitions. These include transgender, gender fluid and non-binary.</p>
-  <h4>They</h4>
-  <p>It's alright to use "they" to avoid "he or she" or where you need a gender-neutral pronoun.</p>
+  <h3>Gender neutral language</h3>
+  <p>We make content gender neutral as far as possible. In general, we word our content to avoid masculine and feminine pronouns (“he” or “she”). Instead we use “you” where appropriate.​</p>
+  <p>It's alright to use "they" to avoid "he” or “she" or where you need a gender-neutral pronoun.​</p>
   <p>For example:</p>
   {{ insetText({
-    "HTML": "<p>You should see the GP if you have persistent symptoms of osteoarthritis so they can confirm the diagnosis and prescribe any necessary treatment.</p>"
+    "HTML": "<p>You should see the GP if you have persistent symptoms of osteoarthritis so they can confirm the diagnosis and prescribe any treatment you need.</p>"
   }) }}
 
-  <h3>When to use "sex" and when to use "gender"</h3>
-  <p>Sex is biological – male, female or intersex.</p>
-  <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
-  <p>Gender is more complex. It's about social and legal status and social expectations. It's also about how people feel and think about themselves.</p>
-  <p>Someone may see themselves as a man, a woman or neither (non-binary). They may identify with a gender opposite to the sex they were assigned at birth or neither.</p>
-  <p>We use "gender" when we're:</p>
-  <ul>
-    <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender</li>
-    <li>writing about a survey or report based on gender, such as gender and professions</li>
-  </ul>
+<p>Avoid asking users for their title, such as Mr, Miss, Mrs, or Ms.</p>
+<p>We use "trans" as an umbrella term to describe people whose current gender identity or way of expressing their gender differs from the sex they were registered at birth. ​Some trans people may identify as male, female, a combination of the 2, or as non-binary (neither genders). These can be either fluid or fixed identities. Some, but not all, trans people may want to transition socially and/or medically.</p>
+<p>We use "trans woman" for someone who was registered male at birth and now identifies as a woman and "trans man" for someone who was registered female at birth and now identifies as a man.</p>
+<p>We use "trans woman" or "trans man" in content about the particular health needs of trans people - for example, screening or treatments that trans people need to be aware of, like advising a trans man about cervical and breast screening.​</p>
+<p>We use “intersex” in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person’s sex development is different to most other people’s. Some adults prefer the term “differences in sex development”. As always, test your language with the people who will be using your content or service.</p>
+
+<h3>Sexuality</h3>
+<p>We use language about sexuality when it’s helpful to signpost or help people get the health information and access to treatment they need.​</p>
+<p>For example, when we’re talking about specific sexual health services or sexual health content, we use words like:​</p>
+<ul>
+  <li>lesbian</li>
+  <li>gay</li>
+  <li>bisexual</li>
+  <li>men who have sex with men (MSM includes men who may not identify as gay)​</li>
+</ul>
 
   <h2 id="age">Age</h2>
-  <p>Only include age if relevant, for example, with vaccination, screening or testing programmes where age determines eligibility. An example of this is chlamydia testing as tests are free for under-25s.</p>
+  <p>Only include age if it’s relevant, for example, with vaccination, screening or testing programmes for particular age groups. An example of this is chlamydia testing as tests are free for under-25s.</p>
   <p>Here are some of the terms we use for different stages of life with some guidance about the ages they relate to.</p>
   <p>When you need to be more specific, for example if you're writing about medicines dosage, give the actual age. For example, "teenagers aged 16 and over".</p>
   <p>We use:</p>
@@ -102,7 +110,6 @@
     <li>teenager: 13 to 19 years</li>
     <li>young people: 16 to 24 years</li>
     <li>adult: generally from age 18 but this may vary. Be specific, for example: "adults aged 19 to 64"
-    <li>older person: 65 years and over</li>
   </ul>
   <p>With babies and toddlers, we count their age in weeks up until 6 months, then months up until 2 years.</p>
   <p>We do not use the words:</p>
@@ -114,6 +121,10 @@
     <li>pensioner</li>
     <li>senior</li>
   </ul>
+  <h3>Older people</h3>
+  <p>In some contexts, we use “older person” or “older people”, for example, where a health condition might affect people in their 60s or in their 90s.​</p>
+  <p>Example: Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>
+  <p>But we prefer to specify ages: over-65s, over-75s, over-80s.</p>
 
   <div class="nhsuk-review-date">
     <p class="nhsuk-body-s">Updated: September 2019</p>

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -63,15 +63,18 @@
   <p>Many people think that sex and gender are the same but they mean different things. It's important to be clear about the difference.​</p>
   <h4>Sex</h4>
   <p>Sex is biological – male or female. It's based not only on the genes we inherit, but also on how our external and internal sex and reproductive organs work and  respond to hormones. Sex is the label that's recorded when a baby's birth is registered.</p>
-  <p>(We use the phrase "sex assigned at birth" when we're talking about trans health and gender dysphoria, as this is the language our audience uses. In other cases, we use "the sex someone was registered with at birth" because user research shows that this works better for most people as it refers to an actual event.)</p>
   <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
+  <h5 id="sex-assigned-or-registered-at-birth">Sex assigned or registered at birth</h5>
+
+  <p>We use the phrase "sex assigned at birth" when we're talking about trans health and gender dysphoria, as this is the language our audience uses. In other cases, we use "the sex someone was registered with at birth" because user research shows that this works better for most people as it refers to an actual event.</p>
+
   <h4>Gender</h4>
   <p>Gender is more complex. It refers to our internal sense of who we are and how we see and describe ourselves.</p>
   <p>Someone may see themselves as a man, a woman or neither (non-binary). Being non-binary can mean having no gender, a different gender, or being in between genders. Gender can be fixed or fluid. Some people identify with a gender opposite to the sex they were registered with.</p>
 
   <p>We use the word "gender" when we're:​</p>
   <ul>
-    <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender​ health</li>
+    <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender​ health and social care</li>
     <li>writing about a survey or report based on gender, such as gender diversity​</li>
     <li>writing about the results of a national census, where there is a question about gender identity as well as sex to identify the trans (including non-binary) population​</li>
   </ul>
@@ -86,9 +89,10 @@
 
 <h3>Transgender</h3>
 <p>We use "trans" as an umbrella term to describe people whose current gender identity or way of expressing their gender differs from the sex they were registered with at birth. Some, but not all, trans people want to transition (change) socially or medically or both.</p>
-<p>We use "trans woman" for someone who was assigned male at birth and now identifies as a woman and "trans man" for someone who was registered female at birth and now identifies as a man.</p>
+<p>We use "trans woman" for someone who was registered male at birth and now identifies as a woman and "trans man" for someone who was registered female at birth and now identifies as a man.</p>
 <p>We use "trans woman" or "trans man" in content about the particular health needs of trans people - for example, screening or treatments that trans people need to be aware of, like advising a trans man about cervical and breast screening.​<p>
 <p>Otherwise, we leave out the word "trans" and just refer to men and women, if relevant.</p>
+<p>Note: we use "sex assigned at birth" when we're writing for a trans audience. Read more about <a href="#sex-assigned-or-registered-at-birth">sex assigned or registered at birth</a>.</p>
 
 <h3>Intersex</h3>
 <p>We use "intersex" in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person's sex development is different to most other people's. Some adults prefer the term "differences in sex development".</p>

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -60,12 +60,13 @@
   <p>The language around sex, gender and sexuality changes all the time and it's an area that people hold strong and differing opinions about. We try to make sure that we are in touch with the communities we are writing for and we update this guidance regularly. This section should help you get started but the best thing is to test your content and services with the people who use them.</p>
   <p>Only mention sex, gender or sexuality if they’re relevant, for example, to signpost people and help them get the health information and access to treatment they need.</p>
   <h3>When to use "sex" and when to use "gender"</h3>
-  <p>In general, people understand sex and gender to be the same thing. But sometimes it’s important to be clear about the difference.​</p>
+  <p>Many people assume that sex and gender are the same. However, it’s important to be clear on the different meaning of each term.​</p>
   <h3>Sex</h3>
-  <p>Sex is biological – male or female.</p>
+  <p>Sex is biological – male or female - and is the label given when the birth of a baby is registered. Sex is based not only on the genes we inherit, but also how primary sex characteristics (genitalia) and the internal reproductive organs work and respond to hormones.</p>
   <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
   <h3>Gender</h3>
-  <p>Gender is more complex. It refers to our internal sense of who we are and how we see ourselves. Someone may see themselves as a man, a woman or neither (non-binary), for example somewhere between or beyond “man” or “woman” (for example agender). They may identify with a gender opposite to the sex they were registered with.​</p>
+  <p>Gender is more complex. It refers to our internal sense of who we are and how we see and describe ourselves.</p>
+  <p>Someone may see themselves as a man, a woman or neither (non-binary). Being non-binary can mean having no gender, a different gender, or in between genders. Gender can be fixed or fluid. Some people may identify with a gender opposite to the sex they were registered with.</p>
   <p>We use "gender" when we're:​</p>
   <ul>
     <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender​</li>
@@ -74,17 +75,23 @@
   </ul>
   <h3>Gender neutral language</h3>
   <p>We make content gender neutral as far as possible. In general, we word our content to avoid masculine and feminine pronouns (“he” or “she”). Instead we use “you” where appropriate.​</p>
-  <p>It's alright to use "they" to avoid "he” or “she" or where you need a gender-neutral pronoun.​</p>
   <p>For example:</p>
   {{ insetText({
     "HTML": "<p>You should see the GP if you have persistent symptoms of osteoarthritis so they can confirm the diagnosis and prescribe any treatment you need.</p>"
   }) }}
 
+<p>It's alright to use "they" to avoid "he” or “she" or where you need a gender-neutral pronoun, unless this is confusing.​</p>
 <p>Avoid asking users for their title, such as Mr, Miss, Mrs, or Ms.</p>
-<p>We use "trans" as an umbrella term to describe people whose current gender identity or way of expressing their gender differs from the sex they were registered at birth. ​Some trans people may identify as male, female, a combination of the 2, or as non-binary (neither genders). These can be either fluid or fixed identities. Some, but not all, trans people may want to transition socially and/or medically.</p>
+
+<h3>Transgender</h3>
+<p>We use "trans" as an umbrella term to describe people whose current gender identity or way of expressing their gender differs from the sex they were registered wirth (or assigned) at birth. ​Trans people may identify as male, female, a combination of the 2, or as non-binary (neither gender). Their identities can be fixed or fluid. Some, but not all, trans people want to transition (change) socially and/or medically.</p>
 <p>We use "trans woman" for someone who was registered male at birth and now identifies as a woman and "trans man" for someone who was registered female at birth and now identifies as a man.</p>
 <p>We use "trans woman" or "trans man" in content about the particular health needs of trans people - for example, screening or treatments that trans people need to be aware of, like advising a trans man about cervical and breast screening.​</p>
-<p>We use “intersex” in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person’s sex development is different to most other people’s. Some adults prefer the term “differences in sex development”. As always, test your language with the people who will be using your content or service.</p>
+<p>At any other time, we would refer to a "trans woman" as a woman and a "trans man" as a man, unless they state otherwise.</p>
+
+<h3>Intersex</h3>
+<p>We use “intersex” in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person’s sex development is different to most other people’s. Some adults prefer the term “differences in sex development”.</p>
+<p>As always, test your language with the people who will be using your content or service.</p>
 
 <h3>Sexuality</h3>
 <p>We use language about sexuality when it’s helpful to signpost or help people get the health information and access to treatment they need.​</p>
@@ -122,12 +129,13 @@
     <li>senior</li>
   </ul>
   <h3>Older people</h3>
-  <p>In some contexts, we use “older person” or “older people”, for example, where a health condition might affect people in their 60s or in their 90s.​</p>
-  <p>Example: Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>
   <p>But we prefer to specify ages: over-65s, over-75s, over-80s.</p>
+  <p>But in some contexts, we use “older person” or “older people”, for example, where a health condition might affect people in their 60s or in their 90s.​</p>
+  <p>Example: Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>
+  
 
   <div class="nhsuk-review-date">
-    <p class="nhsuk-body-s">Updated: September 2019</p>
+    <p class="nhsuk-body-s">Updated: December 2019</p>
   </div>
 
 {% endblock %}

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -39,7 +39,7 @@
     <li>diabetic person</li>
     <li>sick or diseased person</li>
   </ul>
-  <p>NHS digital services should be accessible to everyone who needs them. Read <a href="/service-manual/accessibility/content">our guidance on accessibility for content designers, writers and editors</a> in the digital service manual.</p>
+  <p>NHS digital services should be accessible to everyone who needs them. Read <a href="/service-manual/accessibility/content">our guidance on accessibility for content designers, writers and editors</a> in the service manual.</p>
 
   <h2 id="mental-health">Mental health</h2>
   <p>We do not describe people as mentally ill.</p>
@@ -53,7 +53,7 @@
   <p>We only refer to people's ethnic heritage or religion if it's relevant to the content.</p>
   <p>For example:</p>
   {{ insetText({
-    "HTML": "<p>You're more at risk of developing type 2 diabetes if you are over 40 - or 25 for south Asian people.</p>"
+    "HTML": "<p>You're more at risk of developing type 2 diabetes if you are of south Asian, Chinese, African Caribbean or black African origin (even if you were born in the UK).</p>"
   }) }}
 
   <h2 id="sex-gender-sexuality">Sex, gender and sexuality</h2>
@@ -62,11 +62,11 @@
   <h3>When to use "sex" and when to use "gender"</h3>
   <p>Many people think that sex and gender are the same but they mean different things. It's important to be clear about the difference.​</p>
   <h4>Sex</h4>
-  <p>Sex is biological – male or female. It's based not only on the genes we inherit, but also on how our external and internal sex and reproductive organs work and  respond to hormones. Sex is the label that's recorded when a baby's birth is registered.</p>
+  <p>Sex is biological – male and female or <a href="#intersex">intersex</a>. It's based not only on the genes we inherit, but also on how our external and internal sex and reproductive organs work and  respond to hormones. Sex is the label that's recorded when a baby's birth is registered.</p>
   <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
   <h5 id="sex-assigned-or-registered-at-birth">Sex assigned or registered at birth</h5>
 
-  <p>We use the phrase "sex assigned at birth" when we're talking about trans health and gender dysphoria, as this is the language our audience uses. In other cases, we use "the sex someone was registered with at birth" because user research shows that this works better for most people as it refers to an actual event.</p>
+  <p>We use the phrase "sex assigned at birth" when we're talking about trans health and gender dysphoria, as this is the language our audience uses. In other cases, we use "the sex someone was registered with at birth" because user research shows that most people understand this better as it refers to an actual event.</p>
 
   <h4>Gender</h4>
   <p>Gender is more complex. It refers to our internal sense of who we are and how we see and describe ourselves.</p>
@@ -94,7 +94,7 @@
 <p>Otherwise, we leave out the word "trans" and just refer to men and women, if relevant.</p>
 <p>Note: we use "sex assigned at birth" when we're writing for a trans audience. Read more about <a href="#sex-assigned-or-registered-at-birth">sex assigned or registered at birth</a>.</p>
 
-<h3>Intersex</h3>
+<h3 id="intersex">Intersex</h3>
 <p>We use "intersex" in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person's sex development is different to most other people's. Some adults prefer the term "differences in sex development".</p>
 <p>As always, test your language with the people who will be using your content or service.</p>
 
@@ -109,7 +109,7 @@
 </ul>
 
   <h2 id="age">Age</h2>
-  <p>Only include age if it’s relevant, for example, with vaccination, screening or testing programmes for particular age groups. An example of this is chlamydia testing as tests are free for under-25s.</p>
+  <p>Only include age if it's relevant, for example, with vaccination, screening or testing programmes for particular age groups. An example of this is chlamydia testing as tests are free for under-25s.</p>
   <p>Here are some of the terms we use for different stages of life with some guidance about the ages they relate to.</p>
   <p>When you need to be more specific, for example if you're writing about medicines dosage, give the actual age. For example, "teenagers aged 16 and over".</p>
   <p>We use:</p>
@@ -124,6 +124,14 @@
     <li>adult: generally from age 18 but this may vary. Be specific, for example: "adults aged 19 to 64"
   </ul>
   <p>With babies and toddlers, we count their age in weeks up until 6 months, then months up until 2 years.</p>
+
+  <h3>Older people</h3>
+  <p>We prefer to specify ages: over-65s, over-75s, over-80s.</p>
+  <p>In some contexts, we use "older person" or "older people", for example, where a health condition might affect people in their 60s or in their 90s.​</p>
+  <p>Example:</p>
+  {{ insetText({
+    "HTML": "<p>Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>"
+  }) }}
   <p>We do not use the words:</p>
   <ul>
     <li>elderly</li>
@@ -133,16 +141,8 @@
     <li>pensioner</li>
     <li>senior</li>
   </ul>
-  <h3>Older people</h3>
-  <p>But we prefer to specify ages: over-65s, over-75s, over-80s.</p>
-  <p>But in some contexts, we use “older person” or “older people”, for example, where a health condition might affect people in their 60s or in their 90s.​</p>
-  <p>Example:</p>
-  {{ insetText({
-    "HTML": "<p>Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>"
-  }) }}
-
   <div class="nhsuk-review-date">
-    <p class="nhsuk-body-s">Updated: December 2019</p>
+    <p class="nhsuk-body-s">Updated: January 2020</p>
   </div>
 
 {% endblock %}

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -62,7 +62,7 @@
   <h3>When to use "sex" and when to use "gender"</h3>
   <p>Many people think that sex and gender are the same but they mean different things. It's important to be clear about the difference.​</p>
   <h4>Sex</h4>
-  <p>Sex is biological – male and female or <a href="#intersex">intersex</a>. It's based not only on the genes we inherit, but also on how our external and internal sex and reproductive organs work and  respond to hormones. Sex is the label that's recorded when a baby's birth is registered.</p>
+  <p>Sex is biological – male, female or <a href="#intersex">intersex</a>. It's based not only on the genes we inherit, but also on how our external and internal sex and reproductive organs work and  respond to hormones. Sex is the label that's recorded when a baby's birth is registered.</p>
   <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
   <h5 id="sex-assigned-or-registered-at-birth">Sex assigned or registered at birth</h5>
 

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -22,7 +22,7 @@
   </div>
 
   <h2 id="disabilities-and-conditions">Disabilities and conditions</h2>
-  <p>We use positive language and don't label people when talking about disabilities and conditions.</p>
+  <p>We use positive language and do not label people when talking about disabilities and conditions.</p>
   <p>We do say things like:</p>
   <ul>
     <li>people living with a disability, or disabled person</li>
@@ -58,44 +58,45 @@
 
   <h2 id="sex-gender-sexuality">Sex, gender and sexuality</h2>
   <p>The language around sex, gender and sexuality changes all the time and it's an area that people hold strong and differing opinions about. We try to make sure that we are in touch with the communities we are writing for and we update this guidance regularly. This section should help you get started but the best thing is to test your content and services with the people who use them.</p>
-  <p>Only mention sex, gender or sexuality if they’re relevant, for example, to signpost people and help them get the health information and access to treatment they need.</p>
+  <p>Only mention sex, gender or sexuality if they're relevant, for example, to signpost people and help them get the health information and access to treatment they need.</p>
   <h3>When to use "sex" and when to use "gender"</h3>
-  <p>Many people assume that sex and gender are the same. However, it’s important to be clear on the different meaning of each term.​</p>
-  <h3>Sex</h3>
-  <p>Sex is biological – male or female - and is the label given when the birth of a baby is registered. Sex is based not only on the genes we inherit, but also how primary sex characteristics (genitalia) and the internal reproductive organs work and respond to hormones.</p>
+  <p>Many people think that sex and gender are the same but they mean different things. It's important to be clear about the difference.​</p>
+  <h4>Sex</h4>
+  <p>Sex is biological – male or female. It's based not only on the genes we inherit, but also on how our external and internal sex and reproductive organs work and  respond to hormones. Sex is the label that's recorded when a baby's birth is registered.</p>
+  <p>(We use the phrase "sex assigned at birth" when we're talking about trans health and gender dysphoria, as this is the language our audience uses. In other cases, we use "the sex someone was registered with at birth" because user research shows that this works better for most people as it refers to an actual event.)</p>
   <p>We use "sex" or, better still, the body part associated with biological sex when we're writing about things like screening that is sex specific, for example, breast and cervical screening.</p>
-  <h3>Gender</h3>
+  <h4>Gender</h4>
   <p>Gender is more complex. It refers to our internal sense of who we are and how we see and describe ourselves.</p>
-  <p>Someone may see themselves as a man, a woman or neither (non-binary). Being non-binary can mean having no gender, a different gender, or in between genders. Gender can be fixed or fluid. Some people may identify with a gender opposite to the sex they were registered with.</p>
-  <p>We use "gender" when we're:​</p>
+  <p>Someone may see themselves as a man, a woman or neither (non-binary). Being non-binary can mean having no gender, a different gender, or being in between genders. Gender can be fixed or fluid. Some people identify with a gender opposite to the sex they were registered with.</p>
+
+  <p>We use the word "gender" when we're:​</p>
   <ul>
-    <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender​</li>
+    <li>discussing the social idea or identity as opposed to the biological sex, for example, if we're writing about gender dysphoria or transgender​ health</li>
     <li>writing about a survey or report based on gender, such as gender diversity​</li>
     <li>writing about the results of a national census, where there is a question about gender identity as well as sex to identify the trans (including non-binary) population​</li>
   </ul>
   <h3>Gender neutral language</h3>
-  <p>We make content gender neutral as far as possible. In general, we word our content to avoid masculine and feminine pronouns (“he” or “she”). Instead we use “you” where appropriate.​</p>
+  <p>We make content gender neutral as far as possible. In general, we word our content to avoid masculine and feminine pronouns ("he" or "she"). Instead we use "you" where appropriate and sometimes "they" when we need a gender-neutral pronoun (unless this is confusing).​</p>
   <p>For example:</p>
   {{ insetText({
     "HTML": "<p>You should see the GP if you have persistent symptoms of osteoarthritis so they can confirm the diagnosis and prescribe any treatment you need.</p>"
   }) }}
 
-<p>It's alright to use "they" to avoid "he” or “she" or where you need a gender-neutral pronoun, unless this is confusing.​</p>
 <p>Avoid asking users for their title, such as Mr, Miss, Mrs, or Ms.</p>
 
 <h3>Transgender</h3>
-<p>We use "trans" as an umbrella term to describe people whose current gender identity or way of expressing their gender differs from the sex they were registered wirth (or assigned) at birth. ​Trans people may identify as male, female, a combination of the 2, or as non-binary (neither gender). Their identities can be fixed or fluid. Some, but not all, trans people want to transition (change) socially and/or medically.</p>
-<p>We use "trans woman" for someone who was registered male at birth and now identifies as a woman and "trans man" for someone who was registered female at birth and now identifies as a man.</p>
-<p>We use "trans woman" or "trans man" in content about the particular health needs of trans people - for example, screening or treatments that trans people need to be aware of, like advising a trans man about cervical and breast screening.​</p>
-<p>At any other time, we would refer to a "trans woman" as a woman and a "trans man" as a man, unless they state otherwise.</p>
+<p>We use "trans" as an umbrella term to describe people whose current gender identity or way of expressing their gender differs from the sex they were registered with at birth. Some, but not all, trans people want to transition (change) socially or medically or both.</p>
+<p>We use "trans woman" for someone who was assigned male at birth and now identifies as a woman and "trans man" for someone who was registered female at birth and now identifies as a man.</p>
+<p>We use "trans woman" or "trans man" in content about the particular health needs of trans people - for example, screening or treatments that trans people need to be aware of, like advising a trans man about cervical and breast screening.​<p>
+<p>Otherwise, we leave out the word "trans" and just refer to men and women, if relevant.</p>
 
 <h3>Intersex</h3>
-<p>We use “intersex” in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person’s sex development is different to most other people’s. Some adults prefer the term “differences in sex development”.</p>
+<p>We use "intersex" in content about people with differences in sex development (DSD). DSD involve genes, hormones and reproductive organs, including genitals. They mean a person's sex development is different to most other people's. Some adults prefer the term "differences in sex development".</p>
 <p>As always, test your language with the people who will be using your content or service.</p>
 
 <h3>Sexuality</h3>
-<p>We use language about sexuality when it’s helpful to signpost or help people get the health information and access to treatment they need.​</p>
-<p>For example, when we’re talking about specific sexual health services or sexual health content, we use words like:​</p>
+<p>We use language about sexuality when it's helpful to signpost or help people get the health information and access to treatment they need.​</p>
+<p>For example, when we're talking about specific sexual health services or sexual health content, we use words like:​</p>
 <ul>
   <li>lesbian</li>
   <li>gay</li>
@@ -131,8 +132,10 @@
   <h3>Older people</h3>
   <p>But we prefer to specify ages: over-65s, over-75s, over-80s.</p>
   <p>But in some contexts, we use “older person” or “older people”, for example, where a health condition might affect people in their 60s or in their 90s.​</p>
-  <p>Example: Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>
-  
+  <p>Example:</p>
+  {{ insetText({
+    "HTML": "<p>Anyone can have a fall, but older people are more vulnerable and likely to fall, especially if they have a long-term health condition.​</p>"
+  }) }}
 
   <div class="nhsuk-review-date">
     <p class="nhsuk-body-s">Updated: December 2019</p>

--- a/app/views/content/numbers-measurements-dates-time.njk
+++ b/app/views/content/numbers-measurements-dates-time.njk
@@ -178,7 +178,7 @@
   <p>Example: Overall, around 7 in every 10 people live at least a year after diagnosis and around 5 in 10 people live at least 10 years.</p>
 
   <div class="nhsuk-review-date">
-    <p class="nhsuk-body-s">Updated: August 2019</p>
+    <p class="nhsuk-body-s">Updated: January 2020</p>
   </div>
 
 {% endblock %}

--- a/app/views/content/numbers-measurements-dates-time.njk
+++ b/app/views/content/numbers-measurements-dates-time.njk
@@ -25,15 +25,15 @@
 
   <h2 id="numbers">Numbers</h2>
   <h3>Numerals (1, 2, 3 and so on)</h3>
-  <p>We use numerals for all numbers (including 1 to 2). People find numerals easier to read and they scan for them.</p>
+  <p>We use numerals for numbers (including 1 and 2), for example when we're talking about statistics, time, measurements, lists, points or steps. People find numerals easier to read and they scan for them.</p>
   <p>For numbers over 999, use a comma for clarity - for example, 1,000.</p>
   <p>For numbers less than 1, use 0 before the decimal point - for example, 0.25.</p>
 
   <h4>Examples of where we use numerals</h4>
   <ul>
     <li>Add 1 to 2 teaspoons of honey.</li>
-    <li>It takes 1 to 3 weeks from the time you were exposed to chickenpox for the spots to start appearing.</li>
     <li>Do this for 1 or 2 minutes.</li>
+    <li>It takes 1 to 3 weeks from the time you were exposed to chickenpox for the spots to start appearing.</li>
     <li>Depression affects about 1 in 10 people at some point during their life.</li>
   </ul>
 
@@ -56,6 +56,14 @@
   </ul>
   <h4>Examples of where we do not use numerals</h4>
   <p>We do not use numerals in some medicines information about <a href="#dosage">dosage</a> because we've found they can be confusing.</p>
+  <p>We spell out "one" when it means "a" or to avoid repeating a word.</p>
+  <p>Example: "Never take 2 doses at the same time to make up for a forgotten one."</p>
+  <p>We also use "one" in phrases like:</p>
+  <ul>
+    <li>"one or the other"</li>
+    <li>"one of the most common"</li>
+    <li>"one at a time"</li>
+  </ul>
 <h3>Ordinal numbers (1st, 2nd, 3rd and so on)</h3>
 <p>We use numerals with letter suffixes for ordinal numbers, for example "1st", as in "your 1st visit".</p>
 <p>Do not use superscript. It does not always read out correctly on screen readers and could confuse people. </p>

--- a/app/views/service-standard/17-make-your-service-interoperable.njk
+++ b/app/views/service-standard/17-make-your-service-interoperable.njk
@@ -20,10 +20,12 @@
     <li>you work to open standards and the Technology Code of Practice</li>
     <li>you maximise flexibility and make content, tools and services available through well-designed APIs to reach more people</li>
     <li>you use agreed FHIR-based APIs to join up care for patients</li>
-    <li>where appropriate, you use the NHS number and NHS data registers and comply with NHS clinical information standards</li>
+    <li>where appropriate, you use the <a href="https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/isb-0149-nhs-number">NHS number</a> and NHS data registers and comply with NHS clinical information standards</li>
     <li>for disease information in mortality and morbidity statistics, you use <a href="https://icd.who.int/browse10/2016/en">ICD-10</a> (the World Health Organization's International Classification of Diseases, version 10)</li>
     <li>for electronic care records, you use <a href="https://digital.nhs.uk/services/terminology-and-classifications/snomed-ct">SNOMED CT</a> (structured clinical vocabulary)</li>
-    <li>if you create any data sets that could be useful to others, you publish them in an open machine readable format, under an Open Government Licence, unless they contain personally identifiable information, sensitive information, or where publishing the data would infringe the intellectual property rights of someone outside the NHS or government</li>
+    <li>if you create any data sets that could be useful to others, you publish them in an open machine readable format, under an <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>, unless they contain personally identifiable information, sensitive information, or where publishing the data would infringe the intellectual property rights of someone outside the NHS or government</li>
+    <li>if you use barcodes or similar identifiers, you comply with the <a href="https://www.gs1uk.org/support-and-training/our-standards/general-specifications">GS1 Barcode Standard</a> as set out in <a href="https://www.scan4safety.nhs.uk/">Scan4Safety</a></li>
+    <li>where relevant, you comply with the <a href="https://www.gov.uk/government/publications/open-standards-for-government">standards published by the Open Standards Board</a></li>
   </ul>
 
   <h2>Guidance</h2>
@@ -35,7 +37,7 @@
     <li><a href="https://www.gov.uk/service-manual/technology/application-programming-interfaces-apis">Application programming interfaces (APIs)</a></li>
     <li><a href="https://www.gov.uk/government/publications/registers">Introducing registers</a></li>
     <li><a href="https://www.gov.uk/government/publications/open-standards-principles/open-standards-principles">Open standards principles</a></li>
-      <li><a href="https://www.gov.uk/government/publications/technology-code-of-practice">Technology Code of Practice</a></li>
+    <li><a href="https://www.gov.uk/government/publications/technology-code-of-practice">Technology Code of Practice</a></li>
     <li><a href="https://www.gov.uk/service-manual/technology/working-with-open-standards">Working with open standards</a></li>
   </ul>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6105,9 +6105,9 @@
       }
     },
     "eslint": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.2.tgz",
-      "integrity": "sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -6252,9 +6252,9 @@
           }
         },
         "inquirer": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
-          "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+          "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -6266,7 +6266,7 @@
             "lodash": "^4.17.15",
             "mute-stream": "0.0.8",
             "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
+            "rxjs": "^6.5.3",
             "string-width": "^4.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
@@ -15817,9 +15817,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.3.tgz",
-      "integrity": "sha512-EcNzP9jGoxpQAXq1VOoTet0ik7/VVU1MovIfcUSAjLowc7GhcQku/sOXALvq5nPpSei2HF6VRhibeJSC3i/Law==",
+      "version": "4.41.5",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
+      "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,15 +14,15 @@
       }
     },
     "@babel/core": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
-      "integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
+      "integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
+        "@babel/generator": "^7.7.7",
         "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.5",
+        "@babel/parser": "^7.7.7",
         "@babel/template": "^7.7.4",
         "@babel/traverse": "^7.7.4",
         "@babel/types": "^7.7.4",
@@ -45,9 +45,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -86,9 +86,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -235,9 +235,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -276,9 +276,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -379,9 +379,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -428,9 +428,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -469,9 +469,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -640,9 +640,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -720,9 +720,9 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -761,9 +761,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -855,9 +855,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -896,9 +896,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -968,9 +968,9 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -1019,9 +1019,9 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -1060,9 +1060,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -1144,9 +1144,9 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
-          "integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.7.4",
@@ -1185,9 +1185,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -1306,9 +1306,9 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
-      "integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
+      "integrity": "sha512-3qp9I8lelgzNedI3hrhkvhaEYree6+WHnyA/q4Dza9z7iEIs1eyhWyJnetk3jJ69RT0AT4G0UhEGwyGFJ7GUuQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -1337,9 +1337,9 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
-      "integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
+      "integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
@@ -1485,9 +1485,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -1533,9 +1533,9 @@
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
-      "integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
+      "integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
       "dev": true,
       "requires": {
         "@babel/helper-create-regexp-features-plugin": "^7.7.4",
@@ -1601,9 +1601,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.7.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
-          "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
+          "version": "7.7.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
           "dev": true
         },
         "@babel/template": {
@@ -1721,9 +1721,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
-      "integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
+      "integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.7.4",
@@ -1838,9 +1838,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.7.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
-      "integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.7.tgz",
+      "integrity": "sha512-pCu0hrSSDVI7kCVUOdcMNQEbOPJ52E+LrQ14sN8uL2ALfSqePZQlKrOy+tM4uhEdYlCHi4imr8Zz2cZe9oSdIg==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -1848,9 +1848,9 @@
         "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
         "@babel/plugin-proposal-dynamic-import": "^7.7.4",
         "@babel/plugin-proposal-json-strings": "^7.7.4",
-        "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.7.7",
         "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
         "@babel/plugin-syntax-async-generators": "^7.7.4",
         "@babel/plugin-syntax-dynamic-import": "^7.7.4",
         "@babel/plugin-syntax-json-strings": "^7.7.4",
@@ -1864,7 +1864,7 @@
         "@babel/plugin-transform-classes": "^7.7.4",
         "@babel/plugin-transform-computed-properties": "^7.7.4",
         "@babel/plugin-transform-destructuring": "^7.7.4",
-        "@babel/plugin-transform-dotall-regex": "^7.7.4",
+        "@babel/plugin-transform-dotall-regex": "^7.7.7",
         "@babel/plugin-transform-duplicate-keys": "^7.7.4",
         "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
         "@babel/plugin-transform-for-of": "^7.7.4",
@@ -1878,7 +1878,7 @@
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
         "@babel/plugin-transform-new-target": "^7.7.4",
         "@babel/plugin-transform-object-super": "^7.7.4",
-        "@babel/plugin-transform-parameters": "^7.7.4",
+        "@babel/plugin-transform-parameters": "^7.7.7",
         "@babel/plugin-transform-property-literals": "^7.7.4",
         "@babel/plugin-transform-regenerator": "^7.7.5",
         "@babel/plugin-transform-reserved-words": "^7.7.4",
@@ -1890,7 +1890,7 @@
         "@babel/plugin-transform-unicode-regex": "^7.7.4",
         "@babel/types": "^7.7.4",
         "browserslist": "^4.6.0",
-        "core-js-compat": "^3.4.7",
+        "core-js-compat": "^3.6.0",
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
@@ -4454,14 +4454,14 @@
       }
     },
     "browserslist": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
+      "integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001015",
+        "caniuse-lite": "^1.0.30001017",
         "electron-to-chromium": "^1.3.322",
-        "node-releases": "^1.1.42"
+        "node-releases": "^1.1.44"
       }
     },
     "bs-recipes": {
@@ -4648,9 +4648,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001015",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-      "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+      "version": "1.0.30001019",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz",
+      "integrity": "sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==",
       "dev": true
     },
     "capture-exit": {
@@ -5122,19 +5122,19 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.8.tgz",
-      "integrity": "sha512-l3WTmnXHV2Sfu5VuD7EHE2w7y+K68+kULKt5RJg8ZJk3YhHF1qLD4O8v8AmNq+8vbOwnPFFDvds25/AoEvMqlQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.1.tgz",
+      "integrity": "sha512-2Tl1EuxZo94QS2VeH28Ebf5g3xbPZG/hj/N5HDDy4XMP/ImR0JIer/nggQRiMN91Q54JVkGbytf42wO29oXVHg==",
       "dev": true,
       "requires": {
         "browserslist": "^4.8.2",
-        "semver": "^6.3.0"
+        "semver": "7.0.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
         }
       }
@@ -5790,9 +5790,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.322",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-      "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+      "version": "1.3.326",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.326.tgz",
+      "integrity": "sha512-kaBmGWJlLW5bGEbm7/HWG9jt4oH+uecBIIfzFWfFkgqssPT2I6RDenGqo4wmKzm7seNu7DSCRZBXCuf7w8dtkQ==",
       "dev": true
     },
     "elliptic": {
@@ -11489,9 +11489,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
-      "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+      "version": "1.1.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.44.tgz",
+      "integrity": "sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -13374,9 +13374,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
+      "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {
@@ -48,7 +48,7 @@
     "babel-loader": "^8.0.6",
     "concurrently": "^4.1.2",
     "cpx": "^1.5.0",
-    "eslint": "^6.7.2",
+    "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-config-nhsuk": "^0.17.0",
     "eslint-plugin-import": "^2.19.1",
@@ -58,7 +58,7 @@
     "node-sass": "^4.13.0",
     "nodemon": "^1.19.4",
     "sass-lint": "^1.13.1",
-    "webpack": "^4.41.3",
+    "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {
@@ -43,8 +43,8 @@
     "path": "^0.12.7"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.5",
-    "@babel/preset-env": "^7.7.6",
+    "@babel/core": "^7.7.7",
+    "@babel/preset-env": "^7.7.7",
     "babel-loader": "^8.0.6",
     "concurrently": "^4.1.2",
     "cpx": "^1.5.0",


### PR DESCRIPTION
## 2.1.0 - 6 January 2020

:new: **New features**
- Add entries for "pharmacy", "chemist" and "sex assigned or registered at birth" to the A to Z of NHS health writing

:wrench: **Fixes**

- Add more detail about interoperability standards to section 17 of NHS service standard 
- Amend guidance on using the number 1 in Numbers, measurements, dates and time after December Style Council meeting
- Update inclusive language page, especially the section on sex, gender and sexuality
- Update package dependencies to latest versions