### PR TITLE
Update What's new, footer and A to Z

### DIFF
--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -113,8 +113,8 @@
       <h3 id="absorb">absorb</h3>
       <p>We use "take in".</p>
       <h3 id="acute">acute</h3>
-      <p>We prefer "sudden" or "develops suddenly" or "in a short period of time".</p>
-      <p>We do use "acute" in the names of conditions like "acute lymphoblastic leukaemia". We also use it if we think that people will hear their doctor use the word "acute" or that people will search for it. If we use it, we explain what it means.</p>
+      <p>We prefer "sudden", "starts suddenly", "in a short period of time" or, where appropriate, "short-term".</p>
+      <p>We do use "acute" in the names of conditions like "acute lymphoblastic leukaemia". We also use it if our search analytics, user testing or survey feedback suggest that people will hear their doctor use the word "acute" or will search for it. If we use it, we explain what it means.</p>
       <h3 id="affects">affects</h3>
       <p>It’s alright to use "affects" but in some contexts, for example with medicines, it can be better to say that "something changes the way something else works". </p>
       <p>Check a dictionary if you’re not sure of the difference between "affect" and "effect".</p>
@@ -212,7 +212,7 @@
       <h3 id="chronic">chronic</h3>
       <p>We prefer "for a long time" or "does not go away".</p>
       <p>We have seen evidence that the word "chronic" confuses people. Some people think it means "bad" or "serious".</p>
-      <p>We do use "chronic" in the names of conditions like "chronic fatigue syndrome". We also use it if we think that people will hear their doctor use the word or that they will search for it, for example in "chronic back pain". If we use it, we explain what "chronic" means.</p>
+      <p>We do use "chronic" in the names of conditions like "chronic fatigue syndrome". We also use it if our search analytics, user testing or survey feedback suggest that people will hear their doctor use the word "chronic" or will search for it. If we use it, we explain what "chronic" means.</p>
       <h3 id="CJD">CJD</h3>
       <p>We use "CJD" – or "variant CJD (vCJD)" as the human form of BSE.</p>
       <p>Use full name "Creutzfeldt-Jakob disease" when you first mention CJD.</p>
@@ -434,7 +434,7 @@
       <h2 id="K">K</h2>
       <h3 id="kidney">kidney</h3>
       <p>We use "kidney" instead of "renal".</p>
-      <p>We may mention "renal" as well as "kidney" if we think that people are likely to hear their doctor use "renal" or that they will search for it.</p>
+      <p>We may mention "renal" as well as "kidney" if our search analytics, user testing or survey feedback suggest that people will hear their doctor use "renal" or will search for it.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
         <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
           <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
@@ -641,7 +641,7 @@
       <p>We say "kidneys that don’t work well".</p>
       <h3 id="renal">renal</h3>
       <p>We prefer "kidney".</p>
-      <p>We may mention "renal" as well as "kidney" if we think that people are likely to hear their doctor use "renal" or that they will search for it.</p>
+      <p>We may mention "renal" as well as "kidney" if our search analytics, user testing or survey feedback suggest that people will hear their doctor use "renal" or will search for it.</p>
       <h3 id="risk-and-risk-factors">risk and risk factors</h3>
       <p>We prefer "chance" to "risk" when we’re writing for the public.</p>
       <p>We try not to talk about "risk factors" and instead explain them some other way.</p>

--- a/app/views/includes/_footer.njk
+++ b/app/views/includes/_footer.njk
@@ -3,11 +3,12 @@
     <div class="nhsuk-width-container">
       <h2 class="nhsuk-u-visually-hidden">Support links</h2>
       <ul class="nhsuk-footer__list">
-        <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/whats-new">What's new</a></li>
+
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/accessibility-statement">Accessibility statement</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/cookie-policy">Cookie policy</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/sitemap">Sitemap</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/terms-and-conditions">Terms and conditions</a></li>
+        <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/whats-new">What's new</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/your-privacy">Your privacy</a></li>
       </ul>
       <p class="nhsuk-footer__copyright">&copy; Crown copyright</p>

--- a/app/views/whats-new/blog-posts.njk
+++ b/app/views/whats-new/blog-posts.njk
@@ -25,10 +25,22 @@
 
   <ul class="nhsuk-list nhsuk-list--border nhsuk-u-margin-bottom-5">
     <li>
+      <a href="https://medium.com/@mattedgar/more-serene-two-and-a-half-years-into-my-work-at-nhs-digital-part-3-598e0d588941" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">More serene: two and a half years into my work at NHS Digital — part 3</a>
+      <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Published on: </span>18 December 2019</p>
+      <p class="app-meta-data nhsuk-u-margin-bottom-2">Medium blog</p>
+      <p>Matt Edgar rounds off his reflections, with a look at the NHS Long Term Plan, his objectives for the next 6 months, and a nod back to the beginnings of the NHS.</p>
+    </li>
+    <li>
       <a href="https://digital.nhs.uk/blog/transformation-blog/2019/how-to-write-good-questions" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">How to write good questions</a>
       <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Published on: </span>21 November 2019</p>
       <p class="app-meta-data nhsuk-u-margin-bottom-2">NHS digital transformation blog</p>
       <p>The NHS digital service manual team has published some new forms guidance that will help digital health teams design better forms and transactional services. Content designer Sara Wilcox explains how and why it was done.</p>
+    </li>
+     <li>
+      <a href="https://medium.com/@deanvipond/building-a-diverse-design-team-in-challenging-circumstances-7bfd17f8415c" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">Building a diverse design team in challenging circumstances</a>
+      <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Published on: </span>18 October 2019</p>
+      <p class="app-meta-data nhsuk-u-margin-bottom-2">Medium blog</p>
+      <p>Growing a diverse team, from a profession which is not diverse, in an environment where your profession is not fully accepted, with tools and processes which can exclude, is a huge challenge. By Dean Vipond</p>
     </li>
     <li>
       <a href="https://digital.nhs.uk/blog/transformation-blog/2019/the-nhs-digital-service-manual-needs-you" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">The NHS digital service manual needs you</a>
@@ -52,7 +64,7 @@
       <a href="https://medium.com/@ianroddis/bravo-gds-on-the-new-service-standard-that-ensures-and-assures-quality-might-we-talk-about-health-cff3f4db9743" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">Bravo GDS on the new Service Standard that ensures and assures quality, might we talk about health?</a>
       <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Published on: </span>10 May 2019</p>
       <p class="app-meta-data nhsuk-u-margin-bottom-2">Medium blog</p>
-      <p>With the latest iteration of the GDS service standard now covering full, end-to-end (not just digital) services, I’ve been thinking about how it might work when applied in a healthcare setting, and if it can be combined with other healthcare assurance models.</p>
+      <p>With the latest iteration of the GDS service standard now covering full, end-to-end (not just digital) services, I’ve been thinking about how it might work when applied in a healthcare setting, and if it can be combined with other healthcare assurance models. By Ian Roddis.</p>
     </li>
     <li>
       <a href="https://digital.nhs.uk/blog/transformation-blog/2019/icons-avoid-temptation-and-start-with-user-needs" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">Icons: avoid temptation and start with user needs</a>
@@ -64,13 +76,13 @@
       <a href="https://medium.com/@ianroddis/the-path-of-user-needs-avoiding-beautiful-nonsense-and-the-shelves-of-wisdom-fe19a9b7bff3" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">The path of user needs, avoiding beautiful nonsense, and the shelves of wisdom</a>
       <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Published on: </span>1 March 2019</p>
       <p class="app-meta-data nhsuk-u-margin-bottom-2">Medium blog</p>
-      <p>At work we like a good metaphor, even more so if we can tweet about it in an abstract fashion without revealing too much of the inner workings of our professional lives. So this post is going to freely use a couple of metaphors to put in context the brilliant work we’ve been doing on a frontend library and prototyping kit we hope will be used heavily across the health system.</p>
+      <p>At work we like a good metaphor, even more so if we can tweet about it in an abstract fashion without revealing too much of the inner workings of our professional lives. So this post is going to freely use a couple of metaphors to put in context the brilliant work we’ve been doing on a frontend library and prototyping kit we hope will be used heavily across the health system. By Ian Roddis.</p>
     </li>
      <li>
       <a href="https://medium.com/@ianroddis/the-role-of-standards-in-a-fragmented-ecosystem-b79094c3920e" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">The role of standards in a fragmented ecosystem</a>
       <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Published on: </span>18 February 2019</p>
       <p class="app-meta-data nhsuk-u-margin-bottom-2">Medium blog</p>
-      <p>I’ve been thinking about the role of standards, and how they can help in the complex sector I’m working in — that of health in England. </p>
+      <p>I’ve been thinking about the role of standards, and how they can help in the complex sector I’m working in — that of health in England. By Ian Roddis.</p>
     </li>
     <li>
       <a href="https://digital.nhs.uk/blog/transformation-blog/2019/pee-and-poo-and-the-language-of-health" class="nhsuk-heading-m nhsuk-u-margin-bottom-2">Pee and poo and the language of health</a>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -21,6 +21,10 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr class="nhsuk-table__row">
+        <td class="nhsuk-table__cell">Site wide</td>
+        <td class="nhsuk-table__cell"><p class="nhsuk-u-margin-bottom-0">Moved service manual from "beta" to "live". Added main, side and in-page navigation and other design changes</p></td>
+      </tr>
+      <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">Community</td>
         <td class="nhsuk-table__cell"><p class="nhsuk-u-margin-bottom-0">Added new page: <a href="/community/backlog-of-components-and-patterns">Backlog of components and patterns</a></p></td>
       </tr>
@@ -32,10 +36,6 @@
       <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell"><p>Added a <a href="/design-system/components/hint-text">Hint text</a> page to components after research showed users did not look for it in text input and other components</p></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Get in touch</td>
-        <td class="nhsuk-table__cell"><p class="nhsuk-u-margin-bottom-0">Added "Need help?" and "Get in touch" to pages across the site</p></td>
       </tr>
       <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">What's new</td>
@@ -81,6 +81,9 @@
 
   <h2>Latest show and tell</h2>
   <p>Watch the team talk about the work behind the service manual.</p>
+  <h3>Next public show and tell</h3>
+  <p>We're holding our next show and tell on <strong>Thursday 13 February</strong>. <a href="https://www.eventbrite.co.uk/e/nhs-digital-service-manual-show-tell-registration-91150727279">Register via Eventbrite</a>.</p>
+  <h3>Last show and tell</h3>
   <div class="nhsuk-grid-row nhsuk-promo-group">
     <div class="nhsuk-grid-column-full nhsuk-promo-group__item">
       <div class="nhsuk-promo app-promo--video">

--- a/app/views/whats-new/show-and-tells.njk
+++ b/app/views/whats-new/show-and-tells.njk
@@ -9,7 +9,9 @@
 {% endblock %}
 
 {% block bodyContent %}
-
+  <h2>Next public show and tell</h2>
+  <p>We're holding our next show and tell on <strong>Thursday 13 February</strong>. <a href="https://www.eventbrite.co.uk/e/nhs-digital-service-manual-show-tell-registration-91150727279">Register via Eventbrite</a>.</p>
+  <h2>Previous show and tells</h2>
   <div class="nhsuk-grid-row nhsuk-promo-group">
     <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
       <div class="nhsuk-promo app-promo--video">

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -21,6 +21,10 @@
       </tr>
     </thead>
     <tbody class="nhsuk-table__body">
+    <tr class="nhsuk-table__row">
+        <td class="nhsuk-table__cell">Site wide</td>
+        <td class="nhsuk-table__cell"><p>Moved service manual from "beta" to "live". Added main, side and in-page navigation and other design changes</p></td>
+      </tr>
       <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">Community</td>
         <td class="nhsuk-table__cell"><p>Added new page: <a href="/community/backlog-of-components-and-patterns">Backlog of components and patterns</a></p></td>


### PR DESCRIPTION
Add 2 more blog posts and info about upcoming show and tell.
Push accessibility to front of footer.
Amend wording re acute, chronic, kidney and renal in A to Z of NHS writing after Style Council meeting.