### PR TITLE
Update content example and research insight callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 4.1.3 - Unreleased
+
+:wrench: **Fixes**
+
+- Update content style guide example and research insight callout boxes
+
 ## 4.1.2 - 15 May 2021
 
 :wrench: **Fixes**

--- a/app/styles/app/_example-callout.scss
+++ b/app/styles/app/_example-callout.scss
@@ -16,6 +16,8 @@
 }
 
 .app-example__heading {
+  background: $color_nhsuk-grey-1;
+  border: 0;
   left: -1px;
   position: absolute;
   top: -1px;

--- a/app/views/content/formatting-and-punctuation.njk
+++ b/app/views/content/formatting-and-punctuation.njk
@@ -165,7 +165,7 @@
   <p>We use "to" instead of a dash for <a href="/content/numbers-measurements-dates-time#ranges">ranges of numbers, dates or time</a>.</p>
 
   <div class="nhsuk-inset-text nhsuk-u-margin-top-4">
-    <h3>Research insight</h3>
+    <h4 class="nhsuk-heading-m">Research insight</h4>
     <p>There are some accessibility concerns with dashes. Assistive technologies read them out in different ways. But <a href="https://accessibility.blog.gov.uk/2017/12/18/what-working-on-gov-uk-navigation-taught-us-about-accessibility/">GOV.UK research</a> shows that commas are consistently read out with a pause.</p>
     <p>People with poor literacy can find hyphens and dashes an obstacle to easy reading. They also find long sentences with lots of commas difficult.</p>
   </div>

--- a/app/views/content/formatting-and-punctuation.njk
+++ b/app/views/content/formatting-and-punctuation.njk
@@ -124,8 +124,8 @@
   <p>Do not use negative contractions like can't and don't. When you’re telling users not to do something, use "Do not" rather than "Don't".</p>
   <p>Avoid should've, could've, would've and they've. They can be hard to read.</p>
 
-  <div class="app-example app-example--content">
-    <strong class="nhsuk-tag app-example__heading">Research insight</strong>
+  <div class="nhsuk-inset-text nhsuk-u-margin-top-4">
+    <h3>Research insight</h3>
     <p>GDS research shows that many users find negative contractions harder to read and they sometimes misread them as the opposite of what they say.</p>
     <p>The NHS.UK medicines team observed that, when we're telling people not to do something, they find "do not" clearer and more emphatic than "don't".</p>
   </div>
@@ -164,8 +164,8 @@
   <p>Avoid using dashes to indicate a pause. Instead use a comma, or write shorter sentences.</p>
   <p>We use "to" instead of a dash for <a href="/content/numbers-measurements-dates-time#ranges">ranges of numbers, dates or time</a>.</p>
 
-  <div class="app-example app-example--content">
-    <strong class="nhsuk-tag app-example__heading">Research insight</strong>
+  <div class="nhsuk-inset-text nhsuk-u-margin-top-4">
+    <h3>Research insight</h3>
     <p>There are some accessibility concerns with dashes. Assistive technologies read them out in different ways. But <a href="https://accessibility.blog.gov.uk/2017/12/18/what-working-on-gov-uk-navigation-taught-us-about-accessibility/">GOV.UK research</a> shows that commas are consistently read out with a pause.</p>
     <p>People with poor literacy can find hyphens and dashes an obstacle to easy reading. They also find long sentences with lots of commas difficult.</p>
   </div>

--- a/app/views/content/how-we-write.njk
+++ b/app/views/content/how-we-write.njk
@@ -72,8 +72,8 @@
   <p>We use a plain English term first, then the medical term. Example: piles (haemorrhoids).</p>
   <p>We use the same style for specialist audiences like health professionals.</p>
 
-  <div class="app-example">
-    <strong class="nhsuk-tag app-example__heading">Research insight</strong>
+  <div class="nhsuk-inset-text nhsuk-u-margin-top-4">
+    <h3>Research insight</h3>
     <p>Research has shown that <a href="https://gds.blog.gov.uk/2014/02/17/guest-post-clarity-is-king-the-evidence-that-reveals-the-desperate-need-to-re-think-the-way-we-write/" title="External website">most people prefer to read plain English</a>, and that the more specialist a person's knowledge is, the greater their preference.</p>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description

### Problem

It's confusing that the 'Example' and 'Research insight' callouts are styled the same.

<img width="707" alt="Screenshot 2021-05-24 at 13 27 15" src="https://user-images.githubusercontent.com/14331000/119347911-12b58600-bc94-11eb-8e92-9b6c83a065a3.png">

### Solution

Use inset text component for 'Research insights'.

![Screenshot 2021-05-24 at 13 14 54](https://user-images.githubusercontent.com/14331000/119348142-5dcf9900-bc94-11eb-9cc5-446e37bbf126.png)

I've also reverted the 'Example' tag colour back to dark grey. This was inadvertently changed when we added the tag component.

![Screenshot 2021-05-24 at 13 13 10](https://user-images.githubusercontent.com/14331000/119348154-61fbb680-bc94-11eb-8b37-48ac3602cb46.png)

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry