### PR TITLE
Update What's new and add link to service standard 17

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -22,7 +22,7 @@
           <div class="nhsuk-card app-card--transparent nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-0">
             <div class="nhsuk-card__content">
               <h2 class="nhsuk-card__heading nhsuk-heading-m"><a href="/whats-new">What's new</a></h2>
-              <p class="nhsuk-card__description">In September 2022 we added new entries for "negative", "specialty" and "opticians" to the <a href="/content/a-to-z-of-nhs-health-writing">A to Z of NHS health writing</a></p>
+              <p class="nhsuk-card__description">In December 2022 we added a button example to the <a href="design-system/components/back-link">back link component</a>.</p>
             </div>
           </div>
         </div>

--- a/app/views/standards-and-technology/service-standard-points/17-make-your-service-interoperable.njk
+++ b/app/views/standards-and-technology/service-standard-points/17-make-your-service-interoperable.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Standards and technology" %}
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "In an organisation as diverse and complex as the NHS, we need systems and services which talk to each other. Build for interoperability to share patient records and get data quickly from one place to another." %}
-{% set dateUpdated = "September 2022" %}
+{% set dateUpdated = "December 2022" %}
 {% set backlog_issue_id = "360" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -20,6 +20,7 @@
   <p>Your team should be able to show that:</p>
   <ul>
     <li>you work to open standards and the Technology Code of Practice</li>
+    <li>you have checked the <a href="https://data.standards.nhs.uk/">NHS data standards directory</a> for relevant standards</li>
     <li>you maximise flexibility and make content, tools and services available through well-designed APIs to reach more people</li>
     <li>you use agreed <a href="https://digital.nhs.uk/developer/api-catalogue?filter=fhir">FHIR-based APIs (from NHS Digital's API catalogue, filtered by FHIR)</a> to join up care for patients</li>
     <li>where appropriate, you use the <a href="https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/isb-0149-nhs-number">NHS number (NHS Digital)</a> and NHS data registers and comply with NHS clinical information standards</li>
@@ -51,6 +52,7 @@
     <li><a href="https://digital.nhs.uk/services/fhir-apis">FHIR (Fast Healthcare Interoperability Resources, NHS Digital)</a></li>
     <li><a href="https://icd.who.int/browse10/2016/en">ICD-10, version: 2016</a> - the World Health Organization's International Classification of Diseases (WHO)</li>
     <li><a href="https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/isb-0149-nhs-number">ISB 0149 NHS number (NHS Digital)</a> - this information standard sets out the scope and use of the NHS number</li>
+    <li><a href="https://data.standards.nhs.uk/">NHS data standards directory</a> - nationally recognised standards that support interoperability in health and adult social care, including the NHS number, SNOMED CT and FHIR-based APIs</li>
     <li><a href="https://developer.api.nhs.uk/">NHS website developer portal (NHS.UK)</a></li>
     <li><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a> (The National Archives)</li>
     <li><a href="https://digital.nhs.uk/services/terminology-and-classifications/snomed-ct">SNOMED CT (on NHS Digital's website)</a> - a structured clinical vocabulary for use in an electronic health record</li>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,9 +9,9 @@
 
 <h2>Latest updates</h2>
 
-<h3>October 2022</h3>
+<h3>December 2022</h3>
 <table class="nhsuk-table">
-  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in October 2022</caption>
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in December 2022</caption>
     <thead class="nhsuk-table__head">
       <tr class="nhsuk-table__row">
         <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
@@ -19,10 +19,22 @@
       </tr>
     </thead>
     <tbody class="nhsuk-table__body">
+      <tr>
+        <td class="nhsuk-table__cell">Content style guide</td>
+        <td class="nhsuk-table__cell">
+        <p>Amended a wrong example <a href="/content/a-to-z-of-nhs-health-writing#phone-and-phone-numbers">phone number in A to Z of NHS health writing</a> - in last release</p>
+        </td>
+      </tr>
     <tr>
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
-        <p>Fixed link and ID reference in <a href="design-system/patterns/a-to-z-page">A to Z page</a> which caused the A-Z list not to link to any cards.</p>
+      <p>Add button example to <a href="/design-system/components/back-link">back link component</a></p>
+      </td>
+    </tr>
+    <tr>
+      <td class="nhsuk-table__cell">Standards and technology</td>
+      <td class="nhsuk-table__cell">
+      <p>Linked to the <a href="https://data.standards.nhs.uk/">NHS data standards directory</a> from <a href="/standards-and-technology/service-standard-points//17-make-your-service-interoperable">point 17 in the NHS service standard</a></p>
       </td>
     </tr>
   </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,6 +10,37 @@
 
 {% block bodyContent %}
 
+<h2>December 2022</h2>
+<table class="nhsuk-table">
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in December 2022</caption>
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+        <th class="nhsuk-table__header" scope="col">Update</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+    <tr>
+      <td class="nhsuk-table__cell">Content style guide</td>
+      <td class="nhsuk-table__cell">
+      <p>Amended a wrong example <a href="/content/a-to-z-of-nhs-health-writing#phone-and-phone-numbers">phone number in A to Z of NHS health writing</a> - in last release</p>
+      </td>
+    </tr>
+    <tr>
+      <td class="nhsuk-table__cell">Design system</td>
+      <td class="nhsuk-table__cell">
+        <p>Add button example to <a href="/design-system/components/back-link">back link component</a></p>
+      </td>
+    </tr>
+    <tr>
+      <td class="nhsuk-table__cell">Standards and technology</td>
+      <td class="nhsuk-table__cell">
+      <p>Linked to the <a href="https://data.standards.nhs.uk/">NHS data standards directory</a> from <a href="/standards-and-technology/service-standard-points//17-make-your-service-interoperable">point 17 in the NHS service standard</a></p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <h2>October 2022</h2>
 <table class="nhsuk-table">
   <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in October 2022</caption>
@@ -24,6 +55,12 @@
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
         <p>Fixed link and ID reference in <a href="design-system/patterns/a-to-z-page">A to Z page</a> which caused the A-Z list not to link to any cards.</p>
+      </td>
+    </tr>
+    <tr>
+      <td class="nhsuk-table__cell">Standards and technology</td>
+      <td class="nhsuk-table__cell">
+      <p>Linked to the <a href="https://data.standards.nhs.uk/">NHS data standards directory</a> from <a href="/standards-and-technology/service-standard-points//17-make-your-service-interoperable">point 17 in the NHS service standard</a></p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Description
- Update What's new and CHANGELOG
- Add link to NHS data standards directory to service standard point 176

### Related issue
- [1819](https://github.com/nhsuk/nhsuk-service-manual/issues/1819)
- [1815](https://github.com/nhsuk/nhsuk-service-manual/issues/1815)


## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry 
- [x] Page updated date - done on page for service standard 17 - not needed elsewhere
