### PR TITLE
prevent the autocomplete from being initialised twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Prevent the autocomplete from being initialised twice
 - Add `role="main"` to `<main>` container for consistency and accessibility fixes
+- Update package dependencies to latest versions
 
 ## 3.3.1 - 23 June 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 3.3.2 - 30 June 2020
+
+:wrench: **Fixes**
+
+- Prevent the autocomplete from being initialised twice
+
 ## 3.3.1 - 23 June 2020
 
 :wrench: **Fixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Prevent the autocomplete from being initialised twice
+- Add `role="main"` to `<main>` container for consistency and accessibility fixes
 
 ## 3.3.1 - 23 June 2020
 

--- a/app/components/layout-main.njk
+++ b/app/components/layout-main.njk
@@ -1,5 +1,5 @@
 <div class="nhsuk-width-container">
-  <main class="nhsuk-main-wrapper" id="maincontent">
+  <main class="nhsuk-main-wrapper" id="maincontent" role="main">
     <!-- Grid row wrapper here -->
   </main>
 </div>

--- a/app/components/layout-one-third-container-fluid.njk
+++ b/app/components/layout-one-third-container-fluid.njk
@@ -1,5 +1,5 @@
 <div class="nhsuk-width-container-fluid">
-  <main class="nhsuk-main-wrapper" id="maincontent">
+  <main class="nhsuk-main-wrapper" id="maincontent" role="main">
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-one-third">
         <h2>One-third column</h2>

--- a/app/components/layout-two-thirds-container.njk
+++ b/app/components/layout-two-thirds-container.njk
@@ -1,5 +1,5 @@
 <div class="nhsuk-width-container">
-  <main class="nhsuk-main-wrapper" id="maincontent">
+  <main class="nhsuk-main-wrapper" id="maincontent" role="main">
     <div class="nhsuk-grid-row">
       <div class="nhsuk-grid-column-two-thirds">
         <h2>Two-thirds column</h2>

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-new */
 // NHS.UK frontend components
 import AutoComplete from 'nhsuk-frontend/packages/components/header/autoCompleteConfig';
-import Header from '../../node_modules/nhsuk-frontend/packages/components/header/header';
+import MenuToggle from 'nhsuk-frontend/packages/components/header/menuToggle';
+import SearchToggle from 'nhsuk-frontend/packages/components/header/searchToggle';
 import SkipLink from '../../node_modules/nhsuk-frontend/packages/components/skip-link/skip-link';
 import Details from '../../node_modules/nhsuk-frontend/packages/components/details/details';
 import Checkboxes from '../../node_modules/nhsuk-frontend/packages/components/checkboxes/checkboxes';
@@ -23,20 +24,6 @@ import {
 import './polyfills';
 
 // Initialise NHS.UK frontend components
-Header();
-Details();
-SkipLink();
-Checkboxes();
-Radios();
-
-// Initialise NHS digital service manual components
-
-// Design examples
-document.querySelectorAll(DesignExample.selector()).forEach((el) => {
-  new DesignExample(el);
-});
-
-// Header autocomplete
 AutoComplete({
   containerId: 'autocomplete-container',
   formId: 'search',
@@ -47,4 +34,17 @@ AutoComplete({
     inputValue,
     suggestion,
   },
+});
+MenuToggle();
+SearchToggle();
+Details();
+SkipLink();
+Checkboxes();
+Radios();
+
+// Initialise NHS digital service manual components
+
+// Design examples
+document.querySelectorAll(DesignExample.selector()).forEach((el) => {
+  new DesignExample(el);
 });

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -121,7 +121,7 @@
 
     {% if pageLayout != "Homepage" %}
     <div class="nhsuk-width-container">
-      <main class="nhsuk-main-wrapper app-main-wrapper" id="maincontent">
+      <main class="nhsuk-main-wrapper app-main-wrapper" id="maincontent" role="main">
         {% block body %}{% endblock %}
       </main>
     </div>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -10,7 +10,7 @@
 
 {% block outerBody %}
 
-<main id="maincontent">
+<main id="maincontent" role="main">
 
   <section class="nhsuk-hero">
     <div class="nhsuk-width-container nhsuk-hero--border">

--- a/package-lock.json
+++ b/package-lock.json
@@ -5537,9 +5537,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.21.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz",
-      "integrity": "sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
+      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-config-nhsuk": "^0.17.0",
-    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-import": "^2.22.0",
     "iframe-resizer": "^3.6.6",
     "jest": "^25.5.4",
     "nhsuk-frontend": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description

The Header autocomplete was being initialised twice, this was due to the default export for the Header component initialising the autocomplete, then our autocomplete configuration in the Service manual was initialising the autocomplete again. This caused duplicate elements for the autocomplete.

<img width="572" alt="Screenshot 2020-06-27 at 12 16 29" src="https://user-images.githubusercontent.com/11615501/85920953-3435a400-b870-11ea-84db-ed31195632dd.png">

Instead of initialising the whole Header, initialise them separately passing our configuration through.

Also add `role="main"` to the `<main>` container for consistency with other NHS services and fix any potential issues with accessibility on older devices/software.

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
