### PR TITLE
Fix - swap the word  'checkbox' with 'radio'

### DIFF
--- a/app/views/design-system/components/radios.njk
+++ b/app/views/design-system/components/radios.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use radios when you want users to select only 1 option from a list." %}
 {% set theme = "Form elements" %}
-{% set dateUpdated = "April 2020" %}
+{% set dateUpdated = "September 2020" %}
 {% set backlog_issue_id = "19" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -25,7 +25,7 @@
   <p>Do not use radios if users might need to select more than 1 option. Use <a href="/design-system/components/checkboxes">checkboxes</a> instead.</p>
 
   <h2 id="how-it-works">How to use radios</h2>
-  <p>When you're drafting your checkbox options, <a href="/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users#beware-binary-choices">beware binary choices</a>. Try testing a 3rd option.</p>
+  <p>When you're drafting your radio options, <a href="/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users#beware-binary-choices">beware binary choices</a>. Try testing a 3rd option.</p>
   <p>Order radio options alphabetically by default. </p>
   <p class="rich-text">Group radios together in a <code>&lt;fieldset&gt;</code> with a <code>&lt;legend&gt;</code> that describes them. You can see an example at the top of this page. This is usually a question, like "Are you 18 or over?".</p>
   <p class="rich-text">If you are asking just <a href="/content/how-to-write-good-questions-for-forms/get-the-questions-into-order#begin-prototyping-with-1-thing-per-page">1 question per page</a> as we recommend, you can set the contents of the <code>&lt;legend&gt;</code> as the page heading. This is good practice as it means that screen reader users will only hear the contents once.</p>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

There was a mistake in the guidance, it said 'checkbox' instead of 'radio'.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Page updated date
