### PR TITLE
use the correct Service Header example on the Header components page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 5.0.6 - Unreleased
+
+:wrench: **Fixes**
+
+- Use the correct Service Header example on the Header components page
+
 ## 5.0.5 - 17 August 2021
 
 :wrench: **Fixes**

--- a/app/views/design-system/components/header/index.njk
+++ b/app/views/design-system/components/header/index.njk
@@ -52,7 +52,7 @@
   {{ designExample({
     group: "components",
     item: "header",
-    type: "default"
+    type: "service"
   }) }}
 
   <h3 id="transactional-header">Transactional header</h3>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description

use the correct Service Header example on the Header components page as it was using the default header twice