### PR TITLE
Amend date and link to accessibility guidance

### DIFF
--- a/app/views/design-system/components/images.njk
+++ b/app/views/design-system/components/images.njk
@@ -22,7 +22,7 @@
   <p>Informative images that meet real user needs can be very important on health services - especially where they help users identify specific health problems and get the treatment they need.</p>
   <p>We've also found users with some access needs (such as dyslexia) navigate health information (conditions and treatment) pages through images. Images help them orient themselves and they separate out the content.</p>
   <p>But having unnecessary or decorative images can frustrate users, especially on information pages or transactional journeys.</p>
-  <p>We are working on more guidance about when to use images. We expect to publish it in spring 2019.</p>
+  <p>We are working on more guidance about when to use images. We expect to publish it in autumn 2020.</p>
 
   <h2>How to use images</h2>
   <p>The image component is made up of 2 elements - the image and caption - in a white box.</p>
@@ -30,10 +30,10 @@
   <p>We recommend stacking images. We've found that gallery views (images side by side) confuse users.</p>
 
   <h3>Accessibility</h3>
-  <p><a href="https://www.w3.org/TR/WCAG20-TECHS/H37.html">Follow W3C's guidance on making images accessible</a>. Images must have text alternatives that describe the information or function they represent. This makes sure that people with disabilities can understand them.</p>
-  <p>Don't use images that have words in them, because screen readers won't be able to read the words.</p>
-  <p>When using an image (or the img element), specify a text alternative with the alt attribute. Alternative text, or alt text, is read out by screen readers or displayed if an image does not load or if images have been switched off. Follow the <a href="https://design-system.service.gov.uk/styles/images/#alternative-text">guidance on alternative text in the GOV.UK Design System.</a>
-
+  <p><a href="/accessibility/content#use-alternative-text-for-images-in-content">Follow our guidance on making images accessible</a>. Images must have text alternatives that describe the information or function they represent. This makes sure that people with disabilities can understand them.</p>
+  <p>When using an image (or the img element), specify a text alternative with the alt attribute. Alternative text, or alt text, is read out by screen readers or displayed if an image does not load or if images have been switched off.</p>
+  <p>Do not use images that have words in them, because screen readers will not be able to read the words.</p>
+  
   <h2>Research</h2>
   <p>In testing we found gallery views (images side by side) confused users. Users either missed the images in the right hand column or they didn't know how to interpret the sequence. To get around this we recommend stacking images.</p>
   <p>We also found that users clicked images in gallery views, expecting them to appear larger in a pop-up modal. When we increased the size of the images and stacked them in 1 column (not 2), we didn't see anyone clicking on them to expand them.</p>


### PR DESCRIPTION
##Description
Update date for images guidance
Link to accessibility guidance on images rather than W3C or GOV.UK
Bring "don't" and "won't" into line with content style

### Related issue
https://jira.service.nhs.uk/browse/STAN-1735

## Checklist
Not yet - I'll do changelog, what's new and update page date when I've checked it in staging.

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
