### PR TITLE
import and initialise the Error Summary JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 5.0.6 - 23 August 2021
+
+:wrench: **Fixes**
+
+- Import and initialise the Error Summary JavaScript so the component example works as expected [NHS.UK frontend issue #766](https://github.com/nhsuk/nhsuk-frontend/issues/766)
+
 ## 5.0.5 - 17 August 2021
 
 :wrench: **Fixes**

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -8,6 +8,7 @@ import Details from '../../node_modules/nhsuk-frontend/packages/components/detai
 import Checkboxes from '../../node_modules/nhsuk-frontend/packages/components/checkboxes/checkboxes';
 import Radios from '../../node_modules/nhsuk-frontend/packages/components/radios/radios';
 import Card from '../../node_modules/nhsuk-frontend/packages/components/card/card';
+import ErrorSummary from '../../node_modules/nhsuk-frontend/packages/components/error-summary/error-summary';
 
 // NHS.UK frontend polyfills
 import '../../node_modules/nhsuk-frontend/packages/polyfills';
@@ -40,6 +41,7 @@ SkipLink();
 Checkboxes();
 Radios();
 Card();
+ErrorSummary();
 
 // Initialise NHS digital service manual components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description

- Import and initialise the Error Summary JavaScript so the component example works as expected

### Related issue

https://github.com/nhsuk/nhsuk-frontend/issues/766

## Checklist

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
