### PR TITLE
Update code example for the font weight normal override class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update package dependencies to latest versions
 - Remove the `pattern="[0-9]*"` attribute from NHS number examples to allow for spaces
+- Update code example for the font weight normal override class
 
 ## 3.10.0 - 21 January 2021
 

--- a/app/components/typography-weight.njk
+++ b/app/components/typography-weight.njk
@@ -1,2 +1,2 @@
-<p class="nhsuk-u-font-weight-regular">nhsuk-u-font-weight-regular</p>
+<p class="nhsuk-u-font-weight-normal">nhsuk-u-font-weight-normal</p>
 <p class="nhsuk-u-font-weight-bold">nhsuk-u-font-weight-bold</p>

--- a/app/views/design-system/styles/typography.njk
+++ b/app/views/design-system/styles/typography.njk
@@ -2,7 +2,7 @@
 {% set pageDescription = "Our fonts and typographic styles, and how to apply them." %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Styles" %}
-{% set dateUpdated = "December 2020" %}
+{% set dateUpdated = "January 2021" %}
 {% set backlog_issue_id = "1" %}
 
 {% extends "includes/app-layout.njk" %}

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -34,6 +34,7 @@
         <td class="nhsuk-table__cell">
           <p>Added guidance for <a href="/design-system/components/text-input#asking-for-whole-numbers">asking for whole numbers using the text input</a> component</p>
           <p>Updated code examples with inputmode numeric for the <a href="/design-system/patterns/ask-users-for-their-nhs-number">ask users for their NHS number pattern</a> and <a href="/design-system/components/date-input">date inputcomponent </a></p>
+          <p>Updated code example for the <a href="/design-system/styles/typography#font-weight">font weight normal override class</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -36,6 +36,7 @@
         <td class="nhsuk-table__cell">
           <p>Added guidance for <a href="/design-system/components/text-input#asking-for-whole-numbers">asking for whole numbers using the text input</a> component</p>
           <p>Updated code examples with inputmode numeric for the <a href="/design-system/patterns/ask-users-for-their-nhs-number">ask users for their NHS number pattern</a> and <a href="/design-system/components/date-input">date inputcomponent </a></p>
+          <p>Updated code example for the <a href="/design-system/styles/typography#font-weight">font weight normal override class</a></p>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

https://github.com/nhsuk/nhsuk-service-manual/issues/912

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [x] Page updated date
