### PR TITLE
remove right arrow on back to top link

### DIFF
--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -151,9 +151,6 @@
       <p>See the guidance on <a href="/content/formatting-and-punctuation#apostrophes">apostrophes on the Formatting and punctuation page</a>.</p>
 
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -216,9 +213,6 @@
       <h3 id="burp">burp</h3>
       <p>We use "burp" and "burping". We also use "<a href="#wind">wind</a>".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -270,9 +264,6 @@
       <h3 id="CT-scan">CT scan</h3>
       <p>You don’t need to spell it out. The abbreviation is fine.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -346,9 +337,6 @@
       <p>We use "medicines".</p>
       <p>We only use "drugs" for illegal drugs.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -375,9 +363,6 @@
       <h3 id="excessive">excessive</h3>
       <p>We use "too much".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -426,9 +411,6 @@
       <p>See the guidance on <a href="/content/formatting-and-punctuation#full-stops">full stops on the Formatting and punctuation page</a>.</p>
 
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -487,9 +469,6 @@
       <p>GUM is short for genito-urinary medicine.</p>
       <p>We use <a href="#sexual-health-clinic">sexual health clinic</a>.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -512,9 +491,6 @@
       <h3 id="hyphens">hyphens</h3>
       <p>See the guidance on <a href="/content/formatting-and-punctuation#hyphens-and-dashes">hyphens and dashes on the Formatting and punctuation page</a>.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -541,9 +517,6 @@
       <h3 id="interaction">interaction</h3>
       <p>For medicines, we say "it does not mix with". </p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -561,9 +534,6 @@
       <p>Research shows that "jab" can make people who are scared of needles more anxious.</p>
       <p>If "jab" is a popular search term for your content (for example, "flu jab"), call it the "flu vaccine" but add "sometimes called the flu jab". Do this in the body content and the meta description.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -573,9 +543,6 @@
       <p>We use "kidney" instead of "renal".</p>
       <p>We may mention "renal" as well as "kidney" if our search analytics, user testing or survey feedback suggest that people will hear their doctor use "renal" or will search for it.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -592,9 +559,6 @@
       <h3 id="lists">lists</h3>
       <p>See the guidance on <a href="/content/formatting-and-punctuation#lists">lists on the Formatting and punctuation page</a>.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -634,9 +598,6 @@
     <p>If you have allergic rhinitis, the inside layer of your nose (the mucous membrane) may become swollen and you may produce a lot of mucus.</p>
   </div>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -694,9 +655,6 @@
       <h3 id="numbers">numbers</h3>
       <p>See our guidance on <a href="/content/numbers-measurements-dates-time">numbers, measurements, dates and time</a>.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -725,9 +683,6 @@
       <p>We say "medicine you buy (from a pharmacy or shop)".</p>
       <p>We put pharmacies first, ahead of supermarkets and shops.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -801,9 +756,6 @@
       <h3 id="prognosis">prognosis</h3>
       <p>We prefer "outlook".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -813,9 +765,6 @@
       <h3 id="quotation-marks">quotation marks</h3>
        <p>See the guidance on <a href="/content/formatting-and-punctuation#quotation-marks">quotation marks on the Formatting and punctuation page</a>.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -850,9 +799,6 @@
       <p>We try not to talk about "risk factors" and instead explain them some other way.</p>
       <p>We do use "risk" and "risk factors" when we are writing for a more specialist audience, for example when we’re explaining science news in <a href="https://www.nhs.uk/news/">Behind the Headlines</a>.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -933,9 +879,6 @@
       <p>We say that people may "get" or "have" symptoms, not "develop" or "experience" them.</p>
 
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -971,9 +914,6 @@
       <p>It can also be a good alternative to abdomen when you’re talking about the outside of the body (a broader area than the stomach).</p>
       <p>Also see "<a href="#abdomen-and-abdominal">abdomen</a>" and "<a href="#stomach">stomach</a>".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -988,9 +928,6 @@
       <h3 id="uterus">uterus</h3>
       <p>We prefer "womb".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -1026,9 +963,6 @@
       <p>We use "vomiting" in phrases like "vomiting blood".</p>
       <p>We use "vomit" as the noun. For example, "blood in your vomit".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -1054,9 +988,6 @@
       <p>We use "burping" too.</p>
       <p>Also see "<a href="#fart">fart</a>".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -1065,9 +996,6 @@
       <h3 id="X-ray">X-ray</h3>
       <p>With a capital X.</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -1077,9 +1005,6 @@
       <p>We address users as "you". See the section on <a href="/content/voice-and-tone">voice and tone</a>.</p>
       <p>We use "your" for parts of the body, where appropriate. For example: "the cells in your liver".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>
@@ -1089,9 +1014,6 @@
       <p>Two words, lower case.</p>
       <p>When we talk about "walking frames", we also mention "zimmer frames". We have found that older people are more likely to know them as "zimmer frames".</p>
       <a class="nhsuk-back-to-top__link" href="#nhsuk-a-z-list">
-        <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-          <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-        </svg>
         Back to top
       </a>
     </div>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removal of right arrow on back to top
<img width="267" alt="Screenshot 2021-11-29 at 17 54 58" src="https://user-images.githubusercontent.com/55799839/144013315-bdb0f84e-a3a9-4cf5-9910-a5148b156feb.png">
### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
