### PR TITLE
Add "print this page" issue to community backlog of components and patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## 3.2.1 - 29 April 2020
+## 3.2.1 - Unreleased
 
 :new: **New content**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## 3.2.0 - 27 April 2020
+## 3.2.1 - 29 April 2020
 
 :new: **New content**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 3.2.0 - 27 April 2020
 
+:new: **New content**
+
+- Update community backlog page
+
+## 3.2.0 - 27 April 2020
+
 :new: **New features**
 
 - Add conditional reveal for radios and checkboxes ([Community backlog Issue 173](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/173))

--- a/app/views/community/backlog-of-components-and-patterns.njk
+++ b/app/views/community/backlog-of-components-and-patterns.njk
@@ -132,6 +132,10 @@
         <td class="nhsuk-table__cell nhsuk-body-s" style="text-align: right">Proposed</td>
       </tr>
       <tr class="nhsuk-table__row">
+        <td class="nhsuk-table__cell"><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/240">Print this page</a></td>
+        <td class="nhsuk-table__cell nhsuk-body-s" style="text-align: right">Proposed</td>
+      </tr>
+      <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell"><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/91">Promo</a></td>
         <td class="nhsuk-table__cell nhsuk-body-s" style="text-align: right">In progress</td>
       </tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description
Add the print this page issue to the [backlog of components and patterns](http://localhost:3000/community/backlog-of-components-and-patterns) page

### Related issue
Print this page - service manual backlog [issue #240](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/240)

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [What's new page](https://service-manual.nhs.uk/whats-new) entry: same as previous what's new page update