### PR TITLE
Fix YouTube cookies and remove unused cookie from policy page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Remove reference to the Oxford Dictionary for Writers and Editors on content style guide hub page and include contact details instead
 - Use the latest version of the NHS.UK frontend library (3.0.3)
 - Use the no cookie version of YouTube video embedding
+- Remove unused cookie (ARRAffinity) from the cookie policy page as we no longer set this cookie
 
 ## 3.0.4 - 12 February 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improve guidance on ordinal numbers on Numbers, measurements, dates and time page
 - Remove reference to the Oxford Dictionary for Writers and Editors on content style guide hub page and include contact details instead
 - Use the latest version of the NHS.UK frontend library (3.0.3)
+- Use the no cookie version of YouTube video embedding
 
 ## 3.0.4 - 12 February 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # NHS digital service manual Changelog
 
-## 3.0.5 - 19 February 2020
+## 3.0.6 - 19 February 2020
+
+- Use the no cookie version of YouTube video embedding
+- Remove unused cookie (ARRAffinity) from the cookie policy page as we no longer set this cookie
+
+## 3.0.5 - 18 February 2020
 
 :new: **New content**
 
@@ -16,8 +21,6 @@
 - Improve guidance on ordinal numbers on Numbers, measurements, dates and time page
 - Remove reference to the Oxford Dictionary for Writers and Editors on content style guide hub page and include contact details instead
 - Use the latest version of the NHS.UK frontend library (3.0.3)
-- Use the no cookie version of YouTube video embedding
-- Remove unused cookie (ARRAffinity) from the cookie policy page as we no longer set this cookie
 
 ## 3.0.4 - 12 February 2020
 

--- a/app/views/cookie-policy.njk
+++ b/app/views/cookie-policy.njk
@@ -48,11 +48,6 @@
             </thead>
             <tbody class="nhsuk-table__body">
               <tr class="nhsuk-table__row" role="row">
-                <td class="nhsuk-table__cell" role="cell" data-label="Cookie name">ARRAffinity</td>
-                <td class="nhsuk-table__cell" role="cell" data-label="Purpose">Helps our website work faster.</td>
-                <td class="nhsuk-table__cell" role="cell" data-label="Expiry">When you close the browser</td>
-              </tr>
-              <tr class="nhsuk-table__row" role="row">
                 <td class="nhsuk-table__cell" role="cell" data-label="Cookie name">nhsuk-cookie-consent</td>
                 <td class="nhsuk-table__cell" role="cell" data-label="Purpose">Remembers if you used our cookies banner</td>
                 <td class="nhsuk-table__cell" role="cell" data-label="Expiry">When you close the browser (if you do not use the banner) or 1 year (if you use the banner)</td>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -81,7 +81,7 @@
   <div class="nhsuk-grid-row nhsuk-promo-group">
     <div class="nhsuk-grid-column-full nhsuk-promo-group__item">
       <div class="nhsuk-promo app-promo--video">
-        <div class="app-embed-container"><iframe src="https://www.youtube.com/embed/idgk2SwC_q4" title="NHS digital service manual - show and tell 20 February 2020" allowfullscreen></iframe></div>
+        <div class="app-embed-container"><iframe src="https://www.youtube-nocookie.com/embed/idgk2SwC_q4" title="NHS digital service manual - show and tell 20 February 2020" allowfullscreen></iframe></div>
         <div class="nhsuk-promo__content">
           <h3 class="app-promo--video-title">NHS digital service manual show and tell</h3>
           <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Recorded on: </span>13 February 2020</p>

--- a/app/views/whats-new/show-and-tells.njk
+++ b/app/views/whats-new/show-and-tells.njk
@@ -16,7 +16,7 @@
   <div class="nhsuk-grid-row nhsuk-promo-group">
     <div class="nhsuk-grid-column-full nhsuk-promo-group__item">
       <div class="nhsuk-promo app-promo--video">
-        <div class="app-embed-container"><iframe src="https://www.youtube.com/embed/idgk2SwC_q4" title="NHS digital service manual - show and tell 20 February 2020" allowfullscreen></iframe></div>
+        <div class="app-embed-container"><iframe src="https://www.youtube-nocookie.com/embed/idgk2SwC_q4" title="NHS digital service manual - show and tell 20 February 2020" allowfullscreen></iframe></div>
         <div class="nhsuk-promo__content">
           <h3 class="app-promo--video-title">NHS digital service manual show and tell</h3>
           <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Recorded on: </span>13 February 2020</p>
@@ -42,7 +42,7 @@
     </div>
     <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
       <div class="nhsuk-promo app-promo--video">
-        <div class="app-embed-container"><iframe src="https://www.youtube.com/embed/Bzs_qJtuxE4" title="NHS digital service manual - show and tell 18 July 2019" allowfullscreen></iframe></div>
+        <div class="app-embed-container"><iframe src="https://www.youtube-nocookie.com/embed/Bzs_qJtuxE4" title="NHS digital service manual - show and tell 18 July 2019" allowfullscreen></iframe></div>
         <div class="nhsuk-promo__content">
           <h3 class="app-promo--video-title">NHS digital service manual show and tell</h3>
           <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Recorded on: </span>18 July 2019</p>
@@ -54,7 +54,7 @@
   <div class="nhsuk-grid-row nhsuk-promo-group">
     <div class="nhsuk-grid-column-one-half nhsuk-promo-group__item">
       <div class="nhsuk-promo app-promo--video">
-        <div class="app-embed-container"><iframe src="https://www.youtube.com/embed/C8dfgJQ8JEo" title="NHS.UK standards and redesign show & tell 14 February 2019" allowfullscreen></iframe></div>
+        <div class="app-embed-container"><iframe src="https://www.youtube-nocookie.com/embed/C8dfgJQ8JEo" title="NHS.UK standards and redesign show & tell 14 February 2019" allowfullscreen></iframe></div>
         <div class="nhsuk-promo__content">
           <h3 class="app-promo--video-title">NHS.UK standards and redesign show and tell</h3>
           <p class="app-meta-data app-meta-data--strong"><span class="nhsuk-u-visually-hidden">Recorded on: </span>14 February 2019</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
- Use the no cookie version of YouTube video embedding
- Remove unused cookie (ARRAffinity) from the cookie policy page as we no longer set this cookie