### PR TITLE
Added forward slash to latest entry

### DIFF
--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -23,7 +23,7 @@
     <tr>
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
-        <p>Fixed link and ID reference in <a href="design-system/patterns/a-to-z-page">A to Z page</a> which caused the A-Z list not to link to any cards.</p>
+        <p>Fixed link and ID reference in <a href="/design-system/patterns/a-to-z-page">A to Z page</a> which caused the A-Z list not to link to any cards.</p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
It was causing a 404 when navigating to the 'updates' page first.

## Description
<!--- Describe your changes in detail -->

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
