### PR TITLE
Change sitemap to site map to align with Style Council decision

### DIFF
--- a/app/views/includes/_footer.njk
+++ b/app/views/includes/_footer.njk
@@ -7,7 +7,7 @@
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/accessibility-statement">Accessibility statement</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/cookie-policy">Cookie policy</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/get-in-touch">Get in touch</a></li>
-        <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/sitemap">Sitemap</a></li>
+        <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/site-map">Site map</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/terms-and-conditions">Terms and conditions</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/whats-new">What's new</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/your-privacy">Your privacy</a></li>

--- a/app/views/site-map.njk
+++ b/app/views/site-map.njk
@@ -1,7 +1,7 @@
-{% set pageTitle = "Sitemap" %}
+{% set pageTitle = "Site map" %}
 {% set pageDescription = "A list of pages on this website - with links" %}
 {% set hideDescription = true %}
-{% set dateUpdated = "January 2020" %}
+{% set dateUpdated = "February 2021" %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}
 


### PR DESCRIPTION
## Description
Bring site map file into line with Style Council decision - "sitemap" should be 2 words "site map" for accessibility reasons.

### Related issue
[Get the site map page on the NHS and service manual sites changed #873](https://github.com/nhsuk/nhsuk-service-manual/issues/873)

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [x] Page updated date
