### PR TITLE
Add contribution links within context #1000 #1001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve content of the publish an accessibility statement
 - Ensure date updated date is correct on the product and delivery pages
 - Update the NHS digital service manual team members
+
 ## 3.14.0 - 16 March 2021
 
 :new: **New features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # NHS digital service manual Changelog
 
-## 3.14.1 - 18 March 2021
+## 3.14.2 - 18 March 2021
 
-:new: **New features**
+:wrench: **Fixes**
 
 - Improve content of the publish an accessibility statement
 - Ensure date updated date is correct on the product and delivery pages
 - Update the NHS digital service manual team members
+
+## 3.14.1 - 16 March 2021
+
+:wrench: **Fixes**
+
+- remove role and focusable attributes from the logo
 
 ## 3.14.0 - 16 March 2021
 

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -991,7 +991,6 @@
     </div>
     </div>
 
-    <h2>Discuss</h2>
-    <p>Please <a href="/community-and-contribution">get in touch</a> if you have any evidence to share or changes to suggest.</p>
+    
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
@@ -74,7 +74,13 @@
   <h2>Read more about sensitive topics</h2>
   <p>The sensitive topics reflect the "protected characteristics" in the <a href="https://www.legislation.gov.uk/ukpga/2010/15/contents">Equality Act 2010</a>. It is against the law to discriminate against anyone because of these characteristics.</p>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+{{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question",
     "previousPage": "Make sure you need each question",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users",

--- a/app/views/content/how-to-write-good-questions-for-forms/get-the-questions-into-order.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/get-the-questions-into-order.njk
@@ -56,7 +56,13 @@
   <p>You need to understand which questions your users expect first and how they group them. One way to do this is with a <a href="/content/how-to-write-good-questions-for-forms/test-your-questions#do-a-card-sorting-exercise">card sorting exercise</a>. Test the order again when you prototype your form.</p>
   <p>For example, do users expect to give you personal details at the start or do they want to deal with the task first and give you personal details at the end?</p>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+{{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users",
     "previousPage": "Use filter questions to route users",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation",

--- a/app/views/content/how-to-write-good-questions-for-forms/index.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/index.njk
@@ -45,11 +45,6 @@
     <li>Caroline Jarrett was our forms design subject matter expert.</li>
   </ul>
 
-  <h2>Help us improve this guidance</h2>
-  <ul>
-    <li><a href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/145">Contribute to the guidance on writing good questions via GitHub</a></li>
-    <li>Join us on the <a href="/slack">service manual Slack workspace</a></li>
-    <li>Email us at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a></li>
-  </ul>
+  
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question.njk
@@ -119,7 +119,13 @@
     <li><a href="https://www.gov.uk/service-manual/design/collecting-personal-information-from-users">Collecting personal information from users</a> (GOV.UK)</li>
   </ul>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+{{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions",
     "previousPage": "Understand the problem before you write your questions",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions",

--- a/app/views/content/how-to-write-good-questions-for-forms/test-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/test-your-questions.njk
@@ -128,7 +128,13 @@
     <li><a href="https://www.gov.uk/service-manual/user-research/using-moderated-usability-testing">Using moderated usability testing</a></li>
   </ul>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+{{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form",
     "previousPage": "Write the supporting content for your form"
   }) }}

--- a/app/views/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation.njk
@@ -158,7 +158,13 @@
   </ul>
   <p>Read more about how people react to questions and produce an answer in "The Psychology of Survey Response" by Tourangeau, Rips and Rasinki (2000).</p>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+{{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/get-the-questions-into-order",
     "previousPage": "Get the questions into order",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form",

--- a/app/views/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions.njk
@@ -47,7 +47,13 @@
   <h2>Read more about the discovery phase</h2>
   <p>GOV.UK has some good guidance on <a href="https://www.gov.uk/service-manual/agile-delivery/how-the-discovery-phase-works">how the discovery phase works</a>.</p>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+{{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/index",
     "previousPage": "How to write good questions for forms home page",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question",

--- a/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
@@ -139,7 +139,13 @@
   <p><a href="/content/how-to-write-good-questions-for-forms/test-your-questions">Read more about testing your questions</a>.</p>
   <p>If a lot of people cannot answer "Yes" or "No", reconsider your question.</p>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+ {{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions",
     "previousPage": "Consider the sensitivities around your questions",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/get-the-questions-into-order",

--- a/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
@@ -153,7 +153,13 @@
   <h2>Read more about writing content for transactions</h2>
   <p>GOV.UK has some good guidance on <a href="https://www.gov.uk/service-manual/design/govuk-content-transactions">designing how GOV.UK content and transactions work together</a>.</p>
 
-  {{ pagination({
+  
+
+{% endblock %}
+
+{% block afterContact %}
+
+ {{ pagination({
     "previousUrl": "/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation",
     "previousPage": "Think of the form as a conversation",
     "nextUrl": "/content/how-to-write-good-questions-for-forms/test-your-questions",

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -8,7 +8,7 @@
 {% if pageSection === "Content style guide" %}
 
 <p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
-<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, it's an open forum where we collect feedback</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, it's an open forum where we collect feedback.</p>
 {% endif %}
 <div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -19,6 +19,6 @@
     <span class="nhsuk-action-link__text">Share your research findings </span>
   </a>
 </div>
-<p>If you have any questions, you can <a href="https://service-manual.nhs.uk/slack">reach out to our community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us via email</a>.
+<p>If you have any questions, you can <a href="https://service-manual.nhs.uk/slack">reach out to our community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us by email</a>.
 </p>
 {% endif %}

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -8,7 +8,7 @@
 {% if pageSection === "Content style guide" %}
 
 <p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
-<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, it's an open forum where we collect feedback.</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>. It's an open forum where we collect feedback.</p>
 {% endif %}
 <div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -1,11 +1,16 @@
+{% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" or pageSection === "Content style guide" %}
+<h2 class="nhsuk-u-padding-top-4">Have you tested{% if subSection === "Styles" %} these styles{% endif %}{% if subSection === "Components" %} this component{% endif %}{% if subSection === "Patterns" %} this pattern{% endif %}{% if pageSection === "Content style guide" %} this guidance{% endif %}?</h2>
 {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
-  <h2 class="nhsuk-u-padding-top-4">Have you tested {% if subSection === "Styles" %} these styles{% endif %}{% if subSection === "Components" %} this component{% endif %}{% if subSection === "Patterns" %} this pattern{% endif %}?</h2>
 
-  <p> If so, please share your research findings and let us know how it has worked for you. This will help us improve it and help others.</p>
+<p> If so, please share your research findings and let us know how it has worked for you. This will help us improve it and help others.</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, It's an open forum where we collect feedback</p>
+{% endif %}
+{% if pageSection === "Content style guide" %}
 
-  <p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, It's an open forum where we collect feedback</p>
-
-  <div class="nhsuk-action-link">
+<p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, It's an open forum where we collect feedback</p>
+{% endif %}
+<div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">
     <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
       <path d="M0 0h24v24H0z" fill="none"></path>
@@ -14,7 +19,6 @@
     <span class="nhsuk-action-link__text">Share your research findings </span>
   </a>
 </div>
-
- <p>If you have questions about {% if subSection === "Styles" %} these styles{% endif %}{% if subSection === "Components" %} this component{% endif %}{% if subSection === "Patterns" %} this pattern{% endif %}, you can reach out to our <a href="https://service-manual.nhs.uk/slack">community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us via email</a>.
+<p>If you have questions about this, you can reach out to our <a href="https://service-manual.nhs.uk/slack">community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us via email</a>.
 </p>
 {% endif %}

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -19,6 +19,6 @@
     <span class="nhsuk-action-link__text">Share your research findings </span>
   </a>
 </div>
-<p>If you have questions about this, you can reach out to our <a href="https://service-manual.nhs.uk/slack">community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us via email</a>.
+<p>If you have any questions, you can <a href="https://service-manual.nhs.uk/slack">reach out to our community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us via email</a>.
 </p>
 {% endif %}

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -8,7 +8,7 @@
 {% if pageSection === "Content style guide" %}
 
 <p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
-<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, It's an open forum where we collect feedback</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, it's an open forum where we collect feedback</p>
 {% endif %}
 <div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -1,48 +1,20 @@
 {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
-  <h2 class="nhsuk-u-padding-top-4">Help improve this page</h2>
+  <h2 class="nhsuk-u-padding-top-4">Have you tested {% if subSection === "Styles" %} these styles{% endif %}{% if subSection === "Components" %} this component{% endif %}{% if subSection === "Patterns" %} this pattern{% endif %}?</h2>
 
-  {% if backlog_issue_id %}
-    <p>The manual is a community effort. Anyone can help improve and grow it.</p>
+  <p> If so, please share your research findings and let us know how it has worked for you. This will help us improve it and help others.</p>
 
-    <p>To help make sure the {{pageTitle}} guidance is useful, relevant and up to date, you can:</p>
+  <p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, It's an open forum where we collect feedback</p>
 
-    <ul class="nhsukuk-list nhsuk-list--bullet">
-      <li>
-        <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">share research or feedback about {% if subSection === "Components" or subSection === "Patterns" %}the {% endif %}{{pageTitle}}{% if subSection === "Components" %} component{% endif %}{% if subSection === "Patterns" %} pattern{% endif %} on GitHub</a>
-      </li>
-      <li>
-        <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual/blob/master/app/views/design-system/{{subSection|lower}}/{{pageTitle|lower|replace(" ", "-")|replace("'", "")}}.njk">propose a code change to this page on GitHub</a>
-      </li>
-    </ul>
-  {% else %}
-    <p>The service manual is a community effort. Anyone can help improve and grow it.</p>
-    {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
-    <p>If you spot a problem with the {{pageTitle}} guidance you can <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual/blob/master/app/views/design-system/{{subSection|lower}}/{{pageTitle|lower|replace(" ", "-")|replace("'", "")}}.njk">propose a code change</a>.</p>
-    {% else %}
-    <p>If you spot a problem with the {{pageTitle}} page you can <a class="app-contact-panel__link" href="https://github.com/nhsuk/nhsuk-service-manual/blob/master/app/views/{{subSection|lower|replace(" ", "-")|replace("'", "")}}/{{pageTitle|lower|replace(" ", "-")|replace("'", "")}}.njk">propose a code change</a>.</p>
-    {% endif %}
-  {% endif %}
-{% endif %}
-
-<div class="app-contact-panel">
-  {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" or pageTitle === "Production code" or pageTitle === "Prototyping" %}
-  <!--<h2 class="app-contact-panel__heading">Need help?</h2>-->
-  <h2 class="app-contact-panel__heading">Have you tested this?</h2>
-  {% else %}
-  <h2 class="app-contact-panel__heading">Get in touch</h2>
-  {% endif %}
-  <!--<p class="app-contact-panel__body">If you’ve got a question about the NHS digital service manual or want to feedback, <a href="/get-in-touch">get in touch</a>.</p>-->
-
-  <p class="app-contact-panel__body">We would appreciate you sharing your research findings on how this has worked for you. This will help us improve and help others.</p>
-
-  <p class="app-contact-panel__body">Before you start, you might need a <a href="https://github.com/login" target="_blank">GitHub account</a>, it's an open forum where we collect feedback.</p>
-
-  {% from 'action-link/macro.njk' import actionLink %}
-
-{{ actionLink({
-  "text": "Share your research findings",
-  "href": "https://"
-}) }}
-
-  <p class="app-contact-panel__body">If you just want to ask questions, you can reach out to our community forum which is hosted on <a href="https://service-manual.nhs.uk/slack">Slack</a>.</p>
+  <div class="nhsuk-action-link">
+  <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">
+    <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M0 0h24v24H0z" fill="none"></path>
+      <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
+    </svg>
+    <span class="nhsuk-action-link__text">Share your research findings </span>
+  </a>
 </div>
+
+ <p>If you have questions about {% if subSection === "Styles" %} these styles{% endif %}{% if subSection === "Components" %} this component{% endif %}{% if subSection === "Patterns" %} this pattern{% endif %}, you can reach out to our <a href="https://service-manual.nhs.uk/slack">community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us via email</a>.
+</p>
+{% endif %}

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -26,9 +26,23 @@
 
 <div class="app-contact-panel">
   {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" or pageTitle === "Production code" or pageTitle === "Prototyping" %}
-  <h2 class="app-contact-panel__heading">Need help?</h2>
+  <!--<h2 class="app-contact-panel__heading">Need help?</h2>-->
+  <h2 class="app-contact-panel__heading">Have you tested this?</h2>
   {% else %}
   <h2 class="app-contact-panel__heading">Get in touch</h2>
   {% endif %}
-  <p class="app-contact-panel__body">If you’ve got a question about the NHS digital service manual or want to feedback, <a href="/get-in-touch">get in touch</a>.</p>
+  <!--<p class="app-contact-panel__body">If you’ve got a question about the NHS digital service manual or want to feedback, <a href="/get-in-touch">get in touch</a>.</p>-->
+
+  <p class="app-contact-panel__body">We would appreciate you sharing your research findings on how this has worked for you. This will help us improve and help others.</p>
+
+  <p class="app-contact-panel__body">Before you start, you might need a <a href="https://github.com/login" target="_blank">GitHub account</a>, it's an open forum where we collect feedback.</p>
+
+  {% from 'action-link/macro.njk' import actionLink %}
+
+{{ actionLink({
+  "text": "Share your research findings",
+  "href": "https://"
+}) }}
+
+  <p class="app-contact-panel__body">If you just want to ask questions, you can reach out to our community forum which is hosted on <a href="https://service-manual.nhs.uk/slack">Slack</a>.</p>
 </div>

--- a/app/views/includes/app-layout.njk
+++ b/app/views/includes/app-layout.njk
@@ -48,6 +48,9 @@
             {% endif %}
           {% endblock %}
 
+          {% block afterContact %}
+          {% endblock %}
+
           {%- if dateUpdated %}
             <p class="nhsuk-body-s nhsuk-u-secondary-text-color nhsuk-u-margin-top-5 nhsuk-u-margin-bottom-0">Updated: {{dateUpdated}}</p>
           {% endif %}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This is a prototype based on improving the users access to our contribution process through the service manual website

We will use this pull request to review changes, updates et al
### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->
#1000 #1001 
## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
