### PR TITLE
Add contribution links within context #1000 #1001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 :wrench: **Fixes**
 
-- Redesigned `contact-panel.njk` to host new contextual contribution links
-- Fixed context links within `app-layout.njk`
-- Fixed context links within `/how-to-write-good-questions-for-forms`
+- Redesigned `includes/contact-panel.njk` to host new contextual contribution links
+- Fixed context links within `includes/app-layout.njk`
+- Fixed context links within `content/how-to-write-good-questions-for-forms`
 
 
 ## 3.14.2 - 18 March 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # NHS digital service manual Changelog
 
+## 3.14.3 - 30 March 2021
+
+:wrench: **Fixes**
+
+- Redesigned `contact-panel.njk` to host new contextual contribution links
+- Fixed context links within `app-layout.njk`
+- Fixed context links within `/how-to-write-good-questions-for-forms`
+
+
 ## 3.14.2 - 18 March 2021
 
 :wrench: **Fixes**

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -8,7 +8,7 @@
 {% if pageSection === "Content style guide" %}
 
 <p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
-<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>. It's an open forum where we collect feedback</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>. It's an open forum where we collect feedback.</p>
 {% endif %}
 <div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -8,7 +8,7 @@
 {% if pageSection === "Content style guide" %}
 
 <p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
-<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>. It's an open forum where we collect feedback.</p>
+<p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>. It's an open forum where we collect feedback</p>
 {% endif %}
 <div class="nhsuk-action-link">
   <a class="nhsuk-action-link__link" href="https://github.com/nhsuk/nhsuk-service-manual-backlog/issues/{{backlog_issue_id}}">

--- a/app/views/includes/_contact-panel.njk
+++ b/app/views/includes/_contact-panel.njk
@@ -1,13 +1,13 @@
 {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" or pageSection === "Content style guide" %}
-<h2 class="nhsuk-u-padding-top-4">Have you tested{% if subSection === "Styles" %} these styles{% endif %}{% if subSection === "Components" %} this component{% endif %}{% if subSection === "Patterns" %} this pattern{% endif %}{% if pageSection === "Content style guide" %} this guidance{% endif %}?</h2>
+<h2 class="nhsuk-u-padding-top-4">Have you{% if subSection === "Styles" %} tested these styles{% endif %}{% if subSection === "Components" %} tested this component{% endif %}{% if subSection === "Patterns" %} tested this pattern{% endif %}{% if pageSection === "Content style guide" %} used this guidance{% endif %}?</h2>
 {% if subSection === "Styles" or subSection === "Components" or subSection === "Patterns" %}
 
-<p> If so, please share your research findings and let us know how it has worked for you. This will help us improve it and help others.</p>
+<p> If so, please share your research findings and let us know how it has worked for you. This will help us improve it for everyone.</p>
 <p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>, It's an open forum where we collect feedback</p>
 {% endif %}
 {% if pageSection === "Content style guide" %}
 
-<p> Please let us know how this has worked for you. This will help us improve it for everyone.</p>
+<p> Please let us know how this has worked for you and, in particular, if you have research findings to share. This will help us improve it for everyone.</p>
 <p>Before you start, you will need a <a href="https://github.com/join?source=login">GitHub account</a>. It's an open forum where we collect feedback.</p>
 {% endif %}
 <div class="nhsuk-action-link">
@@ -16,7 +16,7 @@
       <path d="M0 0h24v24H0z" fill="none"></path>
       <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
     </svg>
-    <span class="nhsuk-action-link__text">Share your research findings </span>
+    <span class="nhsuk-action-link__text">Share your research findings on GitHub</span>
   </a>
 </div>
 <p>If you have any questions, you can <a href="https://service-manual.nhs.uk/slack">reach out to our community forum on Slack</a> or <a href="mailto:service-manual@nhs.net">contact us by email</a>.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "3.14.2",
+  "version": "3.14.3",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This is a prototype based on improving the users access to our contribution process through the service manual website

We will use this pull request to review changes, updates et al
### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->
#1000 #1001 
## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
