### PR TITLE
Create redirects for the old service standards urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ public
 .DS_Store
 app/.DS_Store
 .vscode
+.idea

--- a/app.js
+++ b/app.js
@@ -96,7 +96,7 @@ app.get('/design-example/:group/:item/:type', (req, res) => {
 
   res.render(baseTemplate, {
     body: exampleHtml,
-    item
+    item,
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -94,7 +94,10 @@ app.get('/design-example/:group/:item/:type', (req, res) => {
     baseTemplate = 'includes/design-example-wrapper-blank.njk';
   }
 
-  res.render(baseTemplate, { body: exampleHtml, item });
+  res.render(baseTemplate, {
+    body: exampleHtml,
+    item
+  });
 });
 
 app.get('/search', (req, res) => {
@@ -160,6 +163,20 @@ app.get('/community', (req, res) => {
 
 app.get('/community/propose-component-pattern', (req, res) => {
   res.redirect('/community-and-contribution/propose-component-pattern');
+});
+
+// Redirects for new service standards URLs
+
+app.get('/service-standard', (req, res) => {
+  res.redirect(301, '/standards-and-technology/service-standard');
+});
+
+app.get('/service-standard/about', (req, res) => {
+  res.redirect(301, '/standards-and-technology/about-the-service-standard');
+});
+
+app.get('/service-standard/:page', (req, res) => {
+  res.redirect(301, `/standards-and-technology/service-standard-points/${req.params.page}`);
 });
 
 // REDIRECT STOPS HERE


### PR DESCRIPTION
## Description
Create redirects for the old service standards urls


## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
