### PR TITLE
Change image in image component and explain captions

### DIFF
--- a/app/views/accessibility/partials/use-alternative-text-for-images-in-content.njk
+++ b/app/views/accessibility/partials/use-alternative-text-for-images-in-content.njk
@@ -1,8 +1,7 @@
 <h2 id="use-alternative-text-for-images-in-content">Use alternative text for images in content</h2>
 <p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
-<p>People who can't see a meaningful image need an alternative to understand the content. You need to add "alt-text" to explain what's in the image.</p>
+<p>People who cannot see a meaningful image need an alternative to understand the content. You need to add "alt-text" to explain what's in the image. Alt-text is not usually visible but is read out by screen readers or displayed if an image does not load or if images have been switched off.</p>
 <p>You can see what alt-text an image has by viewing it with <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Chrome's Web Developer toolbar</a>.</p>
-
 <details class="nhsuk-details">
   <summary class="nhsuk-details__summary">
     <span class="nhsuk-details__summary-text">
@@ -11,10 +10,10 @@
   </summary>
   <div class="nhsuk-details__text">
     <p>The content of the alt-text depends on the image and its context. If the image is part of the main content of the page (not a functional image - one that triggers an action), use the alt-text to describe the image in a way that makes sense in the context.</p>
-    <p>You don't need to explain that it's an image because screenreaders usually announce that.</p>
+    <p>You don't need to explain that it's an image because screen readers usually announce that.</p>
     <p>Keep alt-text to a sentence or 2 and ideally under 125 characters including spaces. If there's important information that you cannot fit in 125 characters (for example, you're describing a complex chart), include this information in the alt-text or consider linking to more information for screen reader users. (For example, the NHS website team is testing long descriptions to describe images of conditions appearing on a range of skin tones.)</p>
     <p>Imagine you were reading the page out to a friend. How would you describe the image?</p>
-    <p>This is an image from the <a href="https://www.nhs.uk/conditions/bullous-pemphigoid/">bullous pemphigoid page on the NHS website (nhs.uk)</a>. It comes under a heading "Check if you have bullous pemphigoid". The alt-text is: "Lots of sore red patches with small blisters spread across white skin on a woman's chest." It explains what users can see in the picture.</p>
+    <p>This is an image from the <a href="https://www.nhs.uk/conditions/bullous-pemphigoid/">bullous pemphigoid page on the NHS website</a>. It comes under a heading "Check if you have bullous pemphigoid". The alt-text is: "Lots of sore red patches with small blisters spread across white skin on a woman's chest." It explains what users can see in the picture.</p>
 
     <figure class="nhsuk-image nhsuk-u-margin-top-6">
       <img class="nhsuk-image__img" src="https://assets.nhs.uk/prod/images/S_0318_Bullous_pemphigoid_lesions_.2e16d0ba.fill-320x213.jpg" alt="Lots of sore red patches with small blisters spread across white skin on a woman's chest.">
@@ -22,19 +21,10 @@
         It can affect large areas of the body or limbs.
       </figcaption>
     </figure>
-
-    <p>The caption underneath the image assumes that the user can either see the image or read the alt-text. It shouldn't duplicate the alt-text. Instead, use it to explain why the image is there and what you want users to conclude from it - for example, how serious their symptom is or what stage their condition has reached.</p>
-    <p>Here's another example. The alt-text is "Small red spots on white skin". The caption explains that that's how chickenpox starts.</p>
-
-    <figure class="nhsuk-image nhsuk-u-margin-top-6">
-      <img class="nhsuk-image__img" src="https://assets.nhs.uk/prod/images/ABF9YH_GDGeL2X.2e16d0ba.fill-320x213.jpg" alt="Small red spots on white skin">
-      <figcaption class="nhsuk-image__caption">
-        1. Chickenpox starts with red spots. They can appear anywhere on the body.
-      </figcaption>
-    </figure>
-
+    <p>This example has a caption underneath the image as well as alt-text. Read about captions and how they work with alt-text in the <a href="/design-system/components/images">images</a> component.</p>
     <p>If you have a complex image that you can't describe in short alt-text (such as an infographic), include a longer description in some other way. You can use <a href="/design-system/components/expander">an expander</a>, for example, underneath the infographic with a text explanation.</p>
     <p>If your image has text which conveys its meaning, follow <a href="/accessibility/development#use-alternative-text-for-functional-images">the guidance on functional images</a>. An example would be a link to a health app which includes a brand image and the name of the app. The app name says the same as the brand image, so the image doesn't need explaining.</p>
+
   </div>
 </details>
 

--- a/app/views/design-system/components/images/default/index.njk
+++ b/app/views/design-system/components/images/default/index.njk
@@ -1,7 +1,7 @@
 {% from 'images/macro.njk' import image %}
 
 {{ image({
-  "src": "https://assets.nhs.uk/prod/images/S_1017_allergic-conjunctivitis_M15.2e16d0ba.fill-320x213.jpg",
-  "alt": "Picture of allergic conjunctivitis",
-  "caption": "Itchy, red, watering eyes"
+  "src": "https://assets.nhs.uk/prod/images/S_0318_Bullous_pemphigoid_lesions_.2e16d0ba.fill-320x213.jpg",
+  "alt": "Lots of sore red patches with small blisters spread across white skin on a woman's chest.",
+  "caption": "It can affect large areas of the body or limbs."
 }) }}

--- a/app/views/design-system/components/images/index.njk
+++ b/app/views/design-system/components/images/index.njk
@@ -30,24 +30,33 @@
   <p>Images should flow with the text content, not appear too prominent or isolated.</p>
   <p>We recommend stacking images. We've found that gallery views (images side by side) confuse users.</p>
   <h3>Captions</h3>
-  <p>The image component is made up of 2 elements - the image and caption - in a white box.</p>
+  <p>The image component is made up of 2 elements - the image and a caption underneath it in a white box.</p>
   <p>Not all images need captions. If you use them:</p>
   <ul>
     <li>write a full sentence ending with a full stop</li>
-    <li>do not duplicate alt-text</li>
-    <li>use the caption to explain why the image is there and what you want users to conclude from the image</li>
+    <li>do not duplicate alt-text (<a href="#alternative-text">alternative text</a>)</li>
   </ul>
-  <p>Read more about captions in the guidance on <a href="/accessibility/content#use-alternative-text-for-images-in-content">alt-text for images in content</a>.</p>
+  <p>The caption assumes that the user can either see the image or read the alt-text. Use it to explain what you want users to conclude from it - for example, how serious their symptom is or what stage their condition has reached.</p>
+  <p>Here's an example. The alt-text is "Small red spots on white skin". The caption explains that that's how chickenpox starts.</p>
 
+    <figure class="nhsuk-image nhsuk-u-margin-top-6">
+      <img class="nhsuk-image__img" src="https://assets.nhs.uk/prod/images/ABF9YH_GDGeL2X.2e16d0ba.fill-320x213.jpg" alt="Small red spots on white skin">
+      <figcaption class="nhsuk-image__caption">
+        1. Chickenpox starts with red spots. They can appear anywhere on the body.
+      </figcaption>
+    </figure>
 
   <h3>Accessibility</h3>
-  <p><a href="/accessibility/content#use-alternative-text-for-images-in-content">Follow our guidance on making images accessible</a>. Images must have text alternatives that describe the information or function they represent. This makes sure that people with disabilities can understand them.</p>
-  <p>When using an image (or the img element), specify a text alternative with the alt attribute. Alternative text, or alt text, is read out by screen readers or displayed if an image does not load or if images have been switched off.</p>
   <p>Do not use images that have words in them, because screen readers will not be able to read the words.</p>
+  <h4 id="alternative-text">Alternative text (alt-text)</h4>
+  <p>Images must have text alternatives that describe the information or function they represent. This makes sure that people with disabilities can understand them.</p>
+  <p>When using an image (or the img element), specify a text alternative with the alt attribute.</p>
+  <p>Alt-text is not usually visible but is read out by screen readers or displayed if an image does not load or if images have been switched off.</p>
+  <p>Read more about alt-text in the guidance on <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alt-text for images in content</a>.</p>
 
   <h2>Research</h2>
   <p>In testing we found gallery views (images side by side) confused users. Users either missed the images in the right hand column or they didn't know how to interpret the sequence. To get around this we recommend stacking images.</p>
   <p>We also found that users clicked images in gallery views, expecting them to appear larger in a pop-up modal. When we increased the size of the images and stacked them in 1 column (not 2), we didn't see anyone clicking on them to expand them.</p>
-  <p>We tested images on the <a href="https://www.nhs.uk/conditions/chickenpox/">chickenpox</a> page on nhs.uk in 2018. They tested well and all users said that the images helped them understand the symptoms.</p>
+  <p>We tested images on the <a href="https://www.nhs.uk/conditions/chickenpox/">chickenpox</a> page on the NHS website in 2018. They tested well and all users said that the images helped them understand the symptoms.</p>
 
 {% endblock %}

--- a/app/views/design-system/components/images/index.njk
+++ b/app/views/design-system/components/images/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use images only if there is a real user need. Avoid unnecessary decoration." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "December 2020" %}
+{% set dateUpdated = "June 2021" %}
 {% set backlog_issue_id = "28" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -27,9 +27,18 @@
   <p>We are working on more guidance about when to use images. We expect to publish it in 2021.</p>
 
   <h2>How to use images</h2>
-  <p>The image component is made up of 2 elements - the image and caption - in a white box.</p>
   <p>Images should flow with the text content, not appear too prominent or isolated.</p>
   <p>We recommend stacking images. We've found that gallery views (images side by side) confuse users.</p>
+  <h3>Captions</h3>
+  <p>The image component is made up of 2 elements - the image and caption - in a white box.</p>
+  <p>Not all images need captions. If you use them:</p>
+  <ul>
+    <li>write a full sentence ending with a full stop</li>
+    <li>do not duplicate alt-text</li>
+    <li>use the caption to explain why the image is there and what you want users to conclude from the image</li>
+  </ul>
+  <p>Read more about captions in the guidance on <a href="/accessibility/content#use-alternative-text-for-images-in-content">alt-text for images in content</a>.</p>
+
 
   <h3>Accessibility</h3>
   <p><a href="/accessibility/content#use-alternative-text-for-images-in-content">Follow our guidance on making images accessible</a>. Images must have text alternatives that describe the information or function they represent. This makes sure that people with disabilities can understand them.</p>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -14,10 +14,12 @@
   <table class="nhsuk-table">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in June 2021</caption>
     <thead class="nhsuk-table__head">
+      <tbody class="nhsuk-table__body">
        <tr>
         <td class="nhsuk-table__cell">Accessibility guidance</td>
         <td class="nhsuk-table__cell">
-          <p>Updated guidance on length of alt-text in <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alternative text for images in content</a></p>
+          <p>Updated guidance on length of alt-text in section on <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alternative text for images in content</a></p>
+          <p>Moved guidance on image captions from the accessibility guidance to the <a href="/design-system/components/images">images component</a></p>
         </td>
       </tr>
       <tr>
@@ -28,6 +30,13 @@
           <p>Some guidance on writing about skin colour in the section on <a href="/content/inclusive-language#race-ethnicity-religion-nationality">Race, ethnicity, religion and nationality</a> on the Inclusive language page</p>
           <p>Updated entries in the A to Z of NHS health writing on <a href="/content/a-to-z-of-nhs-health-writing#immunisation">immunisation</a>, <a href="/content/a-to-z-of-nhs-health-writing#jab">jab</a>, <a href="/content/a-to-z-of-nhs-health-writing#vaccine">vaccine</a>, and <a href="/content/a-to-z-of-nhs-health-writing#vaccination">vaccination</a></p>
           <p>New entries in the A to Z for <a href="/content/a-to-z-of-nhs-health-writing#GP-online-services">GP online services</a> and <a href="/content/a-to-z-of-nhs-health-writing#ID">ID</a></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">
+          <p>Brought all guidance on captions together in the <a href="/design-system/components/images">images component</a></p>
+          <p>Brought the <a href="/design-system/components/images">images component</a> example into line with the accessiblity guidance on <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alt-text for images in content</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -21,10 +21,11 @@
       </tr>
     </thead>
     <tbody class="nhsuk-table__body">
-      <tr>
+       <tr>
         <td class="nhsuk-table__cell">Accessibility guidance</td>
         <td class="nhsuk-table__cell">
-          <p>Updated guidance on length of alt-text in <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alternative text for images in content</a></p>
+          <p>Updated guidance on length of alt-text in section on <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alternative text for images in content</a></p>
+          <p>Moved guidance on image captions from the accessibility guidance to the <a href="/design-system/components/images">images component</a></p>
         </td>
       </tr>
       <tr>
@@ -35,6 +36,13 @@
           <p>Some guidance on writing about skin colour in the section on <a href="/content/inclusive-language#race-ethnicity-religion-nationality">Race, ethnicity, religion and nationality</a> on the Inclusive language page</p>
           <p>Updated entries in the A to Z of NHS health writing on <a href="/content/a-to-z-of-nhs-health-writing#immunisation">immunisation</a>, <a href="/content/a-to-z-of-nhs-health-writing#jab">jab</a>, <a href="/content/a-to-z-of-nhs-health-writing#vaccine">vaccine</a>, and <a href="/content/a-to-z-of-nhs-health-writing#vaccination">vaccination</a></p>
           <p>New entries in the A to Z for <a href="/content/a-to-z-of-nhs-health-writing#GP-online-services">GP online services</a> and <a href="/content/a-to-z-of-nhs-health-writing#ID">ID</a></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">
+          <p>Brought all guidance on captions together in the <a href="/design-system/components/images">images component</a></p>
+          <p>Brought <a href="/design-system/components/images">images component</a> example into line with the accessiblity guidance on <a href="/accessibility/content#use-alternative-text-for-images-in-content">using alt-text for images in content</a></p>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description
At Style Council, we agreed to bring the example image in the image component into line with the accessibility guidance example. Having 2 examples was confusing and the accessibility guidance example is the better one.

Also add more guidance about captions - agreed at Style Council

### Related issue
https://github.com/nhsuk/nhsuk-service-manual/issues/1231

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - not yet
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - not yet
- [x] Page updated date - done
