### PR TITLE
Split lunr query on spaces only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Update service manual team page. Remove old members.
 - Update site map with new pattern
+- Search improvements the inclusion of - no longer treats the secondary word as a new search. E.g. `x-ra` now returns `x-ray` instead of `Radios`
 
 ## 5.4.1 - 28 October 2021
 

--- a/middleware/page-index.js
+++ b/middleware/page-index.js
@@ -16,6 +16,9 @@ class PageIndex {
     const baseUrl = `http://localhost:${this.config.port}`;
     const config = this.getConnectionConfig();
 
+    // Set Lunr to only split searches on spaces rather than spaces and hyphens
+    lunr.tokenizer.separator = /\s+/;
+
     try {
       // Make request to get sitemap
       const { data } = await axios.get(`${baseUrl}/site-map`, config);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Improving the search so that the inclusion of - no longer treats the secondary word as a new word.

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->
fixes #742

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
