### PR TITLE
Remove experimental tags + fix code example focus styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # NHS digital service manual Changelog
 
+## 3.3.5 - Unreleased
+
+:new: **New content**
+
+- Remove experimental tag from organisational header and summary list component
+
+:wrench: **Fixes**
+
+- Fix design example link focus style
+
 ## 3.3.4 - 7 August 2020
 
 :new: **New content**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## 3.3.5 - Unreleased
+## 3.4.0 - Unreleased
 
 :new: **New content**
 

--- a/app/styles/design-example/_code-snippet.scss
+++ b/app/styles/design-example/_code-snippet.scss
@@ -112,7 +112,11 @@
       }
 
       &:focus {
-        @include nhsuk-focused-text;
+        background-color: $nhsuk-focus-color;
+        box-shadow: 0 $nhsuk-focus-width $nhsuk-focus-text-color;
+        color: $nhsuk-focus-text-color;
+        outline: $nhsuk-focus-width solid transparent;
+        text-decoration: none;
       }
 
     }

--- a/app/styles/design-example/_design-example.scss
+++ b/app/styles/design-example/_design-example.scss
@@ -28,8 +28,11 @@
     }
 
     &:focus {
-      @include nhsuk-focused-text;
-      border: 0;
+      background-color: $nhsuk-focus-color;
+      box-shadow: 0 $nhsuk-focus-width $nhsuk-focus-text-color;
+      color: $nhsuk-focus-text-color;
+      outline: $nhsuk-focus-width solid transparent;
+      text-decoration: none;
 
       &:hover {
         color: $nhsuk-focus-text-color;

--- a/app/views/design-system/components/header.njk
+++ b/app/views/design-system/components/header.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the header to show users they are on an NHS service and help them get started in finding what they need." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "June 2020" %}
+{% set dateUpdated = "August 2020" %}
 {% set backlog_issue_id = "16" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -28,7 +28,7 @@
 
   <h2 id="when-to-use-the-header">When to use the header</h2>
   <p>Use the NHS default, service or transactional header at the top of every page if your service is on the nhs.uk domain.</p>
-  <p>Use the experimental organisational header if your service is on another domain.</p>
+  <p>Use the <a href="#organisational-header">organisational header</a> if your service is on another domain.</p>
 
   <h2 id="when-not-to-use-the-header">When not to use the header</h2>
   <p>Do not use 1 of the nhs.uk headers if your service is on another domain.</p>
@@ -58,7 +58,6 @@
   }) }}
 
   <h3 id="organisational-header">Organisational header</h3>
-  <p><span class="nhsuk-tag">Experimental</span><br>This component is currently experimental because we haven't tested it in a real service. We are looking for <a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/156">feedback on the organisational header on GitHub</a>.</p>
   <p>Use the organisational header if your NHS organisation or service is not part of the NHS website, for example, for an NHS clinical commissioning group or an NHS trust.</p>
   <p>You must have a Frutiger font licence to use an organisational logo. Our guidance on <a href="/design-system/styles/typography">typography</a> explains how to get hold of the webfont. Read more about creating NHS <a href="https://www.england.nhs.uk/nhsidentity/identity-guidelines/organisational-logos/">organisational logos</a> in the NHS England identity guidelines.</p>
 

--- a/app/views/design-system/components/summary-list.njk
+++ b/app/views/design-system/components/summary-list.njk
@@ -2,9 +2,8 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the summary list to summarise information, for example, a user’s responses at the end of a form." %}
-{% set experimental = true %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "November 2019" %}
+{% set dateUpdated = "August 2020" %}
 {% set backlog_issue_id = "36" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -58,12 +57,5 @@
   {{ designExample({
     type: "summary-list-without-border"
   }) }}
-
-  <h2 id="research">Research</h2>
-  <p>We have tested this component in the NHS in labs and in live services, with and without actions and borders. It has been through several accessibility audits.</p>
-
-  <h3 id="next-steps">Next steps</h3>
-  <p>It is an established GOV.UK component but we want more NHS services to test it in a health context. We are interested, for example, in how it fits into patterns like the <a href="https://design-system.service.gov.uk/patterns/check-answers/">GOV.UK Help users to check answers pattern</a>.
-  <p>If you've used summary lists, please share your user research findings.</p>
 
 {% endblock %}

--- a/app/views/includes/app-layout.njk
+++ b/app/views/includes/app-layout.njk
@@ -31,14 +31,6 @@
             </span>
             {% endif %}
             {{pageTitle}}
-            {%- if experimental %}
-            <div>
-              <strong class="nhsuk-tag nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-2">
-                Experimental
-              </strong>
-              <p class="nhsuk-body-m nhsuk-u-margin-bottom-0">This component is currently experimental which means that we're looking for teams to test it and feedback.</p>
-            </div>
-            {% endif %}
           </h1>
 
           {%- if hideDescription %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.3.5",
+  "version": "3.4.0",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description
Removed the experimental tags from the organisational header and summary list component.

Also, updated the focus style for the design example links.


## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [x] Page updated date
