### PR TITLE
Add new page of standards for health content creation - incomplete

### DIFF
--- a/app/views/content/standards-for-creating-health-content.njk
+++ b/app/views/content/standards-for-creating-health-content.njk
@@ -1,0 +1,70 @@
+{% set pageTitle = "Standards for creating health content" %}
+{% set pageSection = "Content style guide" %}
+{% set pageDescription = "These standards outline best practice in creating good quality health content. They're designed for any organisation that produces health and care information." %}
+{% set dateUpdated = "April 2022" %}
+{% set backlog_issue_id = "430" %}
+
+{% extends "includes/app-layout.njk" %}
+
+{% block breadcrumb %}
+  {% include "content/_breadcrumb.njk" %}
+{% endblock %}
+
+{% block bodyContent %}
+
+ <ol class="featured-list">
+
+    <li class="featured-list--item">
+      <div class="featured-list--item__content">
+        <span class="featured-list--item__number featured-list--item__number--mobile nhsuk-heading-xl">1</span>
+        <h2 class="featured-list--item__heading nhsuk-heading-l">
+          <span class="featured-list--item__number nhsuk-heading-xl nhsuk-u-margin-bottom-1">1</span>
+          Design a clear process for creating content and follow it
+        </h2>
+        <h3>Essential</h3>
+        <ul>
+          <li>Follow a process for checking content and getting sign-off, including clinical approval.</li>
+          <li>Have a plan for reviewing all content making sure it is up to date and clinically accurate.</li>
+          <li>Make clear which organisation has published the content.</li>
+          <li>Be transparent about adverts and any potential conflicts of interest, such as sponsorship.</li>
+        </ul>
+        <h3>Best practice</h3>
+        <ul>
+          <li>Follow a clear, consistent, documented process, including version control and archiving.</li>
+          <li>Include the date the page was last checked and when it will be checked again.</li>
+          <li>Provide training and support so your team can follow the process.</li>
+          <li>Follow your organisation's brand or style guidelines.</li>
+          <li>Invite feedback from users (the people - patients or the public - who will use your content) to feedback so you can improve or review it.</li>
+          <li>Actively manage feedback and respond where appropriate.</li>
+          <li>Set objectives and identify outcomes for your content and evaluate your content against them.</li>
+        </ul>
+      </div>
+    </li>
+
+
+    <li class="featured-list--item">
+      <div class="featured-list--item__content">
+        <span class="featured-list--item__number featured-list--item__number--mobile nhsuk-heading-xl">2</span>
+        <h2 class="featured-list--item__heading nhsuk-heading-l">
+          <span class="featured-list--item__number nhsuk-heading-xl nhsuk-u-margin-bottom-1">2</span>
+           Use relevant, up-to-date and recognised clinical evidence
+        </h2>
+        <h3>Essential</h3>
+        <ul>
+          <li>Create content using high quality clinical evidence and get relevant professionals to review and approve it (as part of your documented process).</li>
+          <li>Check the evidence each time you review and update the content.</li>
+
+        </ul>
+        <h3>Best practice</h3>
+        <ul>
+          <li></li>
+          <li>Include the date the page was last checked and when it will be checked again.</li>
+        </ul>
+      </div>
+    </li>
+
+{% endblock %}
+
+{% block asideContent %}
+  {% include "./partials/related-nav.njk" %}
+{% endblock %}

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -35,6 +35,7 @@
 ] %}
 
 {% set content = [
+  { title: "Standards for creating health content", url: "/content/standards-for-creating-health-content" },
   { title: "How we write", url: "/content/how-we-write" },
   { title: "Voice and tone", url: "/content/voice-and-tone" },
   { title: "Inclusive content", url: "/content/inclusive-content" },


### PR DESCRIPTION
## Description
Incomplete. Initial work on new standard for creating health content - to go in content style guide

### Related issue
#1740 

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - not yet
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - not yet
- [x] Page updated date 
