### PR TITLE
fix the site map path name in page indexer

### DIFF
--- a/middleware/page-index.js
+++ b/middleware/page-index.js
@@ -18,7 +18,7 @@ class PageIndex {
 
     try {
       // Make request to get sitemap
-      const { data } = await axios.get(`${baseUrl}/sitemap`, config);
+      const { data } = await axios.get(`${baseUrl}/site-map`, config);
       // Assign jQuery style DOM of page to $
       let $ = cheerio.load(data);
       // jQuery array of jQuery link objects


### PR DESCRIPTION
## Description

Following the change to the HTML site map page name, fix the site map path name in page indexer
