### PR TITLE
Add what's new content

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -22,7 +22,7 @@
           <div class="nhsuk-card app-card--transparent nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m"><a href="/whats-new">What's new</a></h2>
-              <p class="nhsuk-card__description">In November 2021 we reworked the care card component as a new pattern to <a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">help users decide when and where to get care</a>.</p>
+              <p class="nhsuk-card__description">In December 2021 we published a new page where you can <a href="/accessibility/download-accessibility-posters">download accessibility posters</a></p>
             </div>
           </div>
         </div>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,10 +9,10 @@
 
   <h2>Latest updates</h2>
 
-<h3>November 2021</h3>
+<h3>December 2021</h3>
 
   <table class="nhsuk-table">
-    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in November 2021</caption>
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in December 2021</caption>
       <thead class="nhsuk-table__head">
         <tr class="nhsuk-table__row">
           <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
@@ -21,42 +21,9 @@
       </thead>
       <tbody class="nhsuk-table__body">
       <tr>
-        <td class="nhsuk-table__cell">Content style guide</td>
+        <td class="nhsuk-table__cell">Accessibility guidance</td>
         <td class="nhsuk-table__cell">
-          <p>Updated links to point to the new pattern for <a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">helping users decide when and where to get care (care cards)</a> from:</p>
-          <ul>
-            <li><a href="/content/a-to-z-of-nhs-health-writing">the A to Z of NHS health writing</a></li>
-            <li><a href="/content/formatting-and-punctuation">the Formatting and punctuation page</a></li>
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <td class="nhsuk-table__cell">Design system</td>
-        <td class="nhsuk-table__cell">
-          <p>Reworked the care card component as a pattern to <a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">help users decide when and where to get care</a>, with updated guidance</p>
-          <p>Updated links to point to the new pattern from <a href="/design-system/styles/colour">the colour page</a> and from these components:</p>
-          <ul>
-            <li><a href="/design-system/components/action-link">action link</a></li>
-            <li><a href="/design-system/components/card">card</a></li>
-            <li><a href="/design-system/components/expander">expander</a></li>
-            <li><a href="/design-system/components/inset-text">inset text</a></li>
-            <li><a href="/design-system/components/warning-callout">warning callout</a></li>
-          </ul>
-          <p>Amended the <a href="/design-system/components/care-cards">care cards component page</a> to direct people to the pattern instead</p>
-          <p>Added a <a href="/design-system/components/review-date">review date component page</a> to direct people to the pattern for <a href="/design-system/patterns/reassure-users-that-a-page-is-up-to-date">reassuring users that a page is up to date</a> instead</p>
-        </td>
-      </tr>
-       <tr>
-        <td class="nhsuk-table__cell">NHS service standard</td>
-        <td class="nhsuk-table__cell">
-          <p>Added the word "reuse" alongside "build" and "buy" in the guidance on <a href="/service-standard/11-choose-the-right-tools-and-technology">service standard 11</a></p>
-        </td>
-      </tr>
-            </tr>
-       <tr>
-        <td class="nhsuk-table__cell">Other</td>
-        <td class="nhsuk-table__cell">
-          <p>Updated <a href="/site-map">the site map</a> and <a href="/service-manual-team">service manual team page</a></p>
+          <p>New page where you can <a href="/accessibility/download-accessibility-posters">download accessibility posters</a>, with 6 posters for different professions</p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,6 +10,27 @@
 
 {% block bodyContent %}
 
+
+<h2>December 2021</h2>
+
+  <table class="nhsuk-table">
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in Decembe 2021</caption>
+      <thead class="nhsuk-table__head">
+        <tr class="nhsuk-table__row">
+          <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+          <th class="nhsuk-table__header" scope="col">Update</th>
+        </tr>
+      </thead>
+      <tbody class="nhsuk-table__body">
+      <tr>
+        <td class="nhsuk-table__cell">Accessibility guidance</td>
+        <td class="nhsuk-table__cell">
+          <p>New page where you can <a href="/accessibility/download-accessibility-posters">download accessibility posters</a>, with 6 posters for different professions</p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
 <h2>November 2021</h2>
 
   <table class="nhsuk-table">


### PR DESCRIPTION
Add What's new content for accessibility posters.

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - I'll do this now.
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date - not relevant for What's new
