### PR TITLE
Feature/button debouncing

### DIFF
--- a/app/views/design-system/components/buttons/index.njk
+++ b/app/views/design-system/components/buttons/index.njk
@@ -60,7 +60,7 @@
   <h2 id="when-to-use-buttons">When to use buttons</h2>
   <p>Use buttons to start or save transactional journeys.</p>
 
-  <h2  id="when-not-to-use-buttons">When not to use buttons</h2>
+  <h2 id="when-not-to-use-buttons">When not to use buttons</h2>
   <p>Do not use buttons as links:
   <ul>
     <li>to pages which aren't part of your user journey</li>
@@ -87,6 +87,30 @@
     <li>white button on solid background colour  14.42:1</li>
   </ul>
   <p>Please note that the disabled versions of the 3 buttons do not meet accessibility colour contrast ratios. If your team has discovered a user need for disabled buttons, use them carefully and test them with users with access needs.</p>
+
+  <h2 id="stop-users-from-accidentally-sending-information-more-than-once">Stop users from accidentally sending information more than once</h2>
+
+  <p>Sometimes, users double click buttons because they:</p>
+
+  <ul>
+    <li>have used operating systems where they have to double click items to make them work</li>
+    <li>are experiencing a slow connection which means they are not given feedback on their action quickly enough</li>
+    <li>have motor impairments such as hand tremors which cause them to click the button involuntarily</li>
+  </ul>
+
+  <p>In some cases, this can mean their information is sent twice.</p>
+  <p>For example, the GOV.UK Notify team discovered that a number of users were receiving invitations twice, because the person sending them was double clicking the 'send' button.</p>
+  <p>If your research shows that users are frequently sending information twice, you can configure the button to ignore the 2nd click.</p>
+  <p>To do this, set the <code>data-prevent-double-click</code> attribute to <code>true</code>. You can do this directly in the HTML or, if you’re using Nunjucks, you can use the Nunjucks macro as shown in this example.</p>
+
+    {{ designExample({
+      group: "components",
+      item: "buttons",
+      type: "prevent-double-click"
+    }) }}
+
+  <p>This feature will prevent double clicks for users that have JavaScript enabled, however you should also think about the issue server-side to protect against attacks.</p>
+  <p>In the case of slow connections, aim to give the user information about what’s happening, for example, by showing a loading spinner or a modal, before using <code>data-prevent-double-click</code>.</p>
 
   <h2 id="research">Research</h2>
   <p>We based our buttons on the GOV.UK designs. But because our logo is a blue rectangle and a number of our components (including panel headings) have squared edges, we decided that GOV.UK buttons didn’t stand out enough. The square buttons didn't look clickable next to the other square components.</p>

--- a/app/views/design-system/components/buttons/index.njk
+++ b/app/views/design-system/components/buttons/index.njk
@@ -88,7 +88,7 @@
   </ul>
   <p>Please note that the disabled versions of the 3 buttons do not meet accessibility colour contrast ratios. If your team has discovered a user need for disabled buttons, use them carefully and test them with users with access needs.</p>
 
-  <h2 id="stop-users-from-accidentally-sending-information-more-than-once">Stop users from accidentally sending information more than once</h2>
+  <h3 id="stop-users-from-accidentally-sending-information-more-than-once">Stop users from accidentally sending information more than once</h3>
 
   <p>Sometimes, users double click buttons because they:</p>
 

--- a/app/views/design-system/components/buttons/macro-options.json
+++ b/app/views/design-system/components/buttons/macro-options.json
@@ -59,6 +59,12 @@
 			"type": "object",
 			"required": false,
 			"description": "HTML attributes (for example data attributes) to add to the button component."
+		},
+		{
+			"name": "preventDoubleClick",
+			"type": "boolean",
+			"required": false,
+			"description": "Prevent accidental double clicks on submit buttons from submitting forms multiple times"
 		}
 	]
 }

--- a/app/views/design-system/components/buttons/prevent-double-click/index.njk
+++ b/app/views/design-system/components/buttons/prevent-double-click/index.njk
@@ -1,0 +1,6 @@
+{% from 'button/macro.njk' import button %}
+
+{{ button({
+  "text": "Save and continue",
+  "preventDoubleClick": true
+}) }}

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -28,7 +28,8 @@
     <tr>
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
-      <p>Add button example to <a href="/design-system/components/back-link">back link component</a></p>
+        <p>Add button example to <a href="/design-system/components/back-link">back link component</a></p>
+        <p>Add double click prevention example to <a href="/design-system/components/back-link">button component</a></p>
       </td>
     </tr>
     <tr>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -30,6 +30,7 @@
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
         <p>Add button example to <a href="/design-system/components/back-link">back link component</a></p>
+        <p>Add double click prevention example to <a href="/design-system/components/back-link">button component</a></p>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
## Description
Adding an example showing how to use the new double click prevention feature on buttons.

### Related issue
https://github.com/nhsuk/nhsuk-frontend/pull/840

## Checklist
- [X] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [X] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
