### PR TITLE
add guidance for the main wrapper spacing modifier classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :new: **New content**
 
 - Update community backlog page
+- Add guidance for the `<main>` wrapper vertical spacing modifier classes ([Community backlog Issue 221](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/221))
 
 ## 3.2.0 - 27 April 2020
 

--- a/app/views/design-system/styles/layout.njk
+++ b/app/views/design-system/styles/layout.njk
@@ -98,6 +98,8 @@
     showExample: false
   }) }}
 
+  <p class="rich-text">The vertical padding can be made larger or smaller by using the modifier classes <code>.nhsuk-main-wrapper--l</code> or <code>.nhsuk-main-wrapper--s</code>. We recommend using smaller vertical padding on transactional services.</p>
+
   <h2 id="grid">Grid system</h2>
   <p class="rich-text">The grid is structured with a <code>.nhsuk-grid-row</code> wrapper which acts as a row to contain your grid columns.</p>
   <p class="rich-text">You can add columns inside this wrapper to create your layout. To define your columns, add the class beginning with <code>.nhsuk-grid-column-</code> to a new container followed by the width, for example <code>.nhsuk-grid-column-one-third</code>, to make it the width you want.</p>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,10 +9,10 @@
 
   <h2>Latest updates</h2>
 
-  <h3>April 2020</h3>
+  <h3>May 2020</h3>
 
   <table class="nhsuk-table">
-    <caption class="nhsuk-table__caption">Updates to the service manual in April 2020</caption>
+    <caption class="nhsuk-table__caption">Updates to the service manual in May 2020</caption>
     <thead class="nhsuk-table__head">
       <tr class="nhsuk-table__row">
         <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
@@ -21,15 +21,9 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Community</td>
-        <td class="nhsuk-table__cell">
-          <p>Updated the <a href="/community/backlog-of-components-and-patterns">backlog of components and patterns</a></p>
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
-          <p>Added conditionally revealing <a href="/design-system/components/radios#conditionally-revealing-content">radio</a> and <a href="/design-system/components/checkboxes#conditionally-revealing-content">checkbox</a> components</p>
+          <p>Added guidance for the <a href="/design-system/styles/layout#main-content">main wrapper spacing modifier classes</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,7 +10,27 @@
 
 {% block bodyContent %}
 
-<h2>April 2020</h2>
+  <h2>May 2020</h2>
+
+  <table class="nhsuk-table">
+    <caption class="nhsuk-table__caption">Updates to the service manual in May 2020</caption>
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+        <th class="nhsuk-table__header" scope="col">Update</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+      <tr class="nhsuk-table__row">
+        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">
+          <p>Added guidance for the <a href="/design-system/styles/layout#main-content">main wrapper spacing modifier classes</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>April 2020</h2>
 
   <table class="nhsuk-table">
     <caption class="nhsuk-table__caption">Updates to the service manual in April 2020</caption>


### PR DESCRIPTION
## Description

Add guidance for the `<main>` wrapper vertical spacing modifier classes

### Related issue

([Community backlog Issue 221](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/221))

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
