### PR TITLE
Add phone entry to What's new and update forms guidance

### DIFF
--- a/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Content style guide" %}
 {% set subSection = "How to write good questions for forms" %}
 {% set pageDescription = "People may not trust you with their personal data or they may think the question is inappropriate." %}
-{% set dateUpdated = "November 2019" %}
+{% set dateUpdated = "September 2020" %}
 
 {% extends "includes/app-layout.njk" %}
 
@@ -30,7 +30,7 @@
   <ul>
     <li>their age</li>
     <li>their email address</li>
-    <li>their telephone or mobile number</li>
+    <li>their phone number</li>
     <li>a health complaint</li>
   </ul>
 

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -22,7 +22,7 @@
           <div class="nhsuk-card app-card--transparent nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m"><a href="/whats-new">What's new</a></h2>
-              <p class="nhsuk-card__description">In August 2020 we added the <a href="/accessibility">NHS digital accessibility posters</a>.</p>
+              <p class="nhsuk-card__description">In September 2020 we added an entry for <a href="/content/a-to-z-of-nhs-health-writing#phone-and-phone-numbers">phone and phone numbers</a> to A to Z of NHS health writing.</p>
             </div>
           </div>
         </div>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,7 +9,9 @@
 
   <h2>Latest updates</h2>
 
-  <h3>August 2020</h3>
+
+
+  <h3>September 2020</h3>
 
   <table class="nhsuk-table">
     <caption class="nhsuk-table__caption">Updates to the service manual in August 2020</caption>
@@ -21,27 +23,9 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Accessibility</td>
-        <td class="nhsuk-table__cell">
-          <p>Added <a href="/accessibility">NHS digital accessibility posters</a></p>
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">Content style guide</td>
         <td class="nhsuk-table__cell">
-          <p>Added new entry for <a href="/content/a-to-z-of-nhs-health-writing#NHS-Test-and-Trace">NHS Test and Trace</a> to A to Z of NHS health writing</p>
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Design system</td>
-        <td class="nhsuk-table__cell">
-          <p>Added prototype kit how to guides link to the <a href="/design-system/prototyping#how-to-guides">prototyping page</a></p>
-        </td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Get in touch</td>
-        <td class="nhsuk-table__cell">
-          <p>Added a new "<a href="/get-in-touch">Get in touch</a>" page</p>
+            <p>Added new entry for <a href="/content/a-to-z-of-nhs-health-writing#phone-and-phone-numbers">phone and phone numbers</a> to A to Z of NHS health writing</p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -9,6 +9,28 @@
 {% endblock %}
 
 {% block bodyContent %}
+<h2>September 2020</h2>
+
+  <table class="nhsuk-table">
+    <caption class="nhsuk-table__caption">Updates to the service manual in September 2020</caption>
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+        <th class="nhsuk-table__header" scope="col">Update</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+      <tr class="nhsuk-table__row">
+        <td class="nhsuk-table__cell">Content style guide</td>
+        <td class="nhsuk-table__cell">
+          <p>Added new entry for <a href="/content/a-to-z-of-nhs-health-writing#phone-and-phone-numbers">phone and phone numbers</a> to A to Z of NHS health writing</p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+
+
   <h2>August 2020</h2>
 
   <table class="nhsuk-table">


### PR DESCRIPTION
## Description
Add phone entry in A to Z of health writing to What's new pages.
Also update forms guidance - replace telephone with phone.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
