### PR TITLE
Fix A to Z page pattern example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # NHS digital service manual Changelog
 
-## 3.2.1 - Unreleased
+## 3.2.1 - 18 May 2020
 
 :new: **New content**
 
 - Update community backlog page
 - Add guidance for the `<main>` wrapper vertical spacing modifier classes ([Community backlog Issue 221](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/221))
 - Update footer guidance
+
+:wrench: **Fixes**
+
+- Fix A to Z page pattern example
 
 ## 3.2.0 - 27 April 2020
 

--- a/app/components/a-z.njk
+++ b/app/components/a-z.njk
@@ -1,156 +1,166 @@
+{% extends "includes/design-example-wrapper-full-layout.njk" %}
+
 {% from 'nav-a-z/macro.njk' import azNav %}
 {% from 'list-panel/macro.njk' import listPanel %}
 
-<h1>Health A to Z</h1>
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
 
-{{ azNav({
-  "items": [
-    {
-      "label": "A"
-    },
-    {
-      "disable": "true",
-      "label": "B"
-    },
-    {
-      "label": "C"
-    },
-    {
-      "label": "D"
-    },
-    {
-      "label": "E"
-    },
-    {
-      "label": "F"
-    },
-    {
-      "label": "G"
-    },
-    {
-      "label": "H"
-    },
-    {
-      "label": "I"
-    },
-    {
-      "label": "J"
-    },
-    {
-      "label": "K"
-    },
-    {
-      "label": "L"
-    },
-    {
-      "label": "M"
-    },
-    {
-      "label": "N"
-    },
-    {
-      "label": "O"
-    },
-    {
-      "label": "P"
-    },
-    {
-      "label": "Q"
-    },
-    {
-      "label": "R"
-    },
-    {
-      "label": "S"
-    },
-    {
-      "label": "T"
-    },
-    {
-      "label": "U"
-    },
-    {
-      "label": "V"
-    },
-    {
-      "label": "W"
-    },
-    {
-      "label": "X"
-    },
-    {
-      "label": "Y"
-    },
-    {
-      "label": "Z"
-    }
-  ]
-}) }}
+      <h1>Health A to Z</h1>
 
-{{ listPanel({
-  "label": "A",
-  "id": "A",
-  "backToTop": "true",
-  "backToTopLink": "#nhsuk-nav-a-z",
-  "items": [
-    {
-      "URL": "/conditions/abdominal-aortic-aneurysm/",
-      "link": "AAA"
-    },
-    {
-      "URL": "/conditions/abdominal-aortic-aneurysm/",
-      "link": "Abdominal aortic aneurysm"
-    },
-    {
-      "URL": "/conditions/abscess/",
-      "link": "Abscess"
-    }
-  ]
-}) }}
+      {{ azNav({
+        "items": [
+          {
+            "label": "A"
+          },
+          {
+            "disable": "true",
+            "label": "B"
+          },
+          {
+            "label": "C"
+          },
+          {
+            "label": "D"
+          },
+          {
+            "label": "E"
+          },
+          {
+            "label": "F"
+          },
+          {
+            "label": "G"
+          },
+          {
+            "label": "H"
+          },
+          {
+            "label": "I"
+          },
+          {
+            "label": "J"
+          },
+          {
+            "label": "K"
+          },
+          {
+            "label": "L"
+          },
+          {
+            "label": "M"
+          },
+          {
+            "label": "N"
+          },
+          {
+            "label": "O"
+          },
+          {
+            "label": "P"
+          },
+          {
+            "label": "Q"
+          },
+          {
+            "label": "R"
+          },
+          {
+            "label": "S"
+          },
+          {
+            "label": "T"
+          },
+          {
+            "label": "U"
+          },
+          {
+            "label": "V"
+          },
+          {
+            "label": "W"
+          },
+          {
+            "label": "X"
+          },
+          {
+            "label": "Y"
+          },
+          {
+            "label": "Z"
+          }
+        ]
+      }) }}
 
-{{ listPanel({
-  "label": "B",
-  "id": "B",
-  "disable": "true",
-  "backToTop": "true",
-  "backToTopLink": "#nhsuk-nav-a-z",
-  "message": "There are currently no conditions listed"
-}) }}
+      {{ listPanel({
+        "label": "A",
+        "id": "A",
+        "backToTop": "true",
+        "backToTopLink": "#nhsuk-nav-a-z",
+        "items": [
+          {
+            "URL": "/conditions/abdominal-aortic-aneurysm/",
+            "link": "AAA"
+          },
+          {
+            "URL": "/conditions/abdominal-aortic-aneurysm/",
+            "link": "Abdominal aortic aneurysm"
+          },
+          {
+            "URL": "/conditions/abscess/",
+            "link": "Abscess"
+          }
+        ]
+      }) }}
 
-{{ listPanel({
-  "label": "C",
-  "id": "C",
-  "backToTop": "true",
-  "backToTopLink": "#nhsuk-nav-a-z",
-  "items": [
-    {
-      "URL": "/conditions/chest-pain/",
-      "link": "Chest pain"
-    },
-    {
-      "URL": "/conditions/cold-sores/",
-      "link": "Cold sore"
-    }
-  ]
-}) }}
+      {{ listPanel({
+        "label": "B",
+        "id": "B",
+        "disable": "true",
+        "backToTop": "true",
+        "backToTopLink": "#nhsuk-nav-a-z",
+        "message": "There are currently no conditions listed"
+      }) }}
 
-{{ listPanel({
-  "label": "D",
-  "id": "D",
-  "backToTop": "true",
-  "backToTopLink": "#nhsuk-nav-a-z",
-  "items": [
-    {
-      "URL": "/conditions/dandruff/",
-      "link": "Dandruff"
-    },
-    {
-      "URL": "/conditions/dementia/",
-      "link": "Dementia"
-    },
-    {
-      "URL": "/conditions/toothache/",
-      "link": "Dental pain"
-    }
-  ]
-}) }}
+      {{ listPanel({
+        "label": "C",
+        "id": "C",
+        "backToTop": "true",
+        "backToTopLink": "#nhsuk-nav-a-z",
+        "items": [
+          {
+            "URL": "/conditions/chest-pain/",
+            "link": "Chest pain"
+          },
+          {
+            "URL": "/conditions/cold-sores/",
+            "link": "Cold sore"
+          }
+        ]
+      }) }}
+
+      {{ listPanel({
+        "label": "D",
+        "id": "D",
+        "backToTop": "true",
+        "backToTopLink": "#nhsuk-nav-a-z",
+        "items": [
+          {
+            "URL": "/conditions/dandruff/",
+            "link": "Dandruff"
+          },
+          {
+            "URL": "/conditions/dementia/",
+            "link": "Dementia"
+          },
+          {
+            "URL": "/conditions/toothache/",
+            "link": "Dental pain"
+          }
+        ]
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Description
Fixed the A to Z page example. It wasn't using the 'full page' example code.

Before:
<img width="880" alt="Screenshot 2020-05-18 at 09 53 22" src="https://user-images.githubusercontent.com/14331000/82194183-4f66d880-98ee-11ea-9009-e6642aa54fd4.png">

After:
<img width="891" alt="Screenshot 2020-05-18 at 09 55 20" src="https://user-images.githubusercontent.com/14331000/82194209-5857aa00-98ee-11ea-92c6-e55bebcde5bd.png">

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry