### PR TITLE
Nunjucks markup cleanup

### DIFF
--- a/app/views/accessibility-statement.njk
+++ b/app/views/accessibility-statement.njk
@@ -1,8 +1,8 @@
-{% set pageTitle = 'Accessibility statement' %}
-{% set pageDescription = 'We aim to make the NHS digital service manual as accessible and easy to use as possible.' %}
-{% set dateUpdated = 'June 2019' %}
+{% set pageTitle = "Accessibility statement" %}
+{% set pageDescription = "We aim to make the NHS digital service manual as accessible and easy to use as possible." %}
+{% set dateUpdated = "June 2019" %}
 
-{% extends 'includes/app-layout-two-thirds.njk' %}
+{% extends "includes/app-layout-two-thirds.njk" %}
 
 {% block bodyContent %}
 

--- a/app/views/accessibility/content.njk
+++ b/app/views/accessibility/content.njk
@@ -1,32 +1,32 @@
-{% set pageTitle = 'Content' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'What content designers, writers and editors need to do to make digital services accessible.' %}
-{% set theme = 'Accessibility guidance for:' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Content" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "What content designers, writers and editors need to do to make digital services accessible." %}
+{% set theme = "Accessibility guidance for:" %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include './partials/write-content-thats-easy-to-understand.njk' %}
-  {% include './partials/set-page-titles.njk' %}
-  {% include './partials/use-headings-correctly.njk' %}
-  {% include './partials/write-good-link-and-form-control-names.njk' %}
-  {% include './partials/label-form-fields-clearly.njk' %}
-  {% include './partials/highlight-errors-in-forms.njk' %}
-  {% include './partials/use-alternative-text-for-images-in-content.njk' %}
-  {% include './partials/use-tables-to-show-relationships-between-data.njk' %}
-  {% include './partials/make-video-and-multimedia-accessible.njk' %}
-  {% include './partials/do-not-rely-on-colour-or-position-alone.njk' %}
-  {% include './partials/use-html-rather-than-pdfs.njk' %}
+  {% include "./partials/write-content-thats-easy-to-understand.njk" %}
+  {% include "./partials/set-page-titles.njk" %}
+  {% include "./partials/use-headings-correctly.njk" %}
+  {% include "./partials/write-good-link-and-form-control-names.njk" %}
+  {% include "./partials/label-form-fields-clearly.njk" %}
+  {% include "./partials/highlight-errors-in-forms.njk" %}
+  {% include "./partials/use-alternative-text-for-images-in-content.njk" %}
+  {% include "./partials/use-tables-to-show-relationships-between-data.njk" %}
+  {% include "./partials/make-video-and-multimedia-accessible.njk" %}
+  {% include "./partials/do-not-rely-on-colour-or-position-alone.njk" %}
+  {% include "./partials/use-html-rather-than-pdfs.njk" %}
 
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/accessibility/design.njk
+++ b/app/views/accessibility/design.njk
@@ -1,35 +1,35 @@
-{% set pageTitle = 'Design' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'What graphic and interaction designers need to do to make digital services accessible.' %}
-{% set theme = 'Accessibility guidance for:' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "Design" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "What graphic and interaction designers need to do to make digital services accessible." %}
+{% set theme = "Accessibility guidance for:" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include './partials/define-page-structure.njk' %}
-  {% include './partials/define-skip-links.njk' %}
-  {% include './partials/use-headings-correctly.njk' %}
-  {% include './partials/check-colour-contrast.njk' %}
-  {% include './partials/define-focus-styles.njk' %}
-  {% include './partials/discuss-any-custom-components.njk' %}
-  {% include './partials/write-good-link-and-form-control-names.njk' %}
-  {% include './partials/label-form-fields-clearly.njk' %}
-  {% include './partials/highlight-errors-in-forms.njk' %}
-  {% include './partials/do-not-rely-on-colour-or-position-alone.njk' %}
-  {% include './partials/do-not-include-text-in-images.njk' %}
-  {% include './partials/use-alternative-text-for-images-in-content.njk' %}
-  {% include './partials/use-alternative-text-for-functional-images.njk' %}
-  {% include './partials/make-video-and-multimedia-accessible.njk' %}
+  {% include "./partials/define-page-structure.njk" %}
+  {% include "./partials/define-skip-links.njk" %}
+  {% include "./partials/use-headings-correctly.njk" %}
+  {% include "./partials/check-colour-contrast.njk" %}
+  {% include "./partials/define-focus-styles.njk" %}
+  {% include "./partials/discuss-any-custom-components.njk" %}
+  {% include "./partials/write-good-link-and-form-control-names.njk" %}
+  {% include "./partials/label-form-fields-clearly.njk" %}
+  {% include "./partials/highlight-errors-in-forms.njk" %}
+  {% include "./partials/do-not-rely-on-colour-or-position-alone.njk" %}
+  {% include "./partials/do-not-include-text-in-images.njk" %}
+  {% include "./partials/use-alternative-text-for-images-in-content.njk" %}
+  {% include "./partials/use-alternative-text-for-functional-images.njk" %}
+  {% include "./partials/make-video-and-multimedia-accessible.njk" %}
 
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/accessibility/development.njk
+++ b/app/views/accessibility/development.njk
@@ -1,30 +1,30 @@
-{% set pageTitle = 'Development' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'What developers need to do to make digital services accessible.' %}
-{% set theme = 'Accessibility guidance for:' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "Development" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "What developers need to do to make digital services accessible." %}
+{% set theme = "Accessibility guidance for:" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include './partials/check-keyboard-accessibility.njk' %}
-  {% include './partials/set-page-titles.njk' %}
-  {% include './partials/set-language.njk' %}
-  {% include './partials/use-aria-patterns.njk' %}
-  {% include './partials/discuss-any-custom-components.njk' %}
-  {% include './partials/test-that-text-sizes-and-zooms-correctly.njk' %}
-  {% include './partials/use-alternative-text-for-functional-images.njk' %}
-  {% include './partials/make-video-and-multimedia-accessible.njk' %}
+  {% include "./partials/check-keyboard-accessibility.njk" %}
+  {% include "./partials/set-page-titles.njk" %}
+  {% include "./partials/set-language.njk" %}
+  {% include "./partials/use-aria-patterns.njk" %}
+  {% include "./partials/discuss-any-custom-components.njk" %}
+  {% include "./partials/test-that-text-sizes-and-zooms-correctly.njk" %}
+  {% include "./partials/use-alternative-text-for-functional-images.njk" %}
+  {% include "./partials/make-video-and-multimedia-accessible.njk" %}
 
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}
 

--- a/app/views/accessibility/getting-started.njk
+++ b/app/views/accessibility/getting-started.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Getting started with accessibility' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'Things you can do to learn about accessibility.' %}
-{% set theme = 'Everyone needs to know' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "Getting started with accessibility" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "Things you can do to learn about accessibility." %}
+{% set theme = "Everyone needs to know" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -52,6 +52,6 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}
 

--- a/app/views/accessibility/how-to-make-digital-services-accessible.njk
+++ b/app/views/accessibility/how-to-make-digital-services-accessible.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'How to make digital services accessible' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'Our approach to accessibility.' %}
-{% set theme = 'Everyone needs to know' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "How to make digital services accessible" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "Our approach to accessibility." %}
+{% set theme = "Everyone needs to know" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -53,6 +53,6 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}
 

--- a/app/views/accessibility/index.njk
+++ b/app/views/accessibility/index.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "Accessibility" %}
 {% set pageDescription = "How to make digital services in the NHS work for everyone." %}
 {% set pageSection = "Accessibility" %}
-{% set landingPage = "true" %}
+{% set landingPage = true %}
 
 {% extends "includes/app-layout.njk" %}
 

--- a/app/views/accessibility/index.njk
+++ b/app/views/accessibility/index.njk
@@ -1,9 +1,9 @@
-{% set pageTitle = 'Accessibility' %}
-{% set pageDescription = 'How to make digital services in the NHS work for everyone.' %}
-{% set pageSection = 'Accessibility' %}
-{% set landingPage = 'true' %}
+{% set pageTitle = "Accessibility" %}
+{% set pageDescription = "How to make digital services in the NHS work for everyone." %}
+{% set pageSection = "Accessibility" %}
+{% set landingPage = "true" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block bodyContent %}
 
@@ -12,7 +12,7 @@
   <p>Everyone who works on NHS digital services has a role to play in making them accessible and inclusive.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/accessibility/partials/related-nav.njk
+++ b/app/views/accessibility/partials/related-nav.njk
@@ -2,17 +2,17 @@
   <h2 class="nhsuk-related-nav__heading">Accessibility</h2>
   <nav role="navigation" class="nhsuk-related-nav__nav-section">
     <ul class="nhsuk-related-nav__list">
-      {% if pageTitle != 'What all NHS services need to do about accessibility' %}
+      {% if pageTitle != "What all NHS services need to do about accessibility" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/what-all-NHS-services-need-to-do">What all NHS services need to do about accessibility</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'How to make digital services accessible' %}
+      {% if pageTitle != "How to make digital services accessible" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/how-to-make-digital-services-accessible">How to make digital services accessible</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'Getting started with accessibility' %}
+      {% if pageTitle != "Getting started with accessibility" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/getting-started">Getting started with accessibility</a>
       </li>
@@ -23,32 +23,32 @@
   <h3 class="nhsuk-related-nav__heading nhsuk-related-nav__heading--small">Guidance for different activities</h3>
   <nav role="navigation" class="nhsuk-related-nav__nav-section">
     <ul class="nhsuk-related-nav__list">
-      {% if pageTitle != 'Product and delivery' %}
+      {% if pageTitle != "Product and delivery" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/product-and-delivery">Product and delivery</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'User research' %}
+      {% if pageTitle != "User research" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/user-research">User research</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'Content' %}
+      {% if pageTitle != "Content" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/content">Content</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'Design' %}
+      {% if pageTitle != "Design" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/design">Design</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'Development' %}
+      {% if pageTitle != "Development" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/development">Development</a>
       </li>
       {% endif %}
-      {% if pageTitle != 'Testing' %}
+      {% if pageTitle != "Testing" %}
       <li class="nhsuk-related-nav__item">
         <a href="/accessibility/testing">Testing</a>
       </li>

--- a/app/views/accessibility/product-and-delivery.njk
+++ b/app/views/accessibility/product-and-delivery.njk
@@ -1,26 +1,26 @@
-{% set pageTitle = 'Product and delivery' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'What product and delivery managers need to do to make digital services accessible.' %}
-{% set theme = 'Accessibility guidance for:' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "Product and delivery" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "What product and delivery managers need to do to make digital services accessible." %}
+{% set theme = "Accessibility guidance for:" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include './partials/make-sure-everyone-knows-their-responsibilities.njk' %}
-  {% include './partials/ask-questions-at-the-start-of-the-project.njk' %}
-  {% include './partials/check-that-accessibility-is-done.njk' %}
-  {% include './partials/monitor-and-record-your-work.njk' %}
-  {% include './partials/publish-an-accessibility-statement.njk' %}
+  {% include "./partials/make-sure-everyone-knows-their-responsibilities.njk" %}
+  {% include "./partials/ask-questions-at-the-start-of-the-project.njk" %}
+  {% include "./partials/check-that-accessibility-is-done.njk" %}
+  {% include "./partials/monitor-and-record-your-work.njk" %}
+  {% include "./partials/publish-an-accessibility-statement.njk" %}
 
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/accessibility/testing.njk
+++ b/app/views/accessibility/testing.njk
@@ -1,53 +1,53 @@
-{% set pageTitle = 'Testing' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'What testers and quality assurers need to do to make digital services accessible.' %}
-{% set theme = 'Accessibility guidance for:' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Testing" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "What testers and quality assurers need to do to make digital services accessible." %}
+{% set theme = "Accessibility guidance for:" %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include './partials/understand-types-of-testing.njk' %}
-  {% include './partials/check-orientation-is-not-locked.njk' %}
-  {% include './partials/make-sure-navigation-is-consistent.njk' %}
-  {% include './partials/set-language.njk' %}
-  {% include './partials/set-page-titles.njk' %}
-  {% include './partials/define-page-structure.njk' %}
-  {% include './partials/define-skip-links.njk' %}
-  {% include './partials/use-headings-correctly.njk' %}
-  {% include './partials/check-keyboard-accessibility.njk' %}
-  {% include './partials/test-that-text-sizes-and-zooms-correctly.njk' %}
-  {% include './partials/use-aria-patterns.njk' %}
-  {% include './partials/label-form-fields-clearly.njk' %}
-  {% include './partials/write-good-link-and-form-control-names.njk' %}
-  {% include './partials/highlight-errors-in-forms.njk' %}
-  {% include './partials/check-colour-contrast.njk' %}
-  {% include './partials/do-not-rely-on-colour-or-position-alone.njk' %}
-  {% include './partials/use-alternative-text-for-images-in-content.njk' %}
-  {% include './partials/use-alternative-text-for-functional-images.njk' %}
-  {% include './partials/make-video-and-multimedia-accessible.njk' %}
-  {% include './partials/give-users-time-to-read-and-act.njk' %}
-  {% include './partials/check-autocomplete-in-forms.njk' %}
-  {% include './partials/check-flashes-and-animation.njk' %}
-  {% include './partials/make-users-aware-of-status-updates-away-from-current-focus.njk' %}
-  {% include './partials/do-not-add-keyboard-shortcuts.njk' %}
-  {% include './partials/do-not-override-visible-labels.njk' %}
-  {% include './partials/do-not-use-onkeydown-or-onmousedown-for-links-and-buttons.njk' %}
-  {% include './partials/do-not-include-text-in-images.njk' %}
-  {% include './partials/do-not-trigger-pop-ups-by-hover-or-focus.njk' %}
-  {% include './partials/do-not-play-audio-automatically.njk' %}
-  {% include './partials/do-not-rely-on-touch-gestures.njk' %}
-  {% include './partials/do-not-rely-on-motion-sensors.njk' %}
-  {% include './partials/use-html-rather-than-pdfs.njk' %}
+  {% include "./partials/understand-types-of-testing.njk" %}
+  {% include "./partials/check-orientation-is-not-locked.njk" %}
+  {% include "./partials/make-sure-navigation-is-consistent.njk" %}
+  {% include "./partials/set-language.njk" %}
+  {% include "./partials/set-page-titles.njk" %}
+  {% include "./partials/define-page-structure.njk" %}
+  {% include "./partials/define-skip-links.njk" %}
+  {% include "./partials/use-headings-correctly.njk" %}
+  {% include "./partials/check-keyboard-accessibility.njk" %}
+  {% include "./partials/test-that-text-sizes-and-zooms-correctly.njk" %}
+  {% include "./partials/use-aria-patterns.njk" %}
+  {% include "./partials/label-form-fields-clearly.njk" %}
+  {% include "./partials/write-good-link-and-form-control-names.njk" %}
+  {% include "./partials/highlight-errors-in-forms.njk" %}
+  {% include "./partials/check-colour-contrast.njk" %}
+  {% include "./partials/do-not-rely-on-colour-or-position-alone.njk" %}
+  {% include "./partials/use-alternative-text-for-images-in-content.njk" %}
+  {% include "./partials/use-alternative-text-for-functional-images.njk" %}
+  {% include "./partials/make-video-and-multimedia-accessible.njk" %}
+  {% include "./partials/give-users-time-to-read-and-act.njk" %}
+  {% include "./partials/check-autocomplete-in-forms.njk" %}
+  {% include "./partials/check-flashes-and-animation.njk" %}
+  {% include "./partials/make-users-aware-of-status-updates-away-from-current-focus.njk" %}
+  {% include "./partials/do-not-add-keyboard-shortcuts.njk" %}
+  {% include "./partials/do-not-override-visible-labels.njk" %}
+  {% include "./partials/do-not-use-onkeydown-or-onmousedown-for-links-and-buttons.njk" %}
+  {% include "./partials/do-not-include-text-in-images.njk" %}
+  {% include "./partials/do-not-trigger-pop-ups-by-hover-or-focus.njk" %}
+  {% include "./partials/do-not-play-audio-automatically.njk" %}
+  {% include "./partials/do-not-rely-on-touch-gestures.njk" %}
+  {% include "./partials/do-not-rely-on-motion-sensors.njk" %}
+  {% include "./partials/use-html-rather-than-pdfs.njk" %}
 
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/accessibility/user-research.njk
+++ b/app/views/accessibility/user-research.njk
@@ -1,30 +1,30 @@
-{% set pageTitle = 'User research' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'What user researchers need to do to make digital services accessible.' %}
-{% set theme = 'Accessibility guidance for:' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "User research" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "What user researchers need to do to make digital services accessible." %}
+{% set theme = "Accessibility guidance for:" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include './partials/identify-target-groups-and-accessibility-challenges.njk' %}
-  {% include './partials/involve-people-with-access-needs-at-every-stage.njk' %}
-  {% include './partials/recruit-people-with-access-needs.njk' %}
-  {% include './partials/for-small-or-specialist-user-groups-focus-on-testing-the-interface.njk' %}
-  {% include './partials/run-technical-tests-for-accessibility-beforehand.njk' %}
-  {% include './partials/understand-participants-needs-before-you-test.njk' %}
-  {% include './partials/make-your-research-more-accessible-on-the-day.njk' %}
-  {% include './partials/look-after-your-team.njk' %}
-  {% include './partials/share-your-research.njk' %}
+  {% include "./partials/identify-target-groups-and-accessibility-challenges.njk" %}
+  {% include "./partials/involve-people-with-access-needs-at-every-stage.njk" %}
+  {% include "./partials/recruit-people-with-access-needs.njk" %}
+  {% include "./partials/for-small-or-specialist-user-groups-focus-on-testing-the-interface.njk" %}
+  {% include "./partials/run-technical-tests-for-accessibility-beforehand.njk" %}
+  {% include "./partials/understand-participants-needs-before-you-test.njk" %}
+  {% include "./partials/make-your-research-more-accessible-on-the-day.njk" %}
+  {% include "./partials/look-after-your-team.njk" %}
+  {% include "./partials/share-your-research.njk" %}
 
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/accessibility/what-all-NHS-services-need-to-do.njk
+++ b/app/views/accessibility/what-all-NHS-services-need-to-do.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'What all NHS services need to do about accessibility' %}
-{% set pageSection = 'Accessibility' %}
-{% set subSection = 'Accessibility' %}
-{% set pageDescription = 'The NHS is for everyone, so NHS digital services should be accessible to everyone too.' %}
-{% set theme = 'Everyone needs to know' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "What all NHS services need to do about accessibility" %}
+{% set pageSection = "Accessibility" %}
+{% set subSection = "Accessibility" %}
+{% set pageDescription = "The NHS is for everyone, so NHS digital services should be accessible to everyone too." %}
+{% set theme = "Everyone needs to know" %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'accessibility/_breadcrumb.njk' %}
+  {% include "accessibility/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -40,5 +40,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/community/backlog-of-components-and-patterns.njk
+++ b/app/views/community/backlog-of-components-and-patterns.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Backlog of components and patterns' %}
-{% set pageSection = 'Community' %}
-{% set pageDescription = 'The service manual is built on the research and experience of many digital teams in the NHS. We have a shared backlog and encourage people to contribute.' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Backlog of components and patterns" %}
+{% set pageSection = "Community" %}
+{% set pageDescription = "The service manual is built on the research and experience of many digital teams in the NHS. We have a shared backlog and encourage people to contribute." %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'community/_breadcrumb.njk' %}
+  {% include "community/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/community/contribution-criteria.njk
+++ b/app/views/community/contribution-criteria.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Contribution criteria' %}
-{% set pageSection = 'Community' %}
-{% set pageDescription = 'Follow these criteria when proposing a new component or pattern.' %}
-{% set dateUpdated = 'October 2019' %}
+{% set pageTitle = "Contribution criteria" %}
+{% set pageSection = "Community" %}
+{% set pageDescription = "Follow these criteria when proposing a new component or pattern." %}
+{% set dateUpdated = "October 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'community/_breadcrumb.njk' %}
+  {% include "community/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/community/develop-component-pattern.njk
+++ b/app/views/community/develop-component-pattern.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Develop a component or pattern' %}
-{% set pageSection = 'Community' %}
-{% set pageDescription = 'Anyone can work on something in the NHS digital service manual community backlog.' %}
-{% set dateUpdated = 'March 2019' %}
+{% set pageTitle = "Develop a component or pattern" %}
+{% set pageSection = "Community" %}
+{% set pageDescription = "Anyone can work on something in the NHS digital service manual community backlog." %}
+{% set dateUpdated = "March 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'community/_breadcrumb.njk' %}
+  {% include "community/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/community/index.njk
+++ b/app/views/community/index.njk
@@ -1,8 +1,8 @@
-{% set pageTitle = 'Community' %}
-{% set pageDescription = 'The NHS digital service manual is a community effort. Anyone can help improve and grow it.' %}
-{% set pageSection = 'Community' %}
+{% set pageTitle = "Community" %}
+{% set pageDescription = "The NHS digital service manual is a community effort. Anyone can help improve and grow it." %}
+{% set pageSection = "Community" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block bodyContent %}
 
@@ -16,7 +16,7 @@
   <p>To make sure everything in the service manual is of high quality, contributions need to meet the following <a href="/community/contribution-criteria">contribution criteria</a>.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/community/propose-component-pattern.njk
+++ b/app/views/community/propose-component-pattern.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Propose a component or pattern' %}
-{% set pageSection = 'Community' %}
-{% set pageDescription = 'Anyone can propose a new thing for the NHS digital service manual.' %}
-{% set dateUpdated = 'March 2019' %}
+{% set pageTitle = "Propose a component or pattern" %}
+{% set pageSection = "Community" %}
+{% set pageDescription = "Anyone can propose a new thing for the NHS digital service manual." %}
+{% set dateUpdated = "March 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'community/_breadcrumb.njk' %}
+  {% include "community/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -1,16 +1,16 @@
-{% set pageTitle = 'A to Z of NHS health writing' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'Words and phrases we use to make our content about health and the NHS easy to understand.' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "A to Z of NHS health writing" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "Words and phrases we use to make our content about health and the NHS easy to understand." %}
+{% set dateUpdated = "January 2020" %}
 
 {% block extraMeta %}
   <meta name="page-index" content="special">
 {% endblock %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/content/formatting-and-punctuation.njk
+++ b/app/views/content/formatting-and-punctuation.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Formatting and punctuation' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'Abbreviations, acronyms, capitalisation and other content styles.' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "Formatting and punctuation" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "Abbreviations, acronyms, capitalisation and other content styles." %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block sideNav %}
@@ -196,5 +196,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/health-literacy/index.njk
+++ b/app/views/content/health-literacy/index.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Health literacy' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'NHS services are for everyone. But many adults in the UK have low "health literacy" skills. This means they struggle to read and understand medical content intended for the public.' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "Health literacy" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "NHS services are for everyone. But many adults in the UK have low health literacy skills. This means they struggle to read and understand medical content intended for the public." %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -71,5 +71,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include '../partials/related-nav.njk' %}
+  {% include "../partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/health-literacy/use-a-readability-tool-to-prioritise-content.njk
+++ b/app/views/content/health-literacy/use-a-readability-tool-to-prioritise-content.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = 'Use a readability tool to prioritise content' %}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'Health literacy' %}
-{% set pageDescription = 'If you have a lot of content, one way to decide what to focus on is to use a readability tool.' %}
-{% set dateUpdated = 'July 2019' %}
+{% set pageTitle = "Use a readability tool to prioritise content" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "Health literacy" %}
+{% set pageDescription = "If you have a lot of content, one way to decide what to focus on is to use a readability tool." %}
+{% set dateUpdated = "July 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/health-literacy/_breadcrumb.njk' %}
+  {% include "content/health-literacy/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -128,5 +128,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include '../partials/related-nav.njk' %}
+  {% include "../partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/_layout.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/_layout.njk
@@ -1,4 +1,4 @@
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
 {% block breadcrumb %}
   {{ breadcrumb({
@@ -33,7 +33,7 @@
         {{pageTitle}}
       </h1>
 
-      {% include 'content/how-to-write-good-questions-for-forms/write-good-questions-nav.njk' %}
+      {% include "content/how-to-write-good-questions-for-forms/write-good-questions-nav.njk" %}
 
       <p class="nhsuk-body-l">{{pageDescription}}</p>
 

--- a/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
@@ -1,18 +1,18 @@
-{% set pageTitle = 'Consider the sensitivities around your questions'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'People may not trust you with their personal data or they may think the question is inappropriate.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Consider the sensitivities around your questions" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "People may not trust you with their personal data or they may think the question is inappropriate." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2>Understand the topics that are especially sensitive</h2>
   <p>These include, for example:</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/get-the-questions-into-order.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/get-the-questions-into-order.njk
@@ -1,19 +1,19 @@
 
-{% set pageTitle = 'Get the questions into order'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Think about how the questions flow and group them in a way that makes sense to the user.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Get the questions into order" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Think about how the questions flow and group them in a way that makes sense to the user." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2 id="begin-prototyping-with-1-thing-per-page">Begin prototyping with 1 thing per page</h2>
   <p>Follow the <a href="https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page">GOV.UK principle of each page containing just 1 thing</a>, for example:</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/index.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/index.njk
@@ -1,19 +1,19 @@
-{% set pageTitle = 'How to write good questions for forms' %}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Guidance for people working on forms, questionnaires and transactional services.' %}
-{% set dateUpdated = 'November 2019' %}
-{% set theme = 'Content style guide' %}
+{% set pageTitle "How to write good questions for forms" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Guidance for people working on forms, questionnaires and transactional services." %}
+{% set dateUpdated = "November 2019" %}
+{% set theme = "Content style guide" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <p>This guidance will help you understand:</p>
   <ul>

--- a/app/views/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question.njk
@@ -1,18 +1,18 @@
-{% set pageTitle = 'Make sure you need each question'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Question your questions. Keep them to a minimum.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Make sure you need each question" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Question your questions. Keep them to a minimum." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2 id="understand-why-you're-asking-each-question">Understand why you're asking each question</h2>
   <p>Make a list of all the information you need from your users now for you to deliver the service.</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/test-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/test-your-questions.njk
@@ -1,19 +1,19 @@
 
-{% set pageTitle = 'Test your questions'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Test your questions and answers with real users and the staff who deal with the form.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Test your questions" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Test your questions and answers with real users and the staff who deal with the form." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2 id="user-research-in-your-discovery-phase">Understand your users, their context and your existing forms</h2>
   <p>If you have not already done so, you should start by <a href="/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions">understanding the problem</a>, including who your users are. Watch them fill in any existing forms. If you do not have an existing form, how do users get the service at the moment?</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation.njk
@@ -1,18 +1,18 @@
-{% set pageTitle = 'Think of the form as a conversation'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Help users understand and answer your questions by making them flow and feel like a conversation.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Think of the form as a conversation" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Help users understand and answer your questions by making them flow and feel like a conversation." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2>Build trust</h2>
   <p>Be respectful and inclusive. <a href="/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions">Consider the sensitivities around your questions</a>.</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions.njk
@@ -1,20 +1,20 @@
-{% set pageTitle = 'Understand the problem before you write your questions' %}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Writing good questions starts with a discovery phase.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Understand the problem before you write your questions" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Writing good questions starts with a discovery phase." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   <p class="app-lede-text--sub">You need to understand your users and the problem you&apos;re trying to solve before you start on your questions.</p>
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2>Use your discovery phase to understand the service you're designing</h2>
   <p>Make sure your team understands:</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
@@ -1,18 +1,18 @@
-{% set pageTitle = 'Use filter questions to route users'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'Filter questions help users move quickly through the form by routing them to the questions that apply to them.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Use filter questions to route users" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "Filter questions help users move quickly through the form by routing them to the questions that apply to them." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2 id="what-are-filter-questions">What are filter questions?</h2>
   <p>Filter (or branching) questions ask a short question first, often a Yes/No question, with <a href="/design-system/components/radios">radios</a>. A typical filter question would be: "Are you 18 or over?"</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
@@ -1,19 +1,19 @@
 
-{% set pageTitle = 'Write the supporting content for your form'%}
-{% set pageSection = 'Content style guide' %}
-{% set subSection = 'How to write good questions for forms' %}
-{% set pageDescription = 'As well as questions, your form or service may need an introduction, help text, error messages and a confirmation or thank you page. Think about content across other channels too.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Write the supporting content for your form" %}
+{% set pageSection = "Content style guide" %}
+{% set subSection = "How to write good questions for forms" %}
+{% set pageDescription = "As well as questions, your form or service may need an introduction, help text, error messages and a confirmation or thank you page. Think about content across other channels too." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/how-to-write-good-questions-for-forms/_breadcrumb.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
-  {% include 'content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk' %}
+  {% include "content/how-to-write-good-questions-for-forms/_side-nav-mobile.njk" %}
 
   <h2>Name your form</h2>
   <p>If you have not already done so, name your form or service. (See the GOV.UK guidance on <a href="https://www.gov.uk/service-manual/design/naming-your-service">Naming your service</a>.)</p>

--- a/app/views/content/how-we-write.njk
+++ b/app/views/content/how-we-write.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'How we write' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'Everything we write follows these general principles.' %}
-{% set dateUpdated = 'August 2019' %}
+{% set pageTitle = "How we write" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "Everything we write follows these general principles." %}
+{% set dateUpdated = "August 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -88,5 +88,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/inclusive-language.njk
+++ b/app/views/content/inclusive-language.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Inclusive language' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'Writing for and about people in a way that is inclusive and respectful.' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Inclusive language" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "Writing for and about people in a way that is inclusive and respectful." %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block sideNav %}
@@ -167,5 +167,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/index.njk
+++ b/app/views/content/index.njk
@@ -1,9 +1,9 @@
-{% set pageTitle = 'Content style guide' %}
-{% set pageDescription = 'How to write for digital NHS services.' %}
-{% set pageSection = 'Content style guide' %}
-{% set landingPage = 'true' %}
+{% set pageTitle = "Content style guide" %}
+{% set pageDescription = "How to write for digital NHS services." %}
+{% set pageSection = "Content style guide" %}
+{% set landingPage = "true" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block bodyContent %}
 
@@ -12,7 +12,7 @@
   <p>Check the <a href="https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style">GOV.UK A to Z style guide</a> and <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk">GOV.UK content design guide</a> for any points of style that you do not find here. If it's not there, we recommend using the Oxford Dictionary for Writers and Editors.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/content/index.njk
+++ b/app/views/content/index.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "Content style guide" %}
 {% set pageDescription = "How to write for digital NHS services." %}
 {% set pageSection = "Content style guide" %}
-{% set landingPage = "true" %}
+{% set landingPage = true %}
 
 {% extends "includes/app-layout.njk" %}
 

--- a/app/views/content/links.njk
+++ b/app/views/content/links.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Links' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'How to handle links, including links to PDFs' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Links" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "How to handle links, including links to PDFs" %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -73,6 +73,6 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}
 

--- a/app/views/content/numbers-measurements-dates-time.njk
+++ b/app/views/content/numbers-measurements-dates-time.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Numbers, measurements, dates and time' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'Content styles, including numerals, ordinals, dosage, temperature, fractions and percentages' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Numbers, measurements, dates and time" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "Content styles, including numerals, ordinals, dosage, temperature, fractions and percentages" %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block sideNav %}
@@ -208,5 +208,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/pdfs.njk
+++ b/app/views/content/pdfs.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'PDFs' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'Wherever possible, we avoid PDFs. Instead we create content as structured web pages in HTML. '%}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "PDFs" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "Wherever possible, we avoid PDFs. Instead we create content as structured web pages in HTML." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -50,5 +50,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/content/voice-and-tone.njk
+++ b/app/views/content/voice-and-tone.njk
@@ -1,12 +1,12 @@
-{% set pageTitle = 'Voice and tone' %}
-{% set pageSection = 'Content style guide' %}
-{% set pageDescription = 'How we use a consistent voice and an appropriate tone.' %}
-{% set dateUpdated = 'November 2019' %}
+{% set pageTitle = "Voice and tone" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "How we use a consistent voice and an appropriate tone." %}
+{% set dateUpdated = "November 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'content/_breadcrumb.njk' %}
+  {% include "content/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -44,5 +44,5 @@
 {% endblock %}
 
 {% block asideContent %}
-  {% include './partials/related-nav.njk' %}
+  {% include "./partials/related-nav.njk" %}
 {% endblock %}

--- a/app/views/cookie-confirmation.njk
+++ b/app/views/cookie-confirmation.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "Your cookie settings have been saved" %}
 {% set pageDescription = "Your cookie settings have been saved. We'll save your settings for a year." %}
 
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
 {% block breadcrumb %}
 <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">

--- a/app/views/cookie-policy.njk
+++ b/app/views/cookie-policy.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "Cookie policy" %}
 {% set pageDescription = "Find out about the cookies we use on the NHS digital service manual and how to turn them on or off." %}
 
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
 {% block body %}
 <div class="nhsuk-grid-row">

--- a/app/views/design-system/components/action-link.njk
+++ b/app/views/design-system/components/action-link.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Action link' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use action links to help users get to the next stage of a journey quickly by signposting the start of a digital service.' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '5' %}
+{% set pageTitle = "Action link" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use action links to help users get to the next stage of a journey quickly by signposting the start of a digital service." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "5" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'action-link'
+    type: "action-link"
   }) }}
 
   <h2>When to use action links </h2>

--- a/app/views/design-system/components/back-link.njk
+++ b/app/views/design-system/components/back-link.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Back link' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use back links to help users go back to the previous page in a multi-page transaction' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '32' %}
+{% set pageTitle = "Back link" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use back links to help users go back to the previous page in a multi-page transaction" %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "32" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'back-link'
+    type: "back-link"
   }) }}
 
   <h2>When to use a back link</h2>

--- a/app/views/design-system/components/breadcrumbs.njk
+++ b/app/views/design-system/components/breadcrumbs.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Breadcrumbs' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use breadcrumbs to help users understand where they are in the website.' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '6' %}
+{% set pageTitle = "Breadcrumbs" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use breadcrumbs to help users understand where they are in the website." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "6" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'breadcrumb'
+    type: "breadcrumb"
   }) }}
 
   <h2>When to use breadcrumbs</h2>

--- a/app/views/design-system/components/buttons.njk
+++ b/app/views/design-system/components/buttons.njk
@@ -1,15 +1,15 @@
-{% set pageTitle = 'Buttons' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use buttons to help users carry out an action on a page like starting an application or saving their progress.'%}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '7' %}
+{% set pageTitle = "Buttons" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use buttons to help users carry out an action on a page like starting an application or saving their progress." %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "7" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -23,7 +23,7 @@
 
   <h2 id="primary-button">Primary button</h2>
   {{ designExample({
-    type: 'button'
+    type: "button"
   }) }}
 
   <h3>When to use a primary button</h3>
@@ -32,7 +32,7 @@
 
   <h2 id="secondary-button">Secondary button</h2>
   {{ designExample({
-    type: 'button-secondary'
+    type: "button-secondary"
   }) }}
 
   <h3>When to use a secondary button</h3>
@@ -42,7 +42,7 @@
   <h2 id="reverse-button">White button on solid background colour (reverse button)</h2>
 
   {{ designExample({
-    type: 'button-reverse'
+    type: "button-reverse"
   }) }}
 
   <h3>When to use a white button on solid background colour</h3>

--- a/app/views/design-system/components/care-cards.njk
+++ b/app/views/design-system/components/care-cards.njk
@@ -1,15 +1,15 @@
-{% set pageTitle = 'Care cards' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use care cards to help users identify and understand the sort of care they need, who to contact and how quickly.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'August 2019' %}
-{% set backlog_issue_id = '8' %}
+{% set pageTitle = "Care cards" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use care cards to help users identify and understand the sort of care they need, who to contact and how quickly." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "August 2019" %}
+{% set backlog_issue_id = "8" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -23,7 +23,7 @@
 
   <h2 id="non-urgent-care-card-blue">Non-urgent care card (blue)</h2>
   {{ designExample({
-    type: 'care-card-non-urgent'
+    type: "care-card-non-urgent"
   }) }}
 
   <p>Use this card when you want users to contact their GP or arrange an appointment with a health professional, like a practice nurse. You can also use it to tell people to get advice from a pharmacist or to go to a clinic, for example for a chlamydia test.</p>
@@ -31,7 +31,7 @@
 
   <h2 id="urgent-care-card-red">Urgent care card (red)</h2>
   {{ designExample({
-    type: 'care-card-urgent'
+    type: "care-card-urgent"
   }) }}
 
   <p>Use this card when you want users to call or visit a GP or hospital urgently because they need advice or care quickly. You can, for example, use it to tell people to contact 111 or to go to a walk-in centre or minor injuries centre.</p>
@@ -40,7 +40,7 @@
 
   <h2 id="emergency-care-card-red-and-black">Immediate care card (red and dark grey)</h2>
   {{ designExample({
-    type: 'care-card-immediate'
+    type: "care-card-immediate"
   }) }}
 
   <p>Use this card when users need to get emergency help straight away - meaning "now". Tell them to dial 999 or go to their nearest accident and emergency (A&amp;E) department.</p>

--- a/app/views/design-system/components/checkboxes.njk
+++ b/app/views/design-system/components/checkboxes.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Checkboxes' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use checkboxes to let users select 1 or more options on a form.' %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '9' %}
+{% set pageTitle = "Checkboxes" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use checkboxes to let users select 1 or more options on a form." %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "9" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'checkboxes'
+    type: "checkboxes"
   }) }}
 
   <h2>When to use checkboxes</h2>
@@ -38,14 +38,14 @@
   <p>Use hint text to <a href="/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#give-users-help-in-context">give users help in context</a>. For example, say "Select all the options that are relevant to you".</p>
 
   {{ designExample({
-    type: 'checkboxes-hint'
+    type: "checkboxes-hint"
   }) }}
 
   <h3 id="error-messages">Error messages</h3>
   <p>Error messages should be styled like this:</p>
 
   {{ designExample({
-    type: 'checkboxes-error-messages'
+    type: "checkboxes-error-messages"
   }) }}
 
   <p>Follow:</p>

--- a/app/views/design-system/components/contents-list.njk
+++ b/app/views/design-system/components/contents-list.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Contents list' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use contents lists to allow users to navigate between related pages, for example about a single condition.' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '25' %}
+{% set pageTitle = "Contents list" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use contents lists to allow users to navigate between related pages, for example about a single condition." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "25" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'contents-list'
+    type: "contents-list"
   }) }}
 
   <h2>When to use a contents list</h2>

--- a/app/views/design-system/components/date-input.njk
+++ b/app/views/design-system/components/date-input.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Date input' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use date input to help users enter a memorable date, like their date of birth.' %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '10' %}
+{% set pageTitle = "Date input" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use date input to help users enter a memorable date, like their date of birth." %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "10" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'date-input'
+    type: "date-input"
   }) }}
 
   <h2>When to use date input</h2>
@@ -34,7 +34,7 @@
   <h2>Error messages</h2>
   <p>Style error messages like this:</p>
   {{ designExample({
-    type: 'date-input-errors'
+    type: "date-input-errors"
   }) }}
 
   <p>Follow:</p>

--- a/app/views/design-system/components/details.njk
+++ b/app/views/design-system/components/details.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Details' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Make a page easier to scan by letting users reveal more detailed information only if they need it.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '30' %}
+{% set pageTitle = "Details" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Make a page easier to scan by letting users reveal more detailed information only if they need it." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "30" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'details'
+    type: "details"
   }) }}
   <h2 id="when-to-use-this-component">When to use details</h2>
   <p>There are 2 ways to let users reveal more information:</p>

--- a/app/views/design-system/components/do-and-dont-list.njk
+++ b/app/views/design-system/components/do-and-dont-list.njk
@@ -1,21 +1,21 @@
 {% set pageTitle = "Do and Don't lists" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use Do and Don't lists to help users understand more easily what they should and shouldn't do." %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '11' %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "11" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'do-dont-list'
+    type: "do-dont-list"
   }) }}
 
   <h2>When to use Do and Don't lists</h2>

--- a/app/views/design-system/components/error-message.njk
+++ b/app/views/design-system/components/error-message.njk
@@ -1,27 +1,27 @@
 {% set pageTitle = "Error message" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use an error message when there is a validation error. Explain what went wrong and how to fix it." %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '12' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "12" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   <h3>Error message</h3>
   {{ designExample({
-    type: 'error-message'
+    type: "error-message"
   }) }}
 
   <h3>Error message in context</h3>
   {{ designExample({
-    type: 'error-message-in-context'
+    type: "error-message-in-context"
   }) }}
 
   <h2>When to use error messages </h2>

--- a/app/views/design-system/components/error-summary.njk
+++ b/app/views/design-system/components/error-summary.njk
@@ -1,21 +1,21 @@
 {% set pageTitle = "Error summary" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Include an error summary at the top of a page to summarise any mistakes a user has made." %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '13' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "13" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
     {{ designExample({
-      type: 'error-summary'
+      type: "error-summary"
     }) }}
 
     <h2 id="when-to-use">When to use an error summary</h2>

--- a/app/views/design-system/components/expander.njk
+++ b/app/views/design-system/components/expander.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Expander' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Make a complex topic easier to digest by letting users reveal more detailed information only if they need it.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '29' %}
+{% set pageTitle = "Expander" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Make a complex topic easier to digest by letting users reveal more detailed information only if they need it." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "29" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'expander'
+    type: "expander"
   }) }}
 
   <h2 id="when-to-use-this-component">When to use expanders</h2>
@@ -54,7 +54,7 @@
   <p>It can work well to have several expanders. See the example below.</p>
 
   {{ designExample({
-    type: 'expander-group'
+    type: "expander-group"
   }) }}
 
   <h3 id="write-clear-link-text">Write clear link text</h3>

--- a/app/views/design-system/components/fieldset.njk
+++ b/app/views/design-system/components/fieldset.njk
@@ -1,15 +1,15 @@
 {% set pageTitle = "Fieldset" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use a fieldset to group related form inputs."%}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '14' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "14" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -18,7 +18,7 @@
   <p>Use a fieldset when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single fieldset when asking for an address.</p>
 
   {{ designExample({
-    type: 'fieldset'
+    type: "fieldset"
   }) }}
 
   <h2 id="how-it-works">How to use a fieldset</h2>
@@ -27,7 +27,7 @@
   <p>Read more about <a href="https://design-system.service.gov.uk/get-started/labels-legends-headings/">why and how to set legends as headings</a> on the GOV.UK Design System.</p>
 
   {{ designExample({
-    type: 'fieldset-as-heading'
+    type: "fieldset-as-heading"
   }) }}
 
   <h3>Accessibility</h3>

--- a/app/views/design-system/components/footer.njk
+++ b/app/views/design-system/components/footer.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Footer' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use the footer to show users they are on an NHS service and to help them find links they expect at the bottom of our pages.'%}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '15' %}
+{% set pageTitle = "Footer" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use the footer to show users they are on an NHS service and to help them find links they expect at the bottom of our pages." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "15" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'footer'
+    type: "footer"
   }) }}
 
   <h2 id="when-to-use-the-footer">When to use the footer</h2>

--- a/app/views/design-system/components/header.njk
+++ b/app/views/design-system/components/header.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Header' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use the header to show users they are on an NHS service and help them get started in finding what they need.' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '16' %}
+{% set pageTitle = "Header" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use the header to show users they are on an NHS service and help them get started in finding what they need." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "16" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'header'
+    type: "header"
   }) }}
 
   <p>We have 3 versions of the header for services on the NHS website (nhs.uk):</p>
@@ -39,14 +39,14 @@
   <p>Use the default header on the NHS website.</p>
 
   {{ designExample({
-    type: 'header'
+    type: "header"
   }) }}
 
   <h3 id="service-header">Service header</h3>
   <p>Use the service header if your service is on the NHS website.</p>
 
   {{ designExample({
-    type: 'header-service'
+    type: "header-service"
   }) }}
 
   <h3 id="transactional-header">Transactional header</h3>
@@ -54,7 +54,7 @@
   <p>We have found that the full header is too distracting to be used in transactional services.</p>
 
   {{ designExample({
-    type: 'header-transactional'
+    type: "header-transactional"
   }) }}
 
   <h3 id="organisational-header">Organisational header
@@ -69,13 +69,13 @@
   <p>You must have a Frutiger font licence to use an organisational logo. Our guidance on <a href="/design-system/styles/typography">typography</a> explains how to get hold of the webfont. Read more about creating NHS <a href="https://www.england.nhs.uk/nhsidentity/identity-guidelines/organisational-logos/">organisational logos</a> in the NHS England identity guidelines.</p>
 
   {{ designExample({
-    type: 'header-org'
+    type: "header-org"
   }) }}
 
   <h4>White variant</h4>
 
   {{ designExample({
-    type: 'header-org-white'
+    type: "header-org-white"
   }) }}
 
   <p>The organisational logo is an SVG and you can change the organisation name and descriptor in the code. Longer organisation names should be split onto 2 lines.</p>

--- a/app/views/design-system/components/hint-text.njk
+++ b/app/views/design-system/components/hint-text.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Hint text' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use hint text to help users understand a question.' %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'January 2020' %}
-{% set backlog_issue_id = '17' %}
+{% set pageTitle = "Hint text" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use hint text to help users understand a question." %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "January 2020" %}
+{% set backlog_issue_id = "17" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'hint-text'
+    type: "hint-text"
   }) }}
 
   <h2>How to use hint text</h2>
@@ -24,33 +24,33 @@
   <h3 id="using-hint-text">Text input with hint text</h3>
 
   {{ designExample({
-    type: 'input-hint-text'
+    type: "input-hint-text"
   }) }}
 
   <h3 id="radios-with-hint-text">Radios with hint text</h3>
 
   {{ designExample({
-    type: 'radios-hints'
+    type: "radios-hints"
   }) }}
 
   <h3 id="radio-items-with-hints">Radio items with hints</h3>
   <p>You can add hints to radios to give more information about the options.</p>
 
   {{ designExample({
-    type: 'radios-hints-options'
+    type: "radios-hints-options"
   }) }}
 
   <h3 id="checkboxes-with-hint-text">Checkboxes with hint text</h3>
   <p>Unlike with <a href="/design-system/components/radios">radios</a>, users can select more than 1 option from a list of <a href="/design-system/components/checkboxes">checkboxes</a>. Do not assume that users will know how many options they can select.</p>
 
   {{ designExample({
-    type: 'checkboxes-hint'
+    type: "checkboxes-hint"
   }) }}
 
   <h3 id="textarea-with-hint-text">Textarea with hint text</h3>
 
   {{ designExample({
-    type: 'textarea'
+    type: "textarea"
   }) }}
 
 {% endblock %}

--- a/app/views/design-system/components/images.njk
+++ b/app/views/design-system/components/images.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Images' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use images only if there is a real user need. Avoid unnecessary decoration.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '28' %}
+{% set pageTitle = "Images" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use images only if there is a real user need. Avoid unnecessary decoration." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "28" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'images'
+    type: "images"
   }) }}
 
   <h2>When to use images</h2>

--- a/app/views/design-system/components/index.njk
+++ b/app/views/design-system/components/index.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = 'Components' %}
-{% set pageDescription = 'Components are reusable elements of the user interface.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set theme = 'Design' %}
+{% set pageTitle = "Components" %}
+{% set pageDescription = "Components are reusable elements of the user interface." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set theme = "Design" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/_breadcrumb.njk' %}
+  {% include "design-system/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -17,7 +17,7 @@
   <p>If you are using the <a href="https://nhsuk-prototype-kit.azurewebsites.net/docs">NHS.UK prototype kit</a> or have the <a href="https://github.com/nhsuk/nhsuk-frontend">NHS.UK frontend</a> included in your build, the coded examples for each component will look and work exactly as they do in the service manual.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/design-system/components/inset-text.njk
+++ b/app/views/design-system/components/inset-text.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Inset text' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use inset text to help users identify and understand important content on the page, even if they do not read the whole page.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '18' %}
+{% set pageTitle = "Inset text" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use inset text to help users identify and understand important content on the page, even if they do not read the whole page." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "18" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'inset-text'
+    type: "inset-text"
   }) }}
 
   <h2>When to use inset text</h2>

--- a/app/views/design-system/components/pagination.njk
+++ b/app/views/design-system/components/pagination.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Pagination' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use pagination to allow users to navigate between related pages, for example about a single condition.' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '27' %}
+{% set pageTitle = "Pagination" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use pagination to allow users to navigate between related pages, for example about a single condition." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "27" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'pagination'
+    type: "pagination"
   }) }}
 
   <h2>When to use pagination</h2>

--- a/app/views/design-system/components/radios.njk
+++ b/app/views/design-system/components/radios.njk
@@ -1,21 +1,21 @@
 {% set pageTitle = "Radios" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use radios when you want users to select only 1 option from a list." %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '19' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "19" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'radios'
+    type: "radios"
   }) }}
 
   <h2 id="when-to-use-this-component">When to use radios</h2>
@@ -43,35 +43,35 @@
   <p>If there are only 2 options, you can either stack the radios or display them inline, like this:</p>
 
   {{ designExample({
-    type: 'radios-inline'
+    type: "radios-inline"
   }) }}
 
   <h3 id="radios-with-hints">Radios with hints</h3>
   <p>Use hint text to <a href="/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#give-users-help-in-context">give users help in context</a>.</p>
 
   {{ designExample({
-    type: 'radios-hints'
+    type: "radios-hints"
   }) }}
 
   <h3 id="radio-items-with-hints">Radio items with hints</h3>
   <p>You can add hints to radios to give more information about the options.</p>
 
   {{ designExample({
-    type: 'radios-hints-options'
+    type: "radios-hints-options"
   }) }}
 
   <h3 id="radio-items-with-a-text-divider">Radio items with a text divider</h3>
   <p>If 1 or more of your radio options is different from the others, it can help users if you separate them using a text divider. The text is usually the word "or".</p>
 
   {{ designExample({
-    type: 'radios-divider'
+    type: "radios-divider"
   }) }}
 
   <h3 id="error-messages">Error messages</h3>
   <p>Style error messages like this:</p>
 
   {{ designExample({
-    type: 'radios-error'
+    type: "radios-error"
   }) }}
 
   <p>Follow:</p>

--- a/app/views/design-system/components/review-date.njk
+++ b/app/views/design-system/components/review-date.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Review date' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use review dates to reassure users that our information is up-to-date.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '31' %}
+{% set pageTitle = "Review date" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use review dates to reassure users that our information is up-to-date." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "31" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'review-date'
+    type: "review-date"
   }) }}
 
   <h2>When to use review dates</h2>

--- a/app/views/design-system/components/select.njk
+++ b/app/views/design-system/components/select.njk
@@ -1,21 +1,21 @@
 {% set pageTitle = "Select" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use select to let users choose an option from a long list but only use it as a last resort." %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '20' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "20" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'select'
+    type: "select"
   }) }}
 
   <h2 id="how-it-works">How to use select</h2>

--- a/app/views/design-system/components/skip-link.njk
+++ b/app/views/design-system/components/skip-link.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Skip link' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use a skip link to help keyboard-only users skip to the main content on a page.' %}
-{% set theme = 'Navigation' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '33' %}
+{% set pageTitle = "Skip link" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use a skip link to help keyboard-only users skip to the main content on a page." %}
+{% set theme = "Navigation" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "33" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'skip-link'
+    type: "skip-link"
   }) }}
 
   <h2>When to use a skip link </h2>

--- a/app/views/design-system/components/summary-list.njk
+++ b/app/views/design-system/components/summary-list.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the summary list to summarise information, for example, a user’s responses at the end of a form." %}
-{% set experimental = "true" %}
+{% set experimental = true %}
 {% set theme = "Content presentation" %}
 {% set dateUpdated = "November 2019" %}
 {% set backlog_issue_id = "36" %}

--- a/app/views/design-system/components/summary-list.njk
+++ b/app/views/design-system/components/summary-list.njk
@@ -1,22 +1,22 @@
 {% set pageTitle = "Summary list" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use the summary list to summarise information, for example, a user’s responses at the end of a form." %}
-{% set experimental = 'true' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '36' %}
+{% set experimental = "true" %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "36" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'summary-list'
+    type: "summary-list"
   }) }}
 
   <h2>When to use summary lists</h2>
@@ -35,7 +35,7 @@
   <p>There are 2 ways to use the summary list component. You can use HTML or, if you’re using <a href="https://mozilla.github.io/nunjucks/">Nunjucks</a> or the <a href="https://nhsuk-prototype-kit.azurewebsites.net/docs">NHS.UK prototype kit</a>, you can use the Nunjucks macro.</p>
 
   {{ designExample({
-    type: 'summary-list'
+    type: "summary-list"
   }) }}
 
   <h3 id="label-text-inputs">Summary list with actions</h3>
@@ -43,20 +43,20 @@
   <p>People who use assistive technology, like a screen reader, may hear the action links out of context and not know what they do. To give more context, add visually hidden text to the links. This means a screen reader user will hear a meaningful action, like "Change name" or "Change date of birth".</p>
 
   {{ designExample({
-    type: 'summary-list'
+    type: "summary-list"
   }) }}
 
   <h3 id="label-text-inputs">Summary list without actions</h3>
 
   {{ designExample({
-    type: 'summary-list-without-action'
+    type: "summary-list-without-action"
   }) }}
 
   <h3 id="label-text-inputs">Summary list without actions or borders</h3>
   <p class="rich-text">If you do not include actions in your summary list and it would be better for your design to remove the separating borders, use the <code>nhsuk-summary-list--no-border</code> class.</p>
 
   {{ designExample({
-    type: 'summary-list-without-border'
+    type: "summary-list-without-border"
   }) }}
 
   <h2 id="research">Research</h2>

--- a/app/views/design-system/components/table.njk
+++ b/app/views/design-system/components/table.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Table' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use a table to make it easier for users to compare and scan information.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'April 2019' %}
-{% set backlog_issue_id = '26' %}
+{% set pageTitle = "Table" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use a table to make it easier for users to compare and scan information." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "April 2019" %}
+{% set backlog_issue_id = "26" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'table'
+    type: "table"
   }) }}
 
   <h2 id="when-to-use-this-component">When to use a table</h2>

--- a/app/views/design-system/components/text-input.njk
+++ b/app/views/design-system/components/text-input.njk
@@ -1,21 +1,21 @@
 {% set pageTitle = "Text input" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use text input to let users enter a single line of text." %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '21' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "21" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'input'
+    type: "input"
   }) }}
 
   <h2>When to use text input</h2>
@@ -32,7 +32,7 @@
   <p class="rich-text">If you are asking just <a href="/content/how-to-write-good-questions-for-forms/get-the-questions-into-order#begin-prototyping-with-1-thing-per-page">1 question per page</a> as we recommend, you can set the contents of the <code>&lt;label&gt;</code> as the page heading. This is good practice as it means that screen reader users will only hear the contents once.</p>
 
   {{ designExample({
-    type: 'input-heading'
+    type: "input-heading"
   }) }}
 
   <h3 id="use-appropriately-sized-text-inputs">Make text inputs the right size</h3>
@@ -45,7 +45,7 @@
   <p>On fixed width inputs, the width will remain fixed on all screens unless it is wider than the viewport, in which case it will shrink to fit.</p>
 
   {{ designExample({
-    type: 'input-fixed-width'
+    type: "input-fixed-width"
   }) }}
 
   <h4 id="fluid-width-inputs">Fluid width inputs</h4>
@@ -53,21 +53,21 @@
   <p>Fluid width inputs will resize with the viewport.</p>
 
   {{ designExample({
-    type: 'input-fluid-width'
+    type: "input-fluid-width"
   }) }}
 
   <h3 id="using-hint-text">Using hint text</h3>
   <p>Use hint text to <a href="/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#give-users-help-in-context">give users help in context</a>, for example, tell users where to find information or how you will use their data.</p>
 
   {{ designExample({
-    type: 'input-hint-text'
+    type: "input-hint-text"
   }) }}
 
   <h3 id="error-messages">Error messages</h3>
   <p>Style error messages like this.</p>
 
   {{ designExample({
-    type: 'input-error'
+    type: "input-error"
   }) }}
 
   <p>Follow:</p>

--- a/app/views/design-system/components/textarea.njk
+++ b/app/views/design-system/components/textarea.njk
@@ -1,21 +1,21 @@
 {% set pageTitle = "Textarea" %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
 {% set pageDescription = "Use textarea to let users enter more than 1 line of text." %}
-{% set theme = 'Form elements' %}
-{% set dateUpdated = 'January 2020' %}
-{% set backlog_issue_id = '22' %}
+{% set theme = "Form elements" %}
+{% set dateUpdated = "January 2020" %}
+{% set backlog_issue_id = "22" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'textarea'
+    type: "textarea"
   }) }}
 
   <h2 id="when-to-use-this-component">When to use textarea</h2>
@@ -37,7 +37,7 @@
   <p class="rich-text">Make the height of a textarea proportional to the amount of text you expect users to enter. You can set the height of a textarea by specifying the <code>rows</code> attribute.</p>
 
   {{ designExample({
-    type: 'textarea-longer'
+    type: "textarea-longer"
   }) }}
   <h3>Using hint text</h3>
   <p>Use hint text to <a href="/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#give-users-help-in-context">give users help in context</a>, for example, tell users what information to include or not to include.</p>
@@ -48,7 +48,7 @@
   <p>Style error messages like this.</p>
 
   {{ designExample({
-    type: 'textarea-error'
+    type: "textarea-error"
   }) }}
 
   <p>Follow:</p>

--- a/app/views/design-system/components/warning-callout.njk
+++ b/app/views/design-system/components/warning-callout.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'Warning callout' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Components' %}
-{% set pageDescription = 'Use a warning callout to help users identify and understand warning content on the page, even if they do noticedt read the whole page.' %}
-{% set theme = 'Content presentation' %}
-{% set dateUpdated = 'January 2019' %}
-{% set backlog_issue_id = '23' %}
+{% set pageTitle = "Warning callout" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Components" %}
+{% set pageDescription = "Use a warning callout to help users identify and understand warning content on the page, even if they do noticedt read the whole page." %}
+{% set theme = "Content presentation" %}
+{% set dateUpdated = "January 2019" %}
+{% set backlog_issue_id = "23" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/components/_breadcrumb.njk' %}
+  {% include "design-system/components/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'warning-callout'
+    type: "warning-callout"
   }) }}
 
   <h2>When to use a warning callout</h2>

--- a/app/views/design-system/design-principles.njk
+++ b/app/views/design-system/design-principles.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Design principles' %}
-{% set pageDescription = 'These principles guide all of our design. Use them to get started on a project and to help with making decisions.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Design system' %}
-{% set theme = 'Principles' %}
-{% set dateUpdated = 'August 2018' %}
+{% set pageTitle = "Design principles" %}
+{% set pageDescription = "These principles guide all of our design. Use them to get started on a project and to help with making decisions." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Design system" %}
+{% set theme = "Principles" %}
+{% set dateUpdated = "August 2018" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/_breadcrumb.njk' %}
+  {% include "design-system/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/design-system/index.njk
+++ b/app/views/design-system/index.njk
@@ -1,9 +1,9 @@
-{% set pageTitle = 'Design system' %}
-{% set pageDescription = 'Build consistent, accessible user interfaces. Learn from the research and experience of other NHS digital teams.' %}
-{% set pageSection = 'Design system' %}
-{% set landingPage = 'true' %}
+{% set pageTitle = "Design system" %}
+{% set pageDescription = "Build consistent, accessible user interfaces. Learn from the research and experience of other NHS digital teams." %}
+{% set pageSection = "Design system" %}
+{% set landingPage = "true" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block bodyContent %}
 
@@ -12,7 +12,7 @@
   <p>The examples in the NHS digital service manual come with code to make it easy for you to use them in your project.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/design-system/index.njk
+++ b/app/views/design-system/index.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "Design system" %}
 {% set pageDescription = "Build consistent, accessible user interfaces. Learn from the research and experience of other NHS digital teams." %}
 {% set pageSection = "Design system" %}
-{% set landingPage = "true" %}
+{% set landingPage = true %}
 
 {% extends "includes/app-layout.njk" %}
 

--- a/app/views/design-system/patterns/a-to-z.njk
+++ b/app/views/design-system/patterns/a-to-z.njk
@@ -1,21 +1,21 @@
-{% set pageTitle = 'A to Z page' %}
-{% set pageDescription = 'A to Z is a way of presenting a number of pages alphabetically.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Patterns' %}
-{% set theme = 'Page types' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '96' %}
+{% set pageTitle = "A to Z page" %}
+{% set pageDescription = "A to Z is a way of presenting a number of pages alphabetically." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Page types" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "96" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/patterns/_breadcrumb.njk' %}
+  {% include "design-system/patterns/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
 
   {{ designExample({
-    type: 'a-z',
+    type: "a-z",
     fullpage: true
   }) }}
 
@@ -48,7 +48,7 @@
   <h3 id="a-to-z-navigation">A to Z navigation</h3>
 
   {{ designExample({
-    type: 'a-z-nav'
+    type: "a-z-nav"
   }) }}
 
   <p>Use the A to Z navigation at the top of the page.</p>
@@ -56,7 +56,7 @@
   <h3 id="a-to-z-list-panel">A to Z list panel</h3>
 
   {{ designExample({
-    type: 'a-z-list-panel'
+    type: "a-z-list-panel"
   }) }}
 
   <p>Use the A to Z list panel below the A to Z navigation to help users to navigate around a large section, for example a range of different health conditions. The example on this page is from the Health A to Z page on the NHS website.</p>

--- a/app/views/design-system/patterns/index.njk
+++ b/app/views/design-system/patterns/index.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = 'Patterns' %}
-{% set pageDescription = 'Patterns are best practice design solutions for specific user-focused tasks and page types.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Patterns' %}
-{% set theme = 'Design' %}
+{% set pageTitle = "Patterns" %}
+{% set pageDescription = "Patterns are best practice design solutions for specific user-focused tasks and page types." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Design" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/_breadcrumb.njk' %}
+  {% include "design-system/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -16,7 +16,7 @@
    <p>They may, for example, ask users for different kinds of information or help users navigate or do something.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/design-system/patterns/mini-hub.njk
+++ b/app/views/design-system/patterns/mini-hub.njk
@@ -1,15 +1,15 @@
-{% set pageTitle = 'Mini-hub' %}
-{% set pageDescription = 'Mini-hubs are a way of presenting a number of pages about 1 topic on the NHS website.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Patterns' %}
-{% set theme = 'Page types' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '86' %}
+{% set pageTitle = "Mini-hub" %}
+{% set pageDescription = "Mini-hubs are a way of presenting a number of pages about 1 topic on the NHS website." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Page types" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "86" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/patterns/_breadcrumb.njk' %}
+  {% include "design-system/patterns/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -42,7 +42,7 @@
   <p>In this example, "What is AMD?" is the heading for the page. "Age-related macular degeneration (AMD)" is the topic.</p>
 
   {{ designExample({
-    type: 'typography-mini-hub-heading',
+    type: "typography-mini-hub-heading",
     htmlOnly: true
   }) }}
 
@@ -50,14 +50,14 @@
   <p>Use a <a href="/design-system/components/contents-list">contents list</a> at the top of the page, underneath the heading and sub-heading, to help users navigate around a small group of related pages (up to 8 pages), for example a group of pages about a specific health condition. The example on this page is from the NHS website information about AMD.</p>
 
   {{ designExample({
-    type: 'contents-list'
+    type: "contents-list"
   }) }}
 
   <h3 class="nhsuk-u-margin-top-6">Pagination</h3>
   <p>Use <a href="/design-system/components/pagination">pagination</a>  at the bottom of the page to help users navigate around a small group of related pages (up to 8 pages), for example a group of pages about a specific health condition.</p>
 
   {{ designExample({
-    type: 'pagination'
+    type: "pagination"
   }) }}
 
   <h2 id="research">Research on this pattern</h2>

--- a/app/views/design-system/patterns/nhs-number.njk
+++ b/app/views/design-system/patterns/nhs-number.njk
@@ -1,15 +1,15 @@
-{% set pageTitle = 'Ask users for their NHS number' %}
-{% set pageDescription = 'Use this pattern to ask people for their NHS number and help them find it.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Patterns' %}
-{% set theme = 'Tasks' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '109' %}
+{% set pageTitle = "Ask users for their NHS number" %}
+{% set pageDescription = "Use this pattern to ask people for their NHS number and help them find it." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Tasks" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "109" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/patterns/_breadcrumb.njk' %}
+  {% include "design-system/patterns/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -40,7 +40,7 @@
   <p>However, we recommend you avoid building a service that requires users to enter their NHS number. If possible, always try to give users an alternative way to continue with their journey, and use 1 of the other ways of asking for an NHS number on this page instead.</p>
 
   {{ designExample({
-    type: 'nhs-number-single',
+    type: "nhs-number-single",
     fullpage: true
   }) }}
 
@@ -56,14 +56,14 @@
   <p>Use a 2-option radio button that asks the user if they know their NHS number.</p>
 
   {{ designExample({
-    type: 'nhs-number-filter',
+    type: "nhs-number-filter",
     fullpage: true
   }) }}
 
   <p>If users do know their NHS number, route them to a page that asks for it.</p>
 
   {{ designExample({
-    type: 'nhs-number-filter-single',
+    type: "nhs-number-filter-single",
     fullpage: true
   }) }}
 
@@ -75,7 +75,7 @@
   <p>Our research and testing in alpha and discovery stages showed a 3rd option is often useful. We recommend that you always try and give a 3rd option.</p>
 
   {{ designExample({
-    type: 'nhs-number-filter-third-option',
+    type: "nhs-number-filter-third-option",
     fullpage: true
   }) }}
 
@@ -99,7 +99,7 @@
   </ul>
 
   {{ designExample({
-    type: 'details'
+    type: "details"
   }) }}
 
   <h3>Use the correct NHS number format</h3>
@@ -110,7 +110,7 @@
   <p>Make sure you use clear <a href='/design-system/components/error-message'>error messages</a> and <a href='/design-system/components/error-summary'>error summaries</a> when you ask users for their NHS number.</p>
 
   {{ designExample({
-    type: 'nhs-number-error',
+    type: "nhs-number-error",
     fullpage: true
   }) }}
 

--- a/app/views/design-system/production.njk
+++ b/app/views/design-system/production.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Production code' %}
-{% set pageDescription = 'The code you need to start building user interfaces for NHS websites and services.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Design system' %}
-{% set theme = 'Setup' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Production code" %}
+{% set pageDescription = "The code you need to start building user interfaces for NHS websites and services." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Design system" %}
+{% set theme = "Setup" %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/_breadcrumb.njk' %}
+  {% include "design-system/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -49,7 +49,7 @@
   <p>You can get the code from the HTML or Nunjucks tabs below the examples on our component pages, like this example of a button.</p>
 
   {{ designExample({
-    type: 'button'
+    type: "button"
   }) }}
 
   <h3 id="using-nunjucks-macros">Using Nunjucks macros</h3>

--- a/app/views/design-system/prototyping.njk
+++ b/app/views/design-system/prototyping.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Prototyping' %}
-{% set pageDescription = 'Build prototypes quickly to show people and test with users.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Design system' %}
-{% set theme = 'Setup' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Prototyping" %}
+{% set pageDescription = "Build prototypes quickly to show people and test with users." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Design system" %}
+{% set theme = "Setup" %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/_breadcrumb.njk' %}
+  {% include "design-system/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -26,7 +26,7 @@
   <p>You can copy the code from the HTML or Nunjucks tabs below the examples on our component pages, like this example of a button.</p>
 
   {{ designExample({
-    type: 'button'
+    type: "button"
   }) }}
 
   <h2 id="using-nunjucks-macros">Using Nunjucks macros</h2>

--- a/app/views/design-system/styles/colour.njk
+++ b/app/views/design-system/styles/colour.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Colour' %}
-{% set pageDescription = 'Our colours, and how to apply them.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '2' %}
+{% set pageTitle = "Colour" %}
+{% set pageDescription = "Our colours, and how to apply them." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "2" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/styles/_breadcrumb.njk' %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/design-system/styles/focus-state.njk
+++ b/app/views/design-system/styles/focus-state.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Focus state' %}
-{% set pageDescription = 'Use these focus state styles to let users know which element they’re on and that they can interact with it.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set dateUpdated = 'October 2019' %}
-{% set backlog_issue_id = '193' %}
+{% set pageTitle = "Focus state" %}
+{% set pageDescription = "Use these focus state styles to let users know which element they’re on and that they can interact with it." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "October 2019" %}
+{% set backlog_issue_id = "193" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/styles/_breadcrumb.njk' %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/design-system/styles/icons.njk
+++ b/app/views/design-system/styles/icons.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Icons' %}
-{% set pageDescription = 'Use this small set of icons that we know our users need and understand to help them identify and navigate content more quickly.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '4' %}
+{% set pageTitle = "Icons" %}
+{% set pageDescription = "Use this small set of icons that we know our users need and understand to help them identify and navigate content more quickly." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "4" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/styles/_breadcrumb.njk' %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/design-system/styles/index.njk
+++ b/app/views/design-system/styles/index.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = 'Styles' %}
-{% set pageDescription = 'Make your service look and feel like the NHS website with these tested styles.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set theme = 'Design' %}
+{% set pageTitle = "Styles" %}
+{% set pageDescription = "Make your service look and feel like the NHS website with these tested styles." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set theme = "Design" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/_breadcrumb.njk' %}
+  {% include "design-system/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}
@@ -15,7 +15,7 @@
   <p>If you are using the <a href="https://nhsuk-prototype-kit.azurewebsites.net/docs">NHS.UK prototype kit</a> or have the <a href="https://github.com/nhsuk/nhsuk-frontend">NHS.UK frontend</a> included in your build, the coded examples in the service manual do not need any additional styling.</p>
 
   <div class="app-index-navigation app-u-hide-desktop">
-    {% include 'includes/_side-nav.njk' %}
+    {% include "includes/_side-nav.njk" %}
   </div>
 
 {% endblock %}

--- a/app/views/design-system/styles/layout.njk
+++ b/app/views/design-system/styles/layout.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Layout' %}
-{% set pageDescription = 'Structure your page content and elements.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set dateUpdated = 'February 2019' %}
-{% set backlog_issue_id = '3' %}
+{% set pageTitle = "Layout" %}
+{% set pageDescription = "Structure your page content and elements." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "February 2019" %}
+{% set backlog_issue_id = "3" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/styles/_breadcrumb.njk' %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block sideNav %}
@@ -74,7 +74,7 @@
   <p class="rich-text">Use <code>.nhsuk-width-container</code> for a container with a maximum width of 960px.</p>
 
   {{ designExample({
-    type: 'layout-container',
+    type: "layout-container",
     htmlOnly: true,
     showExample: false
   }) }}
@@ -83,7 +83,7 @@
   <p class="rich-text">Use <code>.nhsuk-width-container-fluid</code> for a full width container, spanning the entire width of the viewport.</p>
 
   {{ designExample({
-    type: 'layout-container-fluid',
+    type: "layout-container-fluid",
     htmlOnly: true,
     showExample: false
   }) }}
@@ -93,7 +93,7 @@
   <p class="rich-text">There should be only one <code>main</code> element and it should have a unique id of <code>maincontent</code>, which allows keyboard-only users to skip to the main content on a page with the <a href="/design-system/components/skip-link">skip link component</a>.</p>
 
   {{ designExample({
-    type: 'layout-main',
+    type: "layout-main",
     htmlOnly: true,
     showExample: false
   }) }}
@@ -106,49 +106,49 @@
   <h3>Full width</h3>
 
   {{ designExample({
-    type: 'layout-full-width',
+    type: "layout-full-width",
     htmlOnly: true
   }) }}
 
   <h3>One-half</h3>
 
   {{ designExample({
-    type: 'layout-one-half',
+    type: "layout-one-half",
     htmlOnly: true
   }) }}
 
   <h3>Two-thirds</h3>
 
   {{ designExample({
-    type: 'layout-two-thirds',
+    type: "layout-two-thirds",
     htmlOnly: true
   }) }}
 
   <h3>One-third</h3>
 
   {{ designExample({
-    type: 'layout-one-third',
+    type: "layout-one-third",
     htmlOnly: true
   }) }}
 
   <h3>Three-quarters</h3>
 
   {{ designExample({
-    type: 'layout-three-quarters',
+    type: "layout-three-quarters",
     htmlOnly: true
   }) }}
 
   <h3>One-quarter</h3>
 
   {{ designExample({
-    type: 'layout-one-quarter',
+    type: "layout-one-quarter",
     htmlOnly: true
   }) }}
 
   <h3>Nested grids</h3>
 
   {{ designExample({
-    type: 'layout-nested',
+    type: "layout-nested",
     htmlOnly: true
   }) }}
 
@@ -157,14 +157,14 @@
   <h3 id="fixed-example">Two-thirds in a fixed-width container</h3>
 
   {{ designExample({
-    type: 'layout-two-thirds-container',
+    type: "layout-two-thirds-container",
     htmlOnly: true
   }) }}
 
   <h3 id="fluid-example">One-third / two-thirds in a fluid-width container</h3>
 
   {{ designExample({
-    type: 'layout-one-third-container-fluid',
+    type: "layout-one-third-container-fluid",
     htmlOnly: true
   }) }}
 
@@ -175,7 +175,7 @@
   <p class="rich-text">When using the fluid-width container or wider grid columns, wrap text content with <code>.nhsuk-u-reading-width</code> to apply a maximum width and limit the number of characters per line.</p>
 
   {{ designExample({
-    type: 'layout-reading-width',
+    type: "layout-reading-width",
     htmlOnly: true
   }) }}
 
@@ -184,7 +184,7 @@
   <p class="rich-text">To define your column sizes, add the utility class <code>.nhsuk-u-</code> followed by the width to an existing grid column, for example <code>.nhsuk-u-one-half</code> will set your column width to be one-half on all screen sizes.</p>
 
   {{ designExample({
-    type: 'layout-grid-tablet-mobile',
+    type: "layout-grid-tablet-mobile",
     htmlOnly: true
   }) }}
 
@@ -193,7 +193,7 @@
   <p class="rich-text">To define your column sizes, add the utility class <code>.nhsuk-u-</code> followed by the width and the suffix <code>-tablet</code> to an existing grid column. For example, <code>.nhsuk-u-one-third-tablet</code> will set your column width to be one-third on screen sizes tablet and above.</p>
 
   {{ designExample({
-    type: 'layout-grid-tablet',
+    type: "layout-grid-tablet",
     htmlOnly: true
   }) }}
 

--- a/app/views/design-system/styles/spacing.njk
+++ b/app/views/design-system/styles/spacing.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Spacing' %}
-{% set pageDescription = 'We\'ve followed the Government Design System\'s approach to spacing pages and setting the width of page elements so that they are consistent, responsive and clear. But we have adapted it for NHS-specific styles.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '24' %}
+{% set pageTitle = "Spacing" %}
+{% set pageDescription = "We've followed the Government Design System's approach to spacing pages and setting the width of page elements so that they are consistent, responsive and clear. But we have adapted it for NHS-specific styles." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "24" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/styles/_breadcrumb.njk' %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block sideNav %}
@@ -217,12 +217,12 @@
   <h3 id="spacing-examples" class="nhsuk-u-padding-top-3">Examples</h3>
 
   {{ designExample({
-    type: 'spacing',
+    type: "spacing",
     htmlOnly: true
   }) }}
 
   {{ designExample({
-    type: 'spacing-text',
+    type: "spacing-text",
     htmlOnly: true
   }) }}
 
@@ -251,7 +251,7 @@
   </ul>
 
   {{ designExample({
-    type: 'spacing-width',
+    type: "spacing-width",
     htmlOnly: true
   }) }}
 

--- a/app/views/design-system/styles/typography.njk
+++ b/app/views/design-system/styles/typography.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = 'Typography' %}
-{% set pageDescription = 'Our fonts and typographic styles, and how to apply them.' %}
-{% set pageSection = 'Design system' %}
-{% set subSection = 'Styles' %}
-{% set dateUpdated = 'November 2019' %}
-{% set backlog_issue_id = '1' %}
+{% set pageTitle = "Typography" %}
+{% set pageDescription = "Our fonts and typographic styles, and how to apply them." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "November 2019" %}
+{% set backlog_issue_id = "1" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'design-system/styles/_breadcrumb.njk' %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block sideNav %}
@@ -70,7 +70,7 @@
   <h2 id="headings">Headings</h2>
 
   {{ designExample({
-    type: 'typography-headings',
+    type: "typography-headings",
     htmlOnly: true
   }) }}
 
@@ -80,7 +80,7 @@
   <p>The default paragraph font size is 19px on large screens and 16px on small screens.</p>
 
   {{ designExample({
-    type: 'typography-body-m',
+    type: "typography-body-m",
     htmlOnly: true
   }) }}
 
@@ -91,7 +91,7 @@
 
 
   {{ designExample({
-    type: 'typography-body-l',
+    type: "typography-body-l",
     htmlOnly: true
   }) }}
 
@@ -100,7 +100,7 @@
   <p>The majority of your body copy should use the standard 19px paragraph size.</p>
 
   {{ designExample({
-    type: 'typography-body-s',
+    type: "typography-body-s",
     htmlOnly: true
   }) }}
 
@@ -111,7 +111,7 @@
   <p>The full NHS.UK typography scale goes from 14px up to 64px on large screens. You can add these font size override classes to any other typographic class or element and they will change the font size.</p>
 
   {{ designExample({
-    type: 'typography-sizes',
+    type: "typography-sizes",
     htmlOnly: true
   }) }}
 
@@ -119,7 +119,7 @@
   <p>As with the font size, you can add a font weight override class to any other typographic class or element to change the font weight to regular or bold weight.</p>
 
   {{ designExample({
-    type: 'typography-weight',
+    type: "typography-weight",
     htmlOnly: true
   }) }}
 
@@ -129,7 +129,7 @@
 
 
   {{ designExample({
-    type: 'typography-link',
+    type: "typography-link",
     htmlOnly: true
   }) }}
 
@@ -137,7 +137,7 @@
   <p>Use lists to make blocks of text easier to read, and to break information into manageable chunks.</p>
 
   {{ designExample({
-    type: 'typography-list',
+    type: "typography-list",
     htmlOnly: true
   }) }}
 
@@ -145,7 +145,7 @@
   <p>Introduce bulleted lists with a lead-in line ending in a colon. Start each item with a lowercase letter, and do not use a full stop at the end.</p>
 
   {{ designExample({
-    type: 'typography-ul',
+    type: "typography-ul",
     htmlOnly: true
   }) }}
 
@@ -154,7 +154,7 @@
   <p>You do not need to use a lead-in line for numbered lists. Items in a numbered list should end in a full stop because each should be a complete sentence.</p>
 
   {{ designExample({
-    type: 'typography-ol',
+    type: "typography-ol",
     htmlOnly: true
   }) }}
 
@@ -163,7 +163,7 @@
   <p class="rich-text">By default <code>nhsuk-section-break</code> is only visible by its margin. You can add the <code>nhsuk-section-break--visible</code> class to make it visible with a separator line.</p>
 
   {{ designExample({
-    type: 'typography-section-breaks',
+    type: "typography-section-breaks",
     htmlOnly: true
   }) }}
 

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -1,4 +1,4 @@
-{% if subSection === 'Styles' or subSection === 'Components' or subSection === 'Patterns' %}
+{% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
   <h2 class="nhsuk-u-padding-top-4">Help improve this page</h2>
 
   {% if backlog_issue_id %}
@@ -8,7 +8,7 @@
 
     <ul class="nhsukuk-list nhsuk-list--bullet">
       <li>
-        <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">share research or feedback about {% if subSection === 'Components' or subSection === 'Patterns' %}the {% endif %}{{pageTitle}}{% if subSection === 'Components' %} component{% endif %}{% if subSection === 'Patterns' %} pattern{% endif %} on GitHub</a>
+        <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">share research or feedback about {% if subSection === "Components" or subSection === "Patterns" %}the {% endif %}{{pageTitle}}{% if subSection === "Components" %} component{% endif %}{% if subSection === "Patterns" %} pattern{% endif %} on GitHub</a>
       </li>
       <li>
         <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual/blob/master/app/views/design-system/{{subSection|lower}}/{{pageTitle|lower|replace(" ", "-")}}.njk">propose a change to this page on GitHub</a>
@@ -16,7 +16,7 @@
     </ul>
   {% else %}
     <p>The service manual is a community effort. Anyone can help improve and grow it.</p>
-    {% if subSection === 'Styles' or subSection === 'Components' or subSection === 'Patterns' %}
+    {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
     <p>If you spot a problem with the {{pageTitle}} guidance you can <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual/blob/master/app/views/design-system/{{subSection|lower}}/{{pageTitle|lower|replace(" ", "-")}}.njk">propose a change</a>.</p>
     {% else %}
     <p>If you spot a problem with the {{pageTitle}} page you can <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual/blob/master/app/views/{{subSection|lower|replace(" ", "-")|replace("'", "")}}/{{pageTitle|lower|replace(" ", "-")|replace("'", "")}}.njk">propose a change</a>.</p>
@@ -25,7 +25,7 @@
 {% endif %}
 
 <div class="app-contact-panel">
-  {% if subSection === 'Styles' or subSection === 'Components' or subSection === 'Patterns' %}
+  {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
   <h2 class="app-contact-panel__heading">Need help?</h2>
   {% else %}
   <h2 class="app-contact-panel__heading">Get in touch</h2>

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -132,7 +132,7 @@
 
 <nav class="app-side-nav">
 
-  {%- if pageSection == 'NHS service standard' %}
+  {%- if pageSection == "NHS service standard" %}
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in serviceStandard %}
       <li class="app-side-nav__item{% if item.title == pageTitle %} app-side-nav__item--current{% endif %}"><a class="app-side-nav__link" href="{{ item.url }}">{{ item.title }}</a></li>
@@ -140,7 +140,7 @@
     </ul>
   {% endif %}
 
-  {%- if pageSection == 'Design system' and subSection != 'Styles' and subSection != 'Components' and subSection != 'Patterns' %}
+  {%- if pageSection == "Design system" and subSection != "Styles" and subSection != "Components" and subSection != "Patterns" %}
     <h2 class="app-side-nav__heading">Principles</h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in dsPrinciples %}
@@ -163,7 +163,7 @@
     </ul>
   {% endif %}
 
-  {%- if subSection == 'Styles' %}
+  {%- if subSection == "Styles" %}
     {{ backLink({
       "href": "/design-system",
       "text": "Design system",
@@ -177,7 +177,7 @@
     </ul>
   {% endif %}
 
-  {%- if subSection == 'Components' %}
+  {%- if subSection == "Components" %}
     {{ backLink({
       "href": "/design-system",
       "text": "Design system",
@@ -205,7 +205,7 @@
     </ul>
   {% endif %}
 
-  {%- if subSection == 'Patterns' %}
+  {%- if subSection == "Patterns" %}
     {{ backLink({
       "href": "/design-system",
       "text": "Design system",
@@ -226,7 +226,7 @@
     </ul>
   {% endif %}
 
-  {%- if pageSection == 'Accessibility' %}
+  {%- if pageSection == "Accessibility" %}
     <h2 class="app-side-nav__heading">Everyone needs to know</h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in accessibilityEveryone %}
@@ -242,7 +242,7 @@
     </ul>
   {% endif %}
 
-  {%- if pageSection == 'Content style guide' and subSection != 'Health literacy' and subSection != 'How to write good questions for forms'  %}
+  {%- if pageSection == "Content style guide" and subSection != "Health literacy" and subSection != "How to write good questions for forms"  %}
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in content %}
       <li class="app-side-nav__item{% if item.title == pageTitle %} app-side-nav__item--current{% endif %}"><a class="app-side-nav__link" href="{{ item.url }}">{{ item.title }}</a></li>
@@ -250,7 +250,7 @@
     </ul>
   {% endif %}
 
-  {%- if subSection == 'How to write good questions for forms' %}
+  {%- if subSection == "How to write good questions for forms" %}
     {{ backLink({
       "href": "/content",
       "text": "Content style guide",
@@ -264,7 +264,7 @@
     </ul>
   {% endif %}
 
-  {%- if subSection == 'Health literacy' %}
+  {%- if subSection == "Health literacy" %}
     {{ backLink({
       "href": "/content/health-literacy",
       "text": "Health literacy",
@@ -278,7 +278,7 @@
     </ul>
   {% endif %}
 
-  {%- if pageSection == 'Community' %}
+  {%- if pageSection == "Community" %}
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in community %}
       <li class="app-side-nav__item{% if item.title == pageTitle %} app-side-nav__item--current{% endif %}"><a class="app-side-nav__link" href="{{ item.url }}">{{ item.title }}</a></li>
@@ -286,7 +286,7 @@
     </ul>
   {% endif %}
 
-  {%- if pageSection == 'What\'s new' %}
+  {%- if pageSection == "What's new" %}
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in whatsNew %}
       <li class="app-side-nav__item{% if item.title == pageTitle %} app-side-nav__item--current{% endif %}"><a class="app-side-nav__link" href="{{ item.url }}">{{ item.title }}</a></li>

--- a/app/views/includes/app-layout-two-thirds.njk
+++ b/app/views/includes/app-layout-two-thirds.njk
@@ -7,7 +7,7 @@
     <h1 class="app-page-heading">{{pageTitle}}</h1>
 
 
-    {%- if hideDescription == "true" %}
+    {%- if hideDescription %}
     {% else %}
       <p class="nhsuk-lede-text app-lede-text">{{pageDescription}}</p>
     {% endif %}

--- a/app/views/includes/app-layout-two-thirds.njk
+++ b/app/views/includes/app-layout-two-thirds.njk
@@ -1,4 +1,4 @@
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
 {% block body %}
 <div class="nhsuk-grid-row">
@@ -7,7 +7,7 @@
     <h1 class="app-page-heading">{{pageTitle}}</h1>
 
 
-    {%- if hideDescription == 'true' %}
+    {%- if hideDescription == "true" %}
     {% else %}
       <p class="nhsuk-lede-text app-lede-text">{{pageDescription}}</p>
     {% endif %}

--- a/app/views/includes/app-layout.njk
+++ b/app/views/includes/app-layout.njk
@@ -1,4 +1,4 @@
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
 {% block body %}
 <div class="nhsuk-grid-row">
@@ -8,14 +8,14 @@
 
         <div class="app-pane__side-bar">
           {% block sideNav %}
-            {% include './_side-nav.njk' %}
+            {% include "./_side-nav.njk" %}
           {% endblock %}
         </div>
 
         <div class="app-pane__main-content">
 
           <h1 class="app-page-heading">
-            {%- if landingPage == 'true' or pageTitle == 'Community' or pageTitle == 'NHS service standard' %}
+            {%- if landingPage == "true" or pageTitle == "Community" or pageTitle == "NHS service standard" %}
             {% else %}
             <span class="nhsuk-caption-l">
               {%- if subSection %}
@@ -31,7 +31,7 @@
             </span>
             {% endif %}
             {{pageTitle}}
-            {%- if experimental == 'true' %}
+            {%- if experimental == "true" %}
             <div>
               <strong class="nhsuk-tag nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
                 Experimental
@@ -41,7 +41,7 @@
             {% endif %}
           </h1>
 
-          {%- if hideDescription == 'true' %}
+          {%- if hideDescription == "true" %}
           {% else %}
             <p class="nhsuk-lede-text app-lede-text">{{pageDescription}}</p>
           {% endif %}
@@ -50,9 +50,9 @@
           {% endblock %}
 
           {% block contactPanel %}
-            {%- if landingPage == 'true' or theme == 'Design' or theme == 'Content style guide' or pageTitle == 'Support' %}
+            {%- if landingPage == "true" or theme == "Design" or theme == "Content style guide" or pageTitle == "Support" %}
             {% else %}
-              {% include './_contact-panel.njk' %}
+              {% include "./_contact-panel.njk" %}
             {% endif %}
           {% endblock %}
 

--- a/app/views/includes/app-layout.njk
+++ b/app/views/includes/app-layout.njk
@@ -15,7 +15,7 @@
         <div class="app-pane__main-content">
 
           <h1 class="app-page-heading">
-            {%- if landingPage == "true" or pageTitle == "Community" or pageTitle == "NHS service standard" %}
+            {%- if landingPage or pageTitle == "Community" or pageTitle == "NHS service standard" %}
             {% else %}
             <span class="nhsuk-caption-l">
               {%- if subSection %}
@@ -31,7 +31,7 @@
             </span>
             {% endif %}
             {{pageTitle}}
-            {%- if experimental == "true" %}
+            {%- if experimental %}
             <div>
               <strong class="nhsuk-tag nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
                 Experimental
@@ -41,7 +41,7 @@
             {% endif %}
           </h1>
 
-          {%- if hideDescription == "true" %}
+          {%- if hideDescription %}
           {% else %}
             <p class="nhsuk-lede-text app-lede-text">{{pageDescription}}</p>
           {% endif %}
@@ -50,7 +50,7 @@
           {% endblock %}
 
           {% block contactPanel %}
-            {%- if landingPage == "true" or theme == "Design" or theme == "Content style guide" or pageTitle == "Support" %}
+            {%- if landingPage or theme == "Design" or theme == "Content style guide" or pageTitle == "Support" %}
             {% else %}
               {% include "./_contact-panel.njk" %}
             {% endif %}

--- a/app/views/includes/design-example.njk
+++ b/app/views/includes/design-example.njk
@@ -1,7 +1,7 @@
 {% macro designExample(params) %}
 
-{% set examplePath = 'app/components/' + params.type + '.njk' %}
-{% set standaloneURL = '/design-example/' + params.type + '?fullpage=' + params.fullpage %}
+{% set examplePath = "app/components/" + params.type + ".njk" %}
+{% set standaloneURL = "/design-example/" + params.type + "?fullpage=" + params.fullpage %}
 
 {# `showExample` is true, unless explicitly turned off with params #}
 {% set showExample = params.showExample !== false %}

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -110,7 +110,7 @@
 
     {% block outerBody %}{% endblock %}
 
-    {%- if beta == "true" %}
+    {%- if beta %}
     {% include "includes/_beta-banner.njk" %}
     {% endif %}
 

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -53,7 +53,7 @@
     <!-- Cookie consent -->
     <script src="/{{VERSION}}/js/cookies.min.js" data-policy-url="/cookie-policy"></script>
 
-    {%- if ENVIRONMENT == 'production' %}
+    {%- if ENVIRONMENT == "production" %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script src="https://www.googletagmanager.com/gtag/js?id=UA-9510975-7" data-cookieconsent="statistics" type="text/plain" async></script>
     <script data-cookieconsent="statistics" type="text/plain" >
@@ -99,7 +99,7 @@
   <body>
     <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
 
-    {% include 'includes/_header-prototype.njk' %}
+    {% include "includes/_header-prototype.njk" %}
 
     {% block breadcrumb %}
       {{ breadcrumb({
@@ -110,11 +110,11 @@
 
     {% block outerBody %}{% endblock %}
 
-    {%- if beta == 'true' %}
-    {% include 'includes/_beta-banner.njk' %}
+    {%- if beta == "true" %}
+    {% include "includes/_beta-banner.njk" %}
     {% endif %}
 
-    {% if pageLayout != 'Homepage' %}
+    {% if pageLayout != "Homepage" %}
     <div class="nhsuk-width-container">
       <main class="nhsuk-main-wrapper app-main-wrapper" id="maincontent">
         {% block body %}{% endblock %}
@@ -122,7 +122,7 @@
     </div>
     {% endif %}
 
-    {% include 'includes/_footer.njk' %}
+    {% include "includes/_footer.njk" %}
 
     {% block pageScripts %}{% endblock %}
   </body>

--- a/app/views/includes/search.njk
+++ b/app/views/includes/search.njk
@@ -1,8 +1,8 @@
-{% set pageTitle = 'Search' %}
-{% set pageDescription = 'Search results.' %}
+{% set pageTitle = "Search" %}
+{% set pageDescription = "Search results." %}
 {% set disableSearch = true %}
 
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
 {% block body %}
   <div class="nhsuk-grid-row">

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -1,11 +1,11 @@
-{% set pageDescription = 'Design and build digital services for the NHS. Things you need to make consistent, usable services that put people first.' %}
+{% set pageDescription = "Design and build digital services for the NHS. Things you need to make consistent, usable services that put people first." %}
 {% set pageLayout = "Homepage" %}
-{% set pageSection = 'Home' %}
+{% set pageSection = "Home" %}
 
-{% extends 'includes/layout.njk' %}
+{% extends "includes/layout.njk" %}
 
-{% from 'hero/macro.njk' import hero %}
-{% from 'promo/macro.njk' import promo%}
+{% from "hero/macro.njk" import hero %}
+{% from "promo/macro.njk" import promo %}
 
 {% block breadcrumb %}{% endblock %}
 

--- a/app/views/page-not-found.njk
+++ b/app/views/page-not-found.njk
@@ -1,5 +1,5 @@
 {% set pageTitle = "We can’t find the page you’re looking for" %}
-{% set hideDescription = "true" %}
+{% set hideDescription = true %}
 {% set disableSearch = true %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}

--- a/app/views/page-not-found.njk
+++ b/app/views/page-not-found.njk
@@ -1,8 +1,8 @@
-{% set pageTitle = 'We can’t find the page you’re looking for' %}
-{% set hideDescription = 'true' %}
+{% set pageTitle = "We can’t find the page you’re looking for" %}
+{% set hideDescription = "true" %}
 {% set disableSearch = true %}
 
-{% extends 'includes/app-layout-two-thirds.njk' %}
+{% extends "includes/app-layout-two-thirds.njk" %}
 
 {% block bodyContent %}
 

--- a/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
+++ b/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '1. Understand users and their needs in the context of health and care' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Take time to understand your users\' clinical, practical and emotional needs - and their abilities - and the problem you\'re trying to solve for them.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "1. Understand users and their needs in the context of health and care" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Take time to understand your users' clinical, practical and emotional needs - and their abilities - and the problem you're trying to solve for them." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
+++ b/app/views/service-standard/1-understand-users-and-their-needs-context-health-and-care.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "1. Understand users and their needs in the context of health and care" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Take time to understand your users' clinical, practical and emotional needs - and their abilities - and the problem you're trying to solve for them." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
+++ b/app/views/service-standard/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "10. Define what success looks like and be open about how your service is performing" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Work out how your service helps improve health and well being, people's experience of health and care, and the efficiency of the health service and how you will know that you're succeeding." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
+++ b/app/views/service-standard/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '10. Define what success looks like and be open about how your service is performing' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Work out how your service helps improve health and well being, people\'s experience of health and care, and the efficiency of the health service and how you will know that you\'re succeeding.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "10. Define what success looks like and be open about how your service is performing" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Work out how your service helps improve health and well being, people's experience of health and care, and the efficiency of the health service and how you will know that you're succeeding." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/11-choose-the-right-tools-and-technology.njk
+++ b/app/views/service-standard/11-choose-the-right-tools-and-technology.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "11. Choose the right tools and technology" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Choose tools and technology that let you build a good service in an efficient, cost effective way." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/11-choose-the-right-tools-and-technology.njk
+++ b/app/views/service-standard/11-choose-the-right-tools-and-technology.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '11. Choose the right tools and technology' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Choose tools and technology that let you build a good service in an efficient, cost effective way.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "11. Choose the right tools and technology" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Choose tools and technology that let you build a good service in an efficient, cost effective way." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/12-make-new-source-code-open.njk
+++ b/app/views/service-standard/12-make-new-source-code-open.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '12. Make new source code open' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Make all new source code open and reusable, and publish it under appropriate licences.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "12. Make new source code open" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Make all new source code open and reusable, and publish it under appropriate licences." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/12-make-new-source-code-open.njk
+++ b/app/views/service-standard/12-make-new-source-code-open.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "12. Make new source code open" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Make all new source code open and reusable, and publish it under appropriate licences." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/13-use-and-contribute-to-open-standards-common-components-and-patterns.njk
+++ b/app/views/service-standard/13-use-and-contribute-to-open-standards-common-components-and-patterns.njk
@@ -1,8 +1,8 @@
 {% set pageTitle = "13. Use and contribute to open standards, common components and patterns" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Use tried and tested components and patterns from the NHS digital service manual or, failing that, the GOV.UK Design System." %}
-{% set beta = "true" %}
-{% set hideDescription = "true" %}
+{% set beta = true %}
+{% set hideDescription = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/13-use-and-contribute-to-open-standards-common-components-and-patterns.njk
+++ b/app/views/service-standard/13-use-and-contribute-to-open-standards-common-components-and-patterns.njk
@@ -1,14 +1,14 @@
-{% set pageTitle = '13. Use and contribute to open standards, common components and patterns' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Use tried and tested components and patterns from the NHS digital service manual or, failing that, the GOV.UK Design System.' %}
-{% set beta = 'true' %}
-{% set hideDescription = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "13. Use and contribute to open standards, common components and patterns" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Use tried and tested components and patterns from the NHS digital service manual or, failing that, the GOV.UK Design System." %}
+{% set beta = "true" %}
+{% set hideDescription = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/14-operate-a-reliable-service.njk
+++ b/app/views/service-standard/14-operate-a-reliable-service.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '14. Operate a reliable service' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'People need the NHS 24 hours a day, every day of the year. Minimise service downtime and have a plan to deal with it when it does happen.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "14. Operate a reliable service" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "People need the NHS 24 hours a day, every day of the year. Minimise service downtime and have a plan to deal with it when it does happen." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/14-operate-a-reliable-service.njk
+++ b/app/views/service-standard/14-operate-a-reliable-service.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "14. Operate a reliable service" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "People need the NHS 24 hours a day, every day of the year. Minimise service downtime and have a plan to deal with it when it does happen." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/15-support-a-culture-of-care.njk
+++ b/app/views/service-standard/15-support-a-culture-of-care.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '15. Support a culture of care' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Caring is the core business of the NHS. NHS services should provide a positive experience of care or help NHS staff provide a caring service.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "15. Support a culture of care" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Caring is the core business of the NHS. NHS services should provide a positive experience of care or help NHS staff provide a caring service." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/15-support-a-culture-of-care.njk
+++ b/app/views/service-standard/15-support-a-culture-of-care.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "15. Support a culture of care" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Caring is the core business of the NHS. NHS services should provide a positive experience of care or help NHS staff provide a caring service." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/16-make-your-service-clinically-safe.njk
+++ b/app/views/service-standard/16-make-your-service-clinically-safe.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '16. Make your service clinically safe' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Digital information, tools and services have the potential to cause patient harm.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "16. Make your service clinically safe" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Digital information, tools and services have the potential to cause patient harm." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/16-make-your-service-clinically-safe.njk
+++ b/app/views/service-standard/16-make-your-service-clinically-safe.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "16. Make your service clinically safe" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Digital information, tools and services have the potential to cause patient harm." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/17-make-your-service-interoperable.njk
+++ b/app/views/service-standard/17-make-your-service-interoperable.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "17. Make your service interoperable" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "In an organisation as diverse and complex as the NHS, we need systems and services which talk to each other. Build for interoperability to share patient records and get data quickly from one place to another." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "January 2020" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/17-make-your-service-interoperable.njk
+++ b/app/views/service-standard/17-make-your-service-interoperable.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '17. Make your service interoperable' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'In an organisation as diverse and complex as the NHS, we need systems and services which talk to each other. Build for interoperability to share patient records and get data quickly from one place to another.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "17. Make your service interoperable" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "In an organisation as diverse and complex as the NHS, we need systems and services which talk to each other. Build for interoperability to share patient records and get data quickly from one place to another." %}
+{% set beta = "true" %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
+++ b/app/views/service-standard/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
@@ -1,14 +1,14 @@
 
-{% set pageTitle = 'Work towards solving a whole problem for users and provide a joined up experience across all channels (2. and 3.)' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Consider where your service fits in your users\' healthcare journey and whether you can solve a whole problem or influence a wider solution.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "Work towards solving a whole problem for users and provide a joined up experience across all channels (2. and 3.)" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Consider where your service fits in your users' healthcare journey and whether you can solve a whole problem or influence a wider solution." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
+++ b/app/views/service-standard/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
@@ -2,7 +2,7 @@
 {% set pageTitle = "Work towards solving a whole problem for users and provide a joined up experience across all channels (2. and 3.)" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Consider where your service fits in your users' healthcare journey and whether you can solve a whole problem or influence a wider solution." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/4-make-the-service-simple-to-use.njk
+++ b/app/views/service-standard/4-make-the-service-simple-to-use.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "4. Make the service simple to use" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Build a service that's simple to use so that people can succeed first time. Test with users to make sure it works for them." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/4-make-the-service-simple-to-use.njk
+++ b/app/views/service-standard/4-make-the-service-simple-to-use.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '4. Make the service simple to use' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Build a service that\'s simple to use so that people can succeed first time. Test with users to make sure it works for them.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "4. Make the service simple to use" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Build a service that's simple to use so that people can succeed first time. Test with users to make sure it works for them." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "5. Make sure everyone can use the service" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Make sure people with different physical, mental health, social, cultural or learning needs can use your service, whether it's for the public or staff." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '5. Make sure everyone can use the service' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Make sure people with different physical, mental health, social, cultural or learning needs can use your service, whether it\'s for the public or staff.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "5. Make sure everyone can use the service" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Make sure people with different physical, mental health, social, cultural or learning needs can use your service, whether it's for the public or staff." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
+++ b/app/views/service-standard/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '6. Create a team that includes multidisciplinary skills and perspectives' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Make sure you have the right - and diverse - skills and roles to build and operate the service.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "6. Create a team that includes multidisciplinary skills and perspectives" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Make sure you have the right - and diverse - skills and roles to build and operate the service." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
+++ b/app/views/service-standard/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "6. Create a team that includes multidisciplinary skills and perspectives" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Make sure you have the right - and diverse - skills and roles to build and operate the service." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/7-use-agile-ways-of-working.njk
+++ b/app/views/service-standard/7-use-agile-ways-of-working.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "7. Use agile ways of working" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Make sure that the team can deliver quickly and adapt to meet users' needs." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/7-use-agile-ways-of-working.njk
+++ b/app/views/service-standard/7-use-agile-ways-of-working.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '7. Use agile ways of working' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Make sure that the team can deliver quickly and adapt to meet users\' needs.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "7. Use agile ways of working" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Make sure that the team can deliver quickly and adapt to meet users' needs." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/8-iterate-and-improve-frequently.njk
+++ b/app/views/service-standard/8-iterate-and-improve-frequently.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "8. Iterate and improve frequently" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Make sure you have the capacity, resources and technical flexibility to iterate and improve the service frequently." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/8-iterate-and-improve-frequently.njk
+++ b/app/views/service-standard/8-iterate-and-improve-frequently.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '8. Iterate and improve frequently'%}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Make sure you have the capacity, resources and technical flexibility to iterate and improve the service frequently.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "8. Iterate and improve frequently" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Make sure you have the capacity, resources and technical flexibility to iterate and improve the service frequently." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/9-respect-and-protect-users-confidentiality-and-privacy.njk
+++ b/app/views/service-standard/9-respect-and-protect-users-confidentiality-and-privacy.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "9. Respect and protect users’ confidentiality and privacy" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "Evaluate what data and information your service will be collecting, storing and providing." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/9-respect-and-protect-users-confidentiality-and-privacy.njk
+++ b/app/views/service-standard/9-respect-and-protect-users-confidentiality-and-privacy.njk
@@ -1,13 +1,13 @@
-{% set pageTitle = '9. Respect and protect users’ confidentiality and privacy' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'Evaluate what data and information your service will be collecting, storing and providing.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "9. Respect and protect users’ confidentiality and privacy" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "Evaluate what data and information your service will be collecting, storing and providing." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/about.njk
+++ b/app/views/service-standard/about.njk
@@ -2,7 +2,7 @@
 {% set pageTitle = "About the NHS service standard" %}
 {% set pageSection = "NHS service standard" %}
 {% set pageDescription = "The NHS service standard is designed to help teams meet the GOV.UK service standard in the context of health and care." %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/service-standard/about.njk
+++ b/app/views/service-standard/about.njk
@@ -1,14 +1,14 @@
 
-{% set pageTitle = 'About the NHS service standard' %}
-{% set pageSection = 'NHS service standard' %}
-{% set pageDescription = 'The NHS service standard is designed to help teams meet the GOV.UK service standard in the context of health and care.' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "About the NHS service standard" %}
+{% set pageSection = "NHS service standard" %}
+{% set pageDescription = "The NHS service standard is designed to help teams meet the GOV.UK service standard in the context of health and care." %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'service-standard/_breadcrumb.njk' %}
+  {% include "service-standard/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/service-standard/index.njk
+++ b/app/views/service-standard/index.njk
@@ -1,10 +1,10 @@
-{% set pageTitle = 'NHS service standard' %}
-{% set pageDescription = 'This NHS companion to the GOV.UK service standard will help you check that you\'re working to best practice from the start.' %}
-{% set pageSection = 'NHS service standard' %}
-{% set beta = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "NHS service standard" %}
+{% set pageDescription = "This NHS companion to the GOV.UK service standard will help you check that you're working to best practice from the start." %}
+{% set pageSection = "NHS service standard" %}
+{% set beta = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block bodyContent %}
 

--- a/app/views/service-standard/index.njk
+++ b/app/views/service-standard/index.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "NHS service standard" %}
 {% set pageDescription = "This NHS companion to the GOV.UK service standard will help you check that you're working to best practice from the start." %}
 {% set pageSection = "NHS service standard" %}
-{% set beta = "true" %}
+{% set beta = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/sitemap.njk
+++ b/app/views/sitemap.njk
@@ -1,9 +1,9 @@
-{% set pageTitle = 'Sitemap' %}
-{% set pageDescription = 'A list of pages on this website - with links' %}
-{% set hideDescription = 'true' %}
-{% set dateUpdated = 'December 2019' %}
+{% set pageTitle = "Sitemap" %}
+{% set pageDescription = "A list of pages on this website - with links" %}
+{% set hideDescription = "true" %}
+{% set dateUpdated = "December 2019" %}
 
-{% extends 'includes/app-layout-two-thirds.njk' %}
+{% extends "includes/app-layout-two-thirds.njk" %}
 
 {% block bodyContent %}
 

--- a/app/views/sitemap.njk
+++ b/app/views/sitemap.njk
@@ -1,6 +1,6 @@
 {% set pageTitle = "Sitemap" %}
 {% set pageDescription = "A list of pages on this website - with links" %}
-{% set hideDescription = "true" %}
+{% set hideDescription = true %}
 {% set dateUpdated = "December 2019" %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}

--- a/app/views/terms-and-conditions.njk
+++ b/app/views/terms-and-conditions.njk
@@ -1,8 +1,8 @@
-{% set pageTitle = 'Terms and conditions' %}
-{% set pageDescription = 'This website is operated by NHS Digital. These terms govern your use of the NHS digital service manual.' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Terms and conditions" %}
+{% set pageDescription = "This website is operated by NHS Digital. These terms govern your use of the NHS digital service manual." %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout-two-thirds.njk' %}
+{% extends "includes/app-layout-two-thirds.njk" %}
 
 {% block bodyContent %}
 

--- a/app/views/whats-new/blog-posts.njk
+++ b/app/views/whats-new/blog-posts.njk
@@ -1,11 +1,11 @@
-{% set pageTitle = 'Blog posts' %}
-{% set pageDescription = 'Posts by the service manual team and community.' %}
-{% set pageSection = 'What\'s new' %}
+{% set pageTitle = "Blog posts" %}
+{% set pageDescription = "Posts by the service manual team and community." %}
+{% set pageSection = "What's new" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'whats-new/_breadcrumb.njk' %}
+  {% include "whats-new/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "What's new" %}
 {% set pageDescription = "Find out what's happening with the service manual." %}
 {% set pageSection = "What's new" %}
-{% set landingPage = "true" %}
+{% set landingPage = true %}
 
 {% extends "includes/app-layout.njk" %}
 

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -1,9 +1,9 @@
-{% set pageTitle = 'What\'s new' %}
-{% set pageDescription = 'Find out what\'s happening with the service manual.' %}
-{% set pageSection = 'What\'s new' %}
-{% set landingPage = 'true' %}
+{% set pageTitle = "What's new" %}
+{% set pageDescription = "Find out what's happening with the service manual." %}
+{% set pageSection = "What's new" %}
+{% set landingPage = "true" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block bodyContent %}
 

--- a/app/views/whats-new/show-and-tells.njk
+++ b/app/views/whats-new/show-and-tells.njk
@@ -1,11 +1,11 @@
-{% set pageTitle = 'Show and tells' %}
-{% set pageDescription = 'Watch the team talk about the work behind the service manual.' %}
-{% set pageSection = 'What\'s new' %}
+{% set pageTitle = "Show and tells" %}
+{% set pageDescription = "Watch the team talk about the work behind the service manual." %}
+{% set pageSection = "What's new" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'whats-new/_breadcrumb.njk' %}
+  {% include "whats-new/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -1,11 +1,11 @@
-{% set pageTitle = 'Updates' %}
-{% set pageDescription = 'Updates to the service manual.' %}
-{% set pageSection = 'What\'s new' %}
+{% set pageTitle = "Updates" %}
+{% set pageDescription = "Updates to the service manual." %}
+{% set pageSection = "What's new" %}
 
-{% extends 'includes/app-layout.njk' %}
+{% extends "includes/app-layout.njk" %}
 
 {% block breadcrumb %}
-  {% include 'whats-new/_breadcrumb.njk' %}
+  {% include "whats-new/_breadcrumb.njk" %}
 {% endblock %}
 
 {% block bodyContent %}

--- a/app/views/your-privacy.njk
+++ b/app/views/your-privacy.njk
@@ -1,8 +1,8 @@
-{% set pageTitle = 'Your privacy' %}
-{% set pageDescription = 'Your privacy is important to us. This privacy policy covers what we collect and how we use, share and store your information.' %}
-{% set dateUpdated = 'January 2020' %}
+{% set pageTitle = "Your privacy" %}
+{% set pageDescription = "Your privacy is important to us. This privacy policy covers what we collect and how we use, share and store your information." %}
+{% set dateUpdated = "January 2020" %}
 
-{% extends 'includes/app-layout-two-thirds.njk' %}
+{% extends "includes/app-layout-two-thirds.njk" %}
 
 {% block bodyContent %}
 


### PR DESCRIPTION
- Use double quotes (") instead of single quotes (') in the Nunjucks markup. This is common practice and allows us to use single quotes in content without having to escape them.
- Use booleans instead of strings for true and false statements 