### PR TITLE
Fix care card example links

### DIFF
--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/emergency/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/emergency/index.njk
@@ -9,6 +9,6 @@
     <li>you have seriously harmed yourself – for example, by taking a drug overdose</li>
   </ul>
   <p>A mental health emergency should be taken as seriously as a medical emergency.</p>
-  <p><a href=\"https://www.nhs.uk/service-search/other-services/Accident-and-emergency-services/LocationSearch/428\">Find your nearest A&E</a></p>
+  <p><a href=\"\">Find your nearest A&E</a></p>
   "
 }) }}

--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/macro-options.json
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/macro-options.json
@@ -1,0 +1,41 @@
+{
+    "params": [
+      {
+        "name": "type",
+        "type": "string",
+        "required": true,
+        "description": "Care card component variant type - non-urgent, urgent or immediate"
+      },
+      {
+        "name": "heading",
+        "type": "string",
+        "required": true,
+        "description": "Heading to be used within the care card component."
+      },
+      {
+        "name": "headingLevel",
+        "type": "integer",
+        "required": false,
+        "description": "Optional heading level for the heading. Default: 3"
+      },
+      {
+        "name": "HTML",
+        "type": "string",
+        "required": true,
+        "description": "Content to be used within the care card component."
+      },
+      {
+        "name": "classes",
+        "type": "string",
+        "required": false,
+        "description": "Classes to add to the care card."
+      },
+      {
+        "name": "attributes",
+        "type": "object",
+        "required": false,
+        "description": "HTML attributes (for example data attributes) to add to the care card."
+      }
+    ]
+  }
+  

--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/non-urgent/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/non-urgent/index.njk
@@ -7,7 +7,7 @@
   <ul>
     <li>you're not sure it's chickenpox</li>
     <li>the skin around the blisters is red, hot or painful (signs of infection)</li>
-    <li>your child is <a href=\"https://www.nhs.uk/conditions/dehydration\">dehydrated</a></li>
+    <li>your child is <a href=\"\">dehydrated</a></li>
     <li>you're concerned about your child or they get worse</li>
   </ul>
   <p>Tell the receptionist you think it's chickenpox before going in. They may recommend a special appointment time if other patients are at risk.</p>


### PR DESCRIPTION
Removed links to live NHS.UK pages from the new care card pattern examples (for now)