### PR TITLE
Add links to satisfaction survey

### DIFF
--- a/app/views/get-in-touch.njk
+++ b/app/views/get-in-touch.njk
@@ -1,6 +1,6 @@
 {% set pageTitle = "Get in touch" %}
 {% set pageDescription = "If you’ve got a question, idea or suggestion, get in touch with the service manual team." %}
-{% set dateUpdated = "August 2020" %}
+{% set dateUpdated = "July 2021" %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}
 
@@ -11,5 +11,8 @@
 
   <h2>Email</h2>
   <p>Email the service manual team on <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
+
+  <h2>Feedback</h2>
+  <p>Let us know about your visit to the service manual today by filling in <a href="https://feedback.digital.nhs.uk/jfe/form/SV_9GIQAEkm6gfFCWp">our survey on the Qualtrics website</a>.</p>
 
 {% endblock %}

--- a/app/views/includes/_footer.njk
+++ b/app/views/includes/_footer.njk
@@ -5,6 +5,7 @@
       <ul class="nhsuk-footer__list app-footer__list">
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/accessibility-statement">Accessibility statement</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/cookie-policy">Cookie policy</a></li>
+        <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="https://feedback.digital.nhs.uk/jfe/form/SV_9GIQAEkm6gfFCWp">Feedback survey</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/get-in-touch">Get in touch</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/service-manual-team">Service manual team</a></li>
         <li class="nhsuk-footer__list-item"><a class="nhsuk-footer__list-item-link" href="/site-map">Site map</a></li>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -85,6 +85,9 @@
       <hr class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-6">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
+
+          <h2>Feedback</h2>
+          <p>Let us know about your visit to the service manual today by filling in <a href="https://feedback.digital.nhs.uk/jfe/form/SV_9GIQAEkm6gfFCWp">our survey on the Qualtrics website</a>.</p>
           <h2>Support</h2>
           <p>The manual is maintained by the <a href="/service-manual-team">service manual team at NHS Digital</a>. If you've got a question or want to feedback, you can <a href="/get-in-touch">get in touch</a>.</p>
         </div>


### PR DESCRIPTION
## Description
Add 3 links to the satisfaction survey to:
- index page
- footer
- Get in touch page

### Related issue
https://github.com/nhsuk/nhsuk-service-manual/issues/1309

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - will do tomorrow
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - I'll do this tomorrow.
- [ ] Page updated date - done on Get in touch page
