### PR TITLE
Add `nhsuk-header__menu--only` class to header for when search is disabled

### DIFF
--- a/app/views/includes/_header-prototype.njk
+++ b/app/views/includes/_header-prototype.njk
@@ -9,7 +9,7 @@
 ] %}
 
 {%- if disableSearch %}
-<header class="nhsuk-header" role="banner">
+<header class="nhsuk-header nhsuk-header__menu--only" role="banner">
   <div class="nhsuk-width-container nhsuk-header__container">
     <div class="nhsuk-header__logo"><a class="nhsuk-header__link nhsuk-header__link--service " href="/" aria-label="NHS digital service manual homepage">
         <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">

--- a/app/views/includes/_header.njk
+++ b/app/views/includes/_header.njk
@@ -4,6 +4,7 @@
   {{ header({
     "homeHref": "/",
     "ariaLabel": "NHS digital service manual homepage",
+    "classes": "nhsuk-header--white",
     "service": {
       "name": "Digital service manual",
       "longName": "true"


### PR DESCRIPTION
## Description
Bug fix for search page header - adding `nhsuk-header__menu--only` class to header when search is disabled
