### PR TITLE
Update link element in the non-urgent card card example

### DIFF
--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/non-urgent/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/non-urgent/index.njk
@@ -7,7 +7,7 @@
   <ul>
     <li>you're not sure it's chickenpox</li>
     <li>the skin around the blisters is red, hot or painful (signs of infection)</li>
-    <li>your child is <a href="https://www.nhs.uk/conditions/dehydration">dehydrated</a></li>
+    <li>your child is <a href=\"https://www.nhs.uk/conditions/dehydration\">dehydrated</a></li>
     <li>you're concerned about your child or they get worse</li>
   </ul>
   <p>Tell the receptionist you think it's chickenpox before going in. They may recommend a special appointment time if other patients are at risk.</p>


### PR DESCRIPTION
Update link element in the non-urgent card cards example.

Although in normal HTML, this isn’t needed, we need to use a backwards slash before each quotation mark in the link (`a`) element here as it’s a nunjucks file.
