### PR TITLE
Checkboxes add an option for none example and guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :new: **New features**
 
 - Checkboxes Add an option for ‘none’ example and guidance
+
 ## 5.2.0 - 22 September 2021
 
 :new: **New features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NHS digital service manual Changelog
 
+## 5.3.0 - Unreleased
+
+:new: **New features**
+
+- Checkboxes Add an option for ‘none’ example and guidance
 ## 5.2.0 - 22 September 2021
 
 :new: **New features**

--- a/app/views/design-system/components/checkboxes/conditional/index.njk
+++ b/app/views/design-system/components/checkboxes/conditional/index.njk
@@ -34,40 +34,42 @@
   }) }}
 {% endset -%}
 
-{{ checkboxes({
-  "idPrefix": "contact",
-  "name": "contact",
-  "fieldset": {
-    "legend": {
-      "text": "How would you prefer to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": "true"
-    }
-  },
-  "hint": {
-    "text": "Select all options that are relevant to you."
-  },
-  "items": [
-    {
-      "value": "email",
-      "text": "Email",
-      "conditional": {
-        "html": emailHtml
+<form>
+  {{ checkboxes({
+    "idPrefix": "contact",
+    "name": "contact",
+    "fieldset": {
+      "legend": {
+        "text": "How would you prefer to be contacted?",
+        "classes": "nhsuk-fieldset__legend--l",
+        "isPageHeading": "true"
       }
     },
-    {
-      "value": "phone",
-      "text": "Phone",
-      "conditional": {
-        "html": phoneHtml
-      }
+    "hint": {
+      "text": "Select all options that are relevant to you."
     },
-    {
-      "value": "text",
-      "text": "Text message",
-      "conditional": {
-        "html": mobileHtml
+    "items": [
+      {
+        "value": "email",
+        "text": "Email",
+        "conditional": {
+          "html": emailHtml
+        }
+      },
+      {
+        "value": "phone",
+        "text": "Phone",
+        "conditional": {
+          "html": phoneHtml
+        }
+      },
+      {
+        "value": "text",
+        "text": "Text message",
+        "conditional": {
+          "html": mobileHtml
+        }
       }
-    }
-  ]
-}) }}
+    ]
+  }) }}
+</form>

--- a/app/views/design-system/components/checkboxes/default/index.njk
+++ b/app/views/design-system/components/checkboxes/default/index.njk
@@ -1,30 +1,32 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
-{{ checkboxes({
-  "idPrefix": "example",
-  "name": "example",
-  "fieldset": {
-    "legend": {
-      "text": "How would you like to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
-      isPageHeading: true
-    }
-  },
-  "hint": {
-    "text": "Select all options that are relevant to you."
-  },
-  "items": [
-    {
-      "value": "email",
-      "text": "Email"
+<form>
+  {{ checkboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "legend": {
+        "text": "How would you like to be contacted?",
+        "classes": "nhsuk-fieldset__legend--l",
+        isPageHeading: true
+      }
     },
-    {
-      "value": "phone",
-      "text": "Phone"
+    "hint": {
+      "text": "Select all options that are relevant to you."
     },
-    {
-      "value": "text message",
-      "text": "Text message"
-    }
-  ]
-}) }}
+    "items": [
+      {
+        "value": "email",
+        "text": "Email"
+      },
+      {
+        "value": "phone",
+        "text": "Phone"
+      },
+      {
+        "value": "text message",
+        "text": "Text message"
+      }
+    ]
+  }) }}
+</form>

--- a/app/views/design-system/components/checkboxes/error-messages/index.njk
+++ b/app/views/design-system/components/checkboxes/error-messages/index.njk
@@ -1,34 +1,36 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
-{{ checkboxes({
-  "idPrefix": "contact",
-  "name": "contact",
-  "fieldset": {
-    "legend": {
-      "text": "How would you like to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
-      isPageHeading: true
-    }
-  },
-  "hint": {
-    "text": "Select all options that are relevant to you."
-  },
-  "errorMessage": {
-    "text": "Select how you like to be contacted"
-  },
-  "items": [
-    {
-      "value": "email",
-      "text": "Email",
-      id: "contact"
+<form>
+  {{ checkboxes({
+    "idPrefix": "contact",
+    "name": "contact",
+    "fieldset": {
+      "legend": {
+        "text": "How would you like to be contacted?",
+        "classes": "nhsuk-fieldset__legend--l",
+        isPageHeading: true
+      }
     },
-    {
-      "value": "phone",
-      "text": "Phone"
+    "hint": {
+      "text": "Select all options that are relevant to you."
     },
-    {
-      "value": "text message",
-      "text": "Text message"
-    }
-  ]
-}) }}
+    "errorMessage": {
+      "text": "Select how you like to be contacted"
+    },
+    "items": [
+      {
+        "value": "email",
+        "text": "Email",
+        id: "contact"
+      },
+      {
+        "value": "phone",
+        "text": "Phone"
+      },
+      {
+        "value": "text message",
+        "text": "Text message"
+      }
+    ]
+  }) }}
+</form>

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use checkboxes to let users select 1 or more options on a form." %}
 {% set theme = "Form elements" %}
-{% set dateUpdated = "April 2020" %}
+{% set dateUpdated = "September 2021" %}
 {% set backlog_issue_id = "9" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -55,7 +55,7 @@
   }) }}
 
   <h3 id="conditionally-revealing-content">Conditionally revealing content</h3>
-  <p>You can add conditionally revealing content to checkboxes, so users only see content when it’s relevant to them.</p>
+  <p>You can add conditionally revealing content to checkboxes, so users only see content when it's relevant to them.</p>
   <p>For example, you could reveal a phone number input only when a user chooses to be contacted by phone.</p>
 
   {{ designExample({
@@ -64,15 +64,16 @@
     type: "conditional"
   }) }}
 
-  <p>Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.</p>
+  <p>Keep it simple. If you need to add a lot of content, consider showing it on the next page in the process instead.</p>
 
-  <h3 id="none-option">Add an option for ‘none’</h3>
-  <p>When ‘none’ would be a valid answer, give users the option to check a box to say none of the other options apply to them — without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.</p>
-  <p>Remember to start by asking one question per page. You might be able to remove the need for a ‘none’ option by asking the user a better question or filtering them out with a ‘filter question’ beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
-  <p>Show the ‘none’ option last. Separate it from the other options using a divider. The text is usually the word ‘or’.</p>
+  <h3 id="none-option">Add an option for "none"</h3>
+  <p>When "none" would be a valid answer, give users the option to check a box to say none of the other options apply to them.</p>
+  <p>Without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.</p>
+  <p>Remember to start by asking 1 question per page. You might be able to remove the need for a "none" option by asking the user a better question or filtering them out with a "filter question" beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
+  <p>Show the "none" option last. Separate it from the other options using a divider. The text is usually the word "or".</p>
   <p>Write a label that repeats the key part of the question.</p>
-  <p>For example, for the question ‘Will you be travelling to any of these countries?’, say ‘No, I will not be travelling to any of these countries’.</p>
-  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks ‘None’, add the <code>exclusive</code> behaviour to the ‘none’ checkbox.</p>
+  <p>For example, for the question "Will you be travelling to any of these countries?", say "No, I will not be travelling to any of these countries".</p>
+  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>exclusive</code> behaviour to the "none" checkbox.</p>
 
   {{ designExample({
     group: "components",
@@ -80,7 +81,7 @@
     type: "none-option"
   }) }}
 
-   <p>If JavaScript is unavailable, and a user selects both the ‘none’ checkbox and another checkbox, display an error message.</p>
+   <p>If JavaScript is unavailable, and a user selects both the "none" checkbox and another checkbox, display an error message.</p>
 
   <h3 id="error-messages">Error messages</h3>
   <p>Error messages should be styled like this:</p>

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -66,6 +66,22 @@
 
   <p>Keep it simple - if you need to add a lot of content, consider showing it on the next page in the process instead.</p>
 
+  <h3 id="none-option">Add an option for ‘none’</h3>
+  <p>When ‘none’ would be a valid answer, give users the option to check a box to say none of the other options apply to them — without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.</p>
+  <p>Remember to start by asking one question per page. You might be able to remove the need for a ‘none’ option by asking the user a better question or filtering them out with a ‘filter question’ beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
+  <p>Show the ‘none’ option last. Separate it from the other options using a divider. The text is usually the word ‘or’.</p>
+  <p>Write a label that repeats the key part of the question.</p>
+  <p>For example, for the question ‘Will you be travelling to any of these countries?’, say ‘No, I will not be travelling to any of these countries’.</p>
+  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks ‘None’, add the <code>exclusive</code> behaviour to the ‘none’ checkbox.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "checkboxes",
+    type: "none-option"
+  }) }}
+
+   <p>If JavaScript is unavailable, and a user selects both the ‘none’ checkbox and another checkbox, display an error message.</p>
+
   <h3 id="error-messages">Error messages</h3>
   <p>Error messages should be styled like this:</p>
 

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -72,7 +72,7 @@
   <p>Remember to start by asking 1 question per page. You might be able to remove the need for a "none" option by asking the user a better question. Or try filtering them out with a "filter question" beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
   <p>Show the "none" option last. Separate it from the other options using a divider, normally the word "Or".</p>
   <p>Write a label that repeats the key part of the question. For example, for the question "Do you have any of these symptoms?", say "No, I do not have any of these symptoms".</p>
-  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>data-checkbox-exclusive-group</code> behaviour to the "none" checkbox.</p>
+  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>data-checkbox-exclusive</code> behaviour to the "none" checkbox.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -66,14 +66,13 @@
 
   <p>Keep it simple. If you need to add a lot of content, consider showing it on the next page in the process instead.</p>
 
-  <h3 id="none-option">Add an option for "none"</h3>
-  <p>When "none" would be a valid answer, give users the option to check a box to say none of the other options apply to them.</p>
-  <p>Without this option, users would have to leave all of the boxes unchecked. Giving users this option also makes sure they do not skip the question by accident.</p>
-  <p>Remember to start by asking 1 question per page. You might be able to remove the need for a "none" option by asking the user a better question or filtering them out with a "filter question" beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
-  <p>Show the "none" option last. Separate it from the other options using a divider. The text is usually the word "or".</p>
-  <p>Write a label that repeats the key part of the question.</p>
-  <p>For example, for the question "Will you be travelling to any of these countries?", say "No, I will not be travelling to any of these countries".</p>
-  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>exclusive</code> behaviour to the "none" checkbox.</p>
+  <h3 id="none-option">Adding an option for "none"</h3>
+  <p>You can give users the option to say none of the other options apply to them. </p>
+  <p>This option means users need to actively select "none" rather than leave all the boxes unchecked, which makes sure they do not skip the question by accident.</p>
+  <p>Remember to start by asking one question per page. You might be able to remove the need for a "none" option by asking the user a better question or filtering them out with a ‘filter question’ beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
+  <p>Show the "none" option last. Separate it from the other options using a divider with the word "Or".</p>
+  <p>Write a label that repeats the key part of the question. For example, for the question "Do you have any of these symptoms?", say "No, I do not have any of these symptoms".</p>
+  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>data-checkbox-exclusive-group</code> behaviour to the "none" checkbox.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -69,8 +69,8 @@
   <h3 id="none-option">Adding an option for "none"</h3>
   <p>You can give users the option to say none of the other options apply to them. </p>
   <p>This option means users need to actively select "none" rather than leave all the boxes unchecked, which makes sure they do not skip the question by accident.</p>
-  <p>Remember to start by asking one question per page. You might be able to remove the need for a "none" option by asking the user a better question or filtering them out with a ‘filter question’ beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
-  <p>Show the "none" option last. Separate it from the other options using a divider with the word "Or".</p>
+  <p>Remember to start by asking 1 question per page. You might be able to remove the need for a "none" option by asking the user a better question. Or try filtering them out with a "filter question" beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
+  <p>Show the "none" option last. Separate it from the other options using a divider, normally the word "Or".</p>
   <p>Write a label that repeats the key part of the question. For example, for the question "Do you have any of these symptoms?", say "No, I do not have any of these symptoms".</p>
   <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>data-checkbox-exclusive-group</code> behaviour to the "none" checkbox.</p>
 

--- a/app/views/design-system/components/checkboxes/items-with-hints/index.njk
+++ b/app/views/design-system/components/checkboxes/items-with-hints/index.njk
@@ -1,33 +1,35 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
-{{ checkboxes({
-  idPrefix: "nationality",
-  name: "nationality",
-  fieldset: {
-    legend: {
-      text: "What is your nationality?",
-      isPageHeading: true,
-      classes: "nhsuk-fieldset__legend--l"
-    }
-  },
-  hint: {
-    text: "If you have dual nationality, select all options that are relevant to you."
-  },
-  items: [
-    {
-      value: "british",
-      text: "British",
-      hint: {
-        text: "including English, Scottish, Welsh and Northern Irish"
+<form>
+  {{ checkboxes({
+    idPrefix: "nationality",
+    name: "nationality",
+    fieldset: {
+      legend: {
+        text: "What is your nationality?",
+        isPageHeading: true,
+        classes: "nhsuk-fieldset__legend--l"
       }
     },
-    {
-      value: "irish",
-      text: "Irish"
+    hint: {
+      text: "If you have dual nationality, select all options that are relevant to you."
     },
-    {
-      value: "other",
-      text: "Citizen of another country"
-    }
-  ]
-}) }}
+    items: [
+      {
+        value: "british",
+        text: "British",
+        hint: {
+          text: "including English, Scottish, Welsh and Northern Irish"
+        }
+      },
+      {
+        value: "irish",
+        text: "Irish"
+      },
+      {
+        value: "other",
+        text: "Citizen of another country"
+      }
+    ]
+  }) }}
+</form>

--- a/app/views/design-system/components/checkboxes/macro-options.json
+++ b/app/views/design-system/components/checkboxes/macro-options.json
@@ -112,6 +112,18 @@
       ]
     },
     {
+      "name": "exclusive",
+      "type": "boolean",
+      "required": false,
+      "description": "If set to `true`, marks this checkbox as the None option in a None of these type behaviour. Unchecking all other checkboxes in the group when None is clicked."
+    },
+    {
+      "name": "exclusiveGroup",
+      "type": "string",
+      "required": false,
+      "description": "Used in conjunction with `exclusive` - this should be set to a string which groups checkboxes together into a set for use in a None of these scenario."
+    },
+    {
       "name": "classes",
       "type": "string",
       "required": false,

--- a/app/views/design-system/components/checkboxes/none-option/index.njk
+++ b/app/views/design-system/components/checkboxes/none-option/index.njk
@@ -16,15 +16,18 @@
   items: [
     {
       value: "sorethroat",
-      text: "Sore throat"
+      text: "Sore throat",
+      exclusiveGroup: "symptoms-list"
     },
     {
       value: "runnynose",
-      text: "Runny nose"
+      text: "Runny nose",
+      exclusiveGroup: "symptoms-list"
     },
     {
       value: "muscleorjointpain",
-      text: "Muscle or joint pain"
+      text: "Muscle or joint pain",
+      exclusiveGroup: "symptoms-list"
     },
     {
       divider: "Or"
@@ -32,7 +35,8 @@
     {
       value: "none",
       text: "No, I do not have any of these symptoms",
-      behaviour: "exclusive"
+      exclusive: true,
+      exclusiveGroup: "symptoms-list"
     }
   ]
 }) }}

--- a/app/views/design-system/components/checkboxes/none-option/index.njk
+++ b/app/views/design-system/components/checkboxes/none-option/index.njk
@@ -1,37 +1,37 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
-  idPrefix: "countries",
-  name: "countries",
+  idPrefix: "symptoms",
+  name: "symptoms",
   fieldset: {
     legend: {
-      text: "Will you be travelling to any of these countries?",
+      text: "Do you have any of these symptoms?",
       isPageHeading: true,
       classes: "nhsuk-fieldset__legend--l"
     }
   },
   hint: {
-    text: "Select all countries that apply"
+    text: "Select all the symptoms you have."
   },
   items: [
     {
-      value: "france",
-      text: "France"
+      value: "sorethroat",
+      text: "Sore throat"
     },
     {
-      value: "portugal",
-      text: "Portugal"
+      value: "runnynose",
+      text: "Runny nose"
     },
     {
-      value: "spain",
-      text: "Spain"
+      value: "muscleorjointpain",
+      text: "Muscle or joint pain"
     },
     {
-      divider: "or"
+      divider: "Or"
     },
     {
       value: "none",
-      text: "No, I will not be travelling to any of these countries",
+      text: "No, I do not have any of these symptoms",
       behaviour: "exclusive"
     }
   ]

--- a/app/views/design-system/components/checkboxes/none-option/index.njk
+++ b/app/views/design-system/components/checkboxes/none-option/index.njk
@@ -1,0 +1,38 @@
+{% from 'checkboxes/macro.njk' import checkboxes %}
+
+{{ checkboxes({
+  idPrefix: "countries",
+  name: "countries",
+  fieldset: {
+    legend: {
+      text: "Will you be travelling to any of these countries?",
+      isPageHeading: true,
+      classes: "nhsuk-fieldset__legend--l"
+    }
+  },
+  hint: {
+    text: "Select all countries that apply"
+  },
+  items: [
+    {
+      value: "france",
+      text: "France"
+    },
+    {
+      value: "portugal",
+      text: "Portugal"
+    },
+    {
+      value: "spain",
+      text: "Spain"
+    },
+    {
+      divider: "or"
+    },
+    {
+      value: "none",
+      text: "No, I will not be travelling to any of these countries",
+      behaviour: "exclusive"
+    }
+  ]
+}) }}

--- a/app/views/design-system/components/checkboxes/none-option/index.njk
+++ b/app/views/design-system/components/checkboxes/none-option/index.njk
@@ -1,42 +1,44 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
-{{ checkboxes({
-  idPrefix: "symptoms",
-  name: "symptoms",
-  fieldset: {
-    legend: {
-      text: "Do you have any of these symptoms?",
-      isPageHeading: true,
-      classes: "nhsuk-fieldset__legend--l"
-    }
-  },
-  hint: {
-    text: "Select all the symptoms you have."
-  },
-  items: [
-    {
-      value: "sorethroat",
-      text: "Sore throat",
-      exclusiveGroup: "symptoms-list"
+<form>
+  {{ checkboxes({
+    idPrefix: "symptoms",
+    name: "symptoms",
+    fieldset: {
+      legend: {
+        text: "Do you have any of these symptoms?",
+        isPageHeading: true,
+        classes: "nhsuk-fieldset__legend--l"
+      }
     },
-    {
-      value: "runnynose",
-      text: "Runny nose",
-      exclusiveGroup: "symptoms-list"
+    hint: {
+      text: "Select all the symptoms you have."
     },
-    {
-      value: "muscleorjointpain",
-      text: "Muscle or joint pain",
-      exclusiveGroup: "symptoms-list"
-    },
-    {
-      divider: "Or"
-    },
-    {
-      value: "none",
-      text: "No, I do not have any of these symptoms",
-      exclusive: true,
-      exclusiveGroup: "symptoms-list"
-    }
-  ]
-}) }}
+    items: [
+      {
+        value: "sorethroat",
+        text: "Sore throat",
+        exclusiveGroup: "symptoms-list"
+      },
+      {
+        value: "runnynose",
+        text: "Runny nose",
+        exclusiveGroup: "symptoms-list"
+      },
+      {
+        value: "muscleorjointpain",
+        text: "Muscle or joint pain",
+        exclusiveGroup: "symptoms-list"
+      },
+      {
+        divider: "Or"
+      },
+      {
+        value: "none",
+        text: "No, I do not have any of these symptoms",
+        exclusive: true,
+        exclusiveGroup: "symptoms-list"
+      }
+    ]
+  }) }}
+</form>

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -22,7 +22,7 @@
           <div class="nhsuk-card app-card--transparent nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m"><a href="/whats-new">What's new</a></h2>
-              <p class="nhsuk-card__description">In September 2021 we updated the section on <a href="/content/inclusive-language#ethnicity-religion-nationality">ethnicity, religion and nationality</a> in our inclusive language guide</p>
+              <p class="nhsuk-card__description">In September 2021 we added a "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
             </div>
           </div>
         </div>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -32,7 +32,7 @@
       <tr>
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
-          <p>Add "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
+          <p>Added "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -29,6 +29,12 @@
           <p>New entry for "<a href="/content/a-to-z-of-nhs-health-writing#positive">positive</a>" in the A to Z of NHS health writing</p>
         </td>
       </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">
+          <p>Add "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
+        </td>
+      </tr>
     </tbody>
   </table>
 

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -33,7 +33,7 @@
       <tr>
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
-          <p>Add "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
+          <p>Added "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -30,6 +30,12 @@
           <p>New entry for "<a href="/content/a-to-z-of-nhs-health-writing#positive">positive</a>" in the A to Z of NHS health writing</p>
         </td>
       </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">
+          <p>Add "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
+        </td>
+      </tr>
     </tbody>
   </table>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description

Following the addition of the logic for "None of the above" in Checkboxes, we need to add guidance to the Service Manual. This is a first draft following the GOV.UK Design System Guidance

- [x] Double check that the markup and nunjucks arguments are correct for the exclusive behaviour also add them to the Nunjucks macro options file

### Related issue

https://github.com/nhsuk/nhsuk-frontend/pull/756

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [x] Page updated date
