### PR TITLE
Add real error message to example

### DIFF
--- a/app/views/design-system/components/date-input/with-errors/index.njk
+++ b/app/views/design-system/components/date-input/with-errors/index.njk
@@ -13,7 +13,7 @@
     "text": "For example, 15 3 1984"
   },
   "errorMessage": {
-    "text": "Error message goes here"
+    "text": "Enter your date of birth"
   },
   "items": [
     {


### PR DESCRIPTION
Where possible, I advocate using real content in examples as opposed to placeholder or indicative content. 

This PR proposes to change the error message text in the date input example to "Enter your date of birth" which:

- is appropriate for the context of the example
- follows GOV.UK Design System guidance on error messages for date inputs: https://design-system.service.gov.uk/components/date-input/

## Description
<!--- Describe your changes in detail -->

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
