### PR TITLE
use anchor link instead of button for start now

### DIFF
--- a/app/views/design-system/patterns/start-page/example/index.njk
+++ b/app/views/design-system/patterns/start-page/example/index.njk
@@ -39,9 +39,7 @@
       <p>The online service is also available in <a href="#">Welsh (Cymraeg)</a>.</p>
       <p>Find out more about <a href="#">this service</a> [for example, related policy information.]<p>
 
-      {{ button({
-        "text": "Start now"
-      }) }}
+      <a class="nhsuk-button" href="#" role="button" draggable="false">Start now</a>
 
       <p>By using this service you are agreeing to our <a href="#">terms of use </a>and <a href="#">privacy policy</a>.</p>
 


### PR DESCRIPTION
## Description

Start now link should be an anchor tag styled as button so that it is semantically correct.

Also removed an empty folder.