### PR TITLE
[refs #1136] fix broken health literacy link on the service standard pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 4.1.4 - Unreleased
+
+:wrench: **Fixes**
+
+- Fix broken health literacy link on the service standard pages [Issue 1136](https://github.com/nhsuk/nhsuk-service-manual/issues/1136)
+
 ## 4.1.3 - 8 June 2021
 
 :wrench: **Fixes**

--- a/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/service-standard/5-make-sure-everyone-can-use-the-service.njk
@@ -34,7 +34,7 @@
   <h3>NHS digital service manual</h3>
   <ul>
     <li><a href="/accessibility">Accessibility: how to make digital services in the NHS work for everyone</a></li>
-    <li><a href="/content/health-literacy/">Health literacy</a></li>
+    <li><a href="/content/health-literacy">Health literacy</a></li>
     <li><a href="/content/inclusive-language">Inclusive language</a></li>
   </ul>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description

fix broken health literacy link on the service standard pages

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

fixes #1136 

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
