### PR TITLE
Update What's new and amend link on checkboxes page

### DIFF
--- a/app/views/design-system/components/checkboxes/hint/index.njk
+++ b/app/views/design-system/components/checkboxes/hint/index.njk
@@ -1,31 +1,33 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
-{{ checkboxes({
-  "idPrefix": "contact",
-  "name": "contact",
-  "fieldset": {
-    "legend": {
-      "text": "How would you like to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
-      isPageHeading: true
-    }
-  },
-  "hint": {
-    "text": "Select all options that are relevant to you."
-  },
-  "items": [
-    {
-      "value": "email",
-      "text": "Email",
-      id: "contact"
+<form>
+  {{ checkboxes({
+    "idPrefix": "contact",
+    "name": "contact",
+    "fieldset": {
+      "legend": {
+        "text": "How would you like to be contacted?",
+        "classes": "nhsuk-fieldset__legend--l",
+        isPageHeading: true
+      }
     },
-    {
-      "value": "phone",
-      "text": "Phone"
+    "hint": {
+      "text": "Select all options that are relevant to you."
     },
-    {
-      "value": "text message",
-      "text": "Text message"
-    }
-  ]
-}) }}
+    "items": [
+      {
+        "value": "email",
+        "text": "Email",
+        id: "contact"
+      },
+      {
+        "value": "phone",
+        "text": "Phone"
+      },
+      {
+        "value": "text message",
+        "text": "Text message"
+      }
+    ]
+  }) }}
+</form>

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -69,10 +69,10 @@
   <h3 id="none-option">Adding an option for "none"</h3>
   <p>You can give users the option to say none of the other options apply to them. </p>
   <p>This option means users need to actively select "none" rather than leave all the boxes unchecked, which makes sure they do not skip the question by accident.</p>
-  <p>Remember to start by asking 1 question per page. You might be able to remove the need for a "none" option by asking the user a better question. Or try filtering them out with a "filter question" beforehand following the guidance in <a href="/content/how-to-write-good-questions-for-forms">how to write good questions for forms</a>.</p>
+  <p>Remember to start by asking 1 question per page. You might be able to remove the need for a "none" option by asking the user a better question or by <a href="/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users">using filter questions</a> to filter users out beforehand.</p>
   <p>Show the "none" option last. Separate it from the other options using a divider, normally the word "Or".</p>
   <p>Write a label that repeats the key part of the question. For example, for the question "Do you have any of these symptoms?", say "No, I do not have any of these symptoms".</p>
-  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "None", add the <code>data-checkbox-exclusive</code> behaviour to the "none" checkbox.</p>
+  <p>To enable some JavaScript that unchecks all other checkboxes when the user clicks "none", add the <code>data-checkbox-exclusive</code> behaviour to the "none" checkbox.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -21,6 +21,12 @@
       </thead>
       <tbody class="nhsuk-table__body">
       <tr>
+        <td class="nhsuk-table__cell">Across the service manual</td>
+        <td class="nhsuk-table__cell">
+          <p>Added more links to our <a href="https://feedback.digital.nhs.uk/jfe/form/SV_9GIQAEkm6gfFCWp">feedback survey – on the Qualtrics website</a></p>
+        </td>
+      </tr>
+      <tr>
         <td class="nhsuk-table__cell">Content style guide</td>
         <td class="nhsuk-table__cell">
           <p>Updates to the section on <a href="/content/inclusive-language#ethnicity-religion-nationality">ethnicity, religion and nationality</a> on the Inclusive language page</p>
@@ -33,6 +39,12 @@
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
           <p>Added "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Team page</td>
+        <td class="nhsuk-table__cell">
+          <p>Updated the <a href="/service-manual-team">service manual team</a> page</p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -22,6 +22,12 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr>
+        <td class="nhsuk-table__cell">Across the service manual</td>
+        <td class="nhsuk-table__cell">
+          <p>Added more links to our <a href="https://feedback.digital.nhs.uk/jfe/form/SV_9GIQAEkm6gfFCWp">feedback survey – on the Qualtrics website</a></p>
+        </td>
+      </tr>
+      <tr>
         <td class="nhsuk-table__cell">Content style guide</td>
         <td class="nhsuk-table__cell">
           <p>Updates to the section on <a href="/content/inclusive-language#ethnicity-religion-nationality">ethnicity, religion and nationality</a> on the Inclusive language page</p>
@@ -34,6 +40,12 @@
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
           <p>Added "none" option to the <a href="/design-system/components/checkboxes">checkboxes component</a></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Team page</td>
+        <td class="nhsuk-table__cell">
+          <p>Updated the <a href="/service-manual-team">service manual team</a> page</p>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description
- Add team page and feedback survey links to What's new
- Amend link wording and destination on checkboxes page

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - will do now
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - this is it
- [x] Page updated date - already done
