### PR TITLE
Add stop users to tell them about important information pattern

### DIFF
--- a/app/views/design-system/patterns/stop-users-to-tell-them-important-information.njk
+++ b/app/views/design-system/patterns/stop-users-to-tell-them-important-information.njk
@@ -1,0 +1,60 @@
+{% set pageTitle = "Stop users to tell them important information" %}
+{% set pageDescription = "Use this pattern to stop users in a journey to tell them important information before continuing" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Tasks" %}
+{% set dateUpdated = "May 2020" %}
+{% set backlog_issue_id = "241" %}
+
+{% extends "includes/app-layout.njk" %}
+
+{% block breadcrumb %}
+  {% include "design-system/patterns/_breadcrumb.njk" %}
+{% endblock %}
+
+{% block bodyContent %}
+
+  <h2>When to use this pattern</h2>
+  <p>In a transactional journey when you need to tell them something important.</p>
+  <p>Use this pattern when:</p>
+  <ul>
+    <li>you need users to understand something so they are more successful using your service</li>
+    <li>you have evidence that providing information before a journey or in a normal page does not work on it’s own</li>
+  </ul>
+  <p>If you need users to understand two or three things. Try providing information just ahead of when a user needs it or use several pages in a row.</p>
+
+  <h2>When not to use this pattern</h2>
+  <p>Do not use this pattern:</p>
+  <ul>
+    <li>outside of transactional journeys</li>
+    <li>when you need to include large amounts of content</li>
+    <li>when you need a user to make a choice between two or more options. In these scenarios, use a radio button instead</li>
+    <li>when you need a user to actively confirm something before an action takes place. For example, when deleting an account or cancelling an appointment</li>
+    <li>alongside other content or data items which may mean the interruption is less visually distinct or easily missed</li>
+  </ul>
+
+  <h2>How to use this pattern</h2>
+  <p>To use this pattern:</p>
+  <ul>
+    <li>use a page that is visually distinct from other pages in a journey</li>
+    <li>use a clear heading that tells the user the most important thing they need to do</li>
+    <li>include a button with “Continue” or “I understand”</li>
+  </ul>
+
+  <h2>Research</h2>
+  <p>The “Choose if data from your health records can be used for research and planning“ team found that:</p>
+  <ul>
+    <li>users can mistake images and other graphical elements [for example, dots] for things they can click</li>
+    <li>users were more likely to stop and read content in an interruption card compared to a page styled like other pages</li>
+    <li>users did not always read anything other than the heading</li>
+    <li>not all users will slow down. There is no pattern that will work for all users</li>
+  </ul>
+  <p>111 Online team found that users were more likely to complete a transaction when told that more questions meant a less serious diagnosis.</p>
+  <p>111 Online saw a 10% increase in completed journeys after using a page to interrupt users.</p>
+  <p>Outside of the NHS:</p>
+  <ul>
+    <li>the passport service found interrupting users’ flow with this pattern has increased understanding and retention of important information</li>
+    <li>the department for Education found that most users will now stop and read the content</li>
+  </ul>
+
+{% endblock %}

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -108,8 +108,9 @@
   { title: "Textarea", url: "/design-system/components/textarea" }
 ] %}
 
-{% set askUsers = [
-  { title: "Ask users for their NHS number", url: "/design-system/patterns/ask-users-for-their-nhs-number" }
+{% set tasks = [
+  { title: "Ask users for their NHS number", url: "/design-system/patterns/ask-users-for-their-nhs-number" },
+  { title: "Stop users to tell them important information", url: "/design-system/patterns/stop-users-to-tell-them-important-information" }
 ] %}
 
 {% set pages = [
@@ -213,7 +214,7 @@
     }) }}
     <h2 class="app-side-nav__heading">Tasks</h2>
     <ul class="nhsuk-list app-side-nav__list">
-    {% for item in askUsers %}
+    {% for item in tasks %}
       <li class="app-side-nav__item{% if item.title == pageTitle %} app-side-nav__item--current{% endif %}"><a class="app-side-nav__link" href="{{ item.url }}">{{ item.title }}</a></li>
     {% endfor %}
     </ul>

--- a/app/views/sitemap.njk
+++ b/app/views/sitemap.njk
@@ -99,6 +99,7 @@
             <li><a href="/design-system/patterns/ask-users-for-their-nhs-number">Ask users for their NHS number</a></li>
             <li><a href="/design-system/patterns/a-to-z-page">A to Z</a></li>
             <li><a href="/design-system/patterns/mini-hub">Mini-hub</a></li>
+            <li><a href="/design-system/patterns/stop-users-to-tell-them-important-information">Stop users to tell them important information</a></li>
           </ul>
         </li>
       </ul>

--- a/app/views/sitemap.xml
+++ b/app/views/sitemap.xml
@@ -203,6 +203,9 @@
     <loc>https://service-manual.nhs.uk/design-system/patterns/mini-hub</loc>
   </url>
   <url>
+    <loc>https://service-manual.nhs.uk/design-system/patterns/stop-users-to-tell-them-important-information</loc>
+  </url>
+  <url>
     <loc>https://service-manual.nhs.uk/design-system/styles/focus-state</loc>
   </url>
   <url>


### PR DESCRIPTION
## Description
Add a page for the "Stop users to tell them about important information" task pattern in the design system.

### Related issue
nhsuk/nhsuk-service-manual-backlog#241

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry