### PR TITLE
Amend aria attributes on header menu toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- Remove static `aria-label` attribute on header menu toggle. Replace with descriptive `aria-expanded="false"` on page load.
+
 ## 5.4.0 — 19 October 2021
 
 :new: **New features**

--- a/app/views/includes/_header-prototype.njk
+++ b/app/views/includes/_header-prototype.njk
@@ -25,7 +25,7 @@
       <div class="nhsuk-header__content" id="content-header">
 
         <div class="nhsuk-header__menu">
-          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false">Menu</button>
         </div>
 
       </div>
@@ -83,7 +83,7 @@
       <div class="nhsuk-header__content" id="content-header">
 
         <div class="nhsuk-header__menu">
-          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+          <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-expanded="false">Menu</button>
         </div>
 
         <div class="nhsuk-header__search">


### PR DESCRIPTION
## Description

The nomensa audit has highlighted that the aria-label="Open menu" is different to the visual label Menu and also doesn't make sense if the Menu is actually in an expanded state.

Removing the static label that and replacing with aria-expanded="false" will make things clearer for users of assistive technology.

### Related issue
EB-1695 in jira

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
