### PR TITLE
Add GOV.UK coronavirus style guide to our A to Z

### DIFF
--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -245,8 +245,7 @@
       <h3 id="contractions">contractions</h3>
       <p>To find out how we use contractions, like "we're" and "don't", see the guidance on <a href="/content/formatting-and-punctuation#contractions">contractions on the Formatting and punctuation page</a>.</p>
       <h3 id="coronavirus-(covid-19)">coronavirus (COVID-19)</h3>
-      <p>Coronavirus is the virus that causes the illness COVID-19. Write "coronavirus" in lower case.</p>
-      <p>We use the full term "coronavirus (COVID-19)" when we first mention the illness but after that we use "coronavirus" as that is what most people call it and search for.</p>
+      <p>Follow the <a href="https://www.gov.uk/guidance/style-guide/coronavirus-covid-19-a-to-z">coronavirus (COVID-19) A to Z on GOV.UK</a>.</p>
       <h3 id="CT-scan">CT scan</h3>
       <p>You don’t need to spell it out. The abbreviation is fine.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -22,7 +22,7 @@
           <div class="nhsuk-card app-card--transparent nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m"><a href="/whats-new">What's new</a></h2>
-              <p class="nhsuk-card__description">In March 2021 we removed the review date component and replaced it with the "<a href="/design-system/patterns/reassure-users-that-a-page-is-up-to-date">Reassure users that a page is up to date</a>" pattern</p>
+              <p class="nhsuk-card__description">In April 2021 we linked from our content style guide to the new <a href="https://www.gov.uk/guidance/style-guide/coronavirus-covid-19-a-to-z">coronavirus (COVID-19) A to Z on GOV.UK</a></p>
             </div>
           </div>
         </div>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,10 +9,10 @@
 
   <h2>Latest updates</h2>
 
-  <h3>March 2021</h3>
+  <h3>April 2021</h3>
 
   <table class="nhsuk-table">
-    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in March 2021</caption>
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in April 2021</caption>
     <thead class="nhsuk-table__head">
       <tr class="nhsuk-table__row">
         <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
@@ -20,28 +20,20 @@
       </tr>
     </thead>
     <tbody class="nhsuk-table__body">
-      
+
       <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Accessibility guidance</td>
+        <td class="nhsuk-table__cell">Service manual</td>
         <td class="nhsuk-table__cell">
-          <p>Updated guidance on accessibility statements within the <a href="/accessibility/product-and-delivery">product and delivery page</a></p>
+          <p>Added content in the design system, content style guide, accessibility guidance and service standard to encourage people to contribute and improve the service manual</p>
         </td>
       </tr>
 
       <tr>
-        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">Content style guide</td>
         <td class="nhsuk-table__cell">
-          <p>Removed the review date component and replaced it with the "<a href="/design-system/patterns/reassure-users-that-a-page-is-up-to-date">Reassure users that a page is up to date</a>" pattern</p>
+          <p>Linked from our A to Z entry for coronavirus (COVID-19) to the new <a href="https://www.gov.uk/guidance/style-guide/coronavirus-covid-19-a-to-z">coronavirus (COVID-19) A to Z on GOV.UK</a></p>
         </td>
       </tr>
-
-      <tr class="nhsuk-table__row">
-        <td class="nhsuk-table__cell">Team page</td>
-        <td class="nhsuk-table__cell">
-          <p>Added a new "<a href="/service-manual-team">service manual team</a>" page</p>
-        </td>
-      </tr>
-
     </tbody>
   </table>
 

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,6 +10,35 @@
 
 {% block bodyContent %}
 
+<h2>April 2021</h2>
+
+  <table class="nhsuk-table">
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in April 2021</caption>
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+        <th class="nhsuk-table__header" scope="col">Update</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+
+      <tr class="nhsuk-table__row">
+        <td class="nhsuk-table__cell">Service manual</td>
+        <td class="nhsuk-table__cell">
+          <p>Added content in the design system, content style guide, accessibility guidance and service standard to encourage people to contribute and improve the service manual</p>
+        </td>
+      </tr>
+
+      <tr>
+        <td class="nhsuk-table__cell">Content style guide</td>
+        <td class="nhsuk-table__cell">
+          <p>Linked from our A to Z entry for coronavirus (COVID-19) to the new <a href="https://www.gov.uk/guidance/style-guide/coronavirus-covid-19-a-to-z">coronavirus (COVID-19) A to Z on GOV.UK</a></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+
   <h2>March 2021</h2>
 
   <table class="nhsuk-table">
@@ -21,14 +50,14 @@
       </tr>
     </thead>
     <tbody class="nhsuk-table__body">
-      
+
       <tr class="nhsuk-table__row">
         <td class="nhsuk-table__cell">Accessibility guidance</td>
         <td class="nhsuk-table__cell">
           <p>Updated guidance on accessibility statements within the <a href="/accessibility/product-and-delivery">product and delivery page</a></p>
         </td>
       </tr>
-      
+
 
       <tr>
         <td class="nhsuk-table__cell">Design system</td>
@@ -44,7 +73,7 @@
           <p>Added a new "<a href="/service-manual-team">service manual team</a>" page</p>
         </td>
       </tr>
-      
+
     </tbody>
   </table>
 


### PR DESCRIPTION
## Description
Update the coronavirus (COVID-19) entry in our content style guide with a link to new GOV.UK coronavirus (COVID-19) A to Z.

### Related issue
Agreed at March 2021 Style Council meeting - one of [follow up actions](https://github.com/nhsuk/nhsuk-service-manual/issues/1064)

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - am doing this now.
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date - forgot this - will do it in staging.
