### PR TITLE
Separated out text from organisational header heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 3.3.1 - Unreleased
+
+:wrench: **Fixes**
+
+- Updated first paragraph for "Organisational header"
+
 ## 3.3.0 - 9 June 2020
 
 :new: **New content**
@@ -82,7 +88,7 @@
 
 :new: **New content**
 
-- Add new entry in A to Z of NHS health writing for "GP" 
+- Add new entry in A to Z of NHS health writing for "GP"
 - Add explanation about using months up to 2 years on Inclusive language page
 - Add new guidance on telephone numbers to A to Z of NHS health writing, based on GOV.UK guidance
 - Add new guidance and examples of an error summary and an error message working together ([Community backlog Issue 189](https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/189))
@@ -99,7 +105,7 @@
 
 :new: **New content**
 
-- Update guidance on "sex" and "intersex" on the Inclusive language page. 
+- Update guidance on "sex" and "intersex" on the Inclusive language page.
 - Update What's new section with latest changes.
 
 :wrench: **Fixes**
@@ -180,7 +186,7 @@
 
 :wrench: **Fixes**
 
-- Add more detail about interoperability standards to section 17 of NHS service standard 
+- Add more detail about interoperability standards to section 17 of NHS service standard
 - Amend guidance on using the number 1 in Numbers, measurements, dates and time after December Style Council meeting
 - Update inclusive language page, especially the section on sex, gender and sexuality
 - Update package dependencies to latest versions
@@ -202,7 +208,7 @@
 
 :new: **New content**
 
-- NHS service standard 
+- NHS service standard
 
 :wrench: **Fixes**
 
@@ -371,7 +377,7 @@
 :wrench: **Fixes**
 
 - Update the guidance for how we use the microgram symbol
-- Update the guidance for how we write concisely with example 
+- Update the guidance for how we write concisely with example
 - Update package dependencies to latest versions
 
 ## 1.6.2 - 30 July 2019

--- a/app/views/design-system/components/header.njk
+++ b/app/views/design-system/components/header.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the header to show users they are on an NHS service and help them get started in finding what they need." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "November 2019" %}
+{% set dateUpdated = "June 2020" %}
 {% set backlog_issue_id = "16" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -57,14 +57,8 @@
     type: "header-transactional"
   }) }}
 
-  <h3 id="organisational-header">Organisational header
-    <div>
-      <strong class="nhsuk-tag nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
-        Experimental
-      </strong>
-      <p class="nhsuk-body-m">This component is currently experimental because we haven't tested it in a real service. We are looking for <a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/156">feedback on the organisational header on GitHub</a>.</p>
-    </div>
-  </h3>
+  <h3 id="organisational-header">Organisational header</h3>
+  <p><span class="nhsuk-tag">Experimental</span><br>This component is currently experimental because we haven't tested it in a real service. We are looking for <a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/156">feedback on the organisational header on GitHub</a>.</p>
   <p>Use the organisational header if your NHS organisation or service is not part of the NHS website, for example, for an NHS clinical commissioning group or an NHS trust.</p>
   <p>You must have a Frutiger font licence to use an organisational logo. Our guidance on <a href="/design-system/styles/typography">typography</a> explains how to get hold of the webfont. Read more about creating NHS <a href="https://www.england.nhs.uk/nhsidentity/identity-guidelines/organisational-logos/">organisational logos</a> in the NHS England identity guidelines.</p>
 


### PR DESCRIPTION
## Description
The paragraph underneath the "Organisational header" heading was in the H3. This makes the heading rather large, especially if screen readers navigate via headings.

### Related issue
None

## Checklist
- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [x] Page updated date
