### PR TITLE
Update placeholder colour to darker grey to increase colour contrast

### DIFF
--- a/app/styles/app/_autocomplete.scss
+++ b/app/styles/app/_autocomplete.scss
@@ -80,7 +80,7 @@
     }
 
     &::placeholder {
-      color: $color_nhsuk-grey-2;
+      color: $color_nhsuk-grey-1;
       font-size: $nhsuk-base-font-size;
     }
   }


### PR DESCRIPTION
## Description
Update the search input field placeholder colour to the darker grey to pass colour contrast levels, as per the frontend library:
https://github.com/nhsuk/nhsuk-frontend/blob/7dc973d2f5d2ae788edb9625bde72b879b4969bc/packages/components/header/_header.scss#L187

### Related issue
none

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
