### PR TITLE
Remove quotes from nunjucks keys

### DIFF
--- a/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions.njk
@@ -75,17 +75,17 @@
   <h2>Read more about sensitive topics</h2>
   <p>The sensitive topics reflect the "protected characteristics" in the <a href="https://www.legislation.gov.uk/ukpga/2010/15/contents">Equality Act 2010</a>. It is against the law to discriminate against anyone because of these characteristics.</p>
 
-  
+
 
 {% endblock %}
 
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question",
-    "previousPage": "Make sure you need each question",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users",
-    "nextPage": "Use filter questions to route users"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question",
+    previousPage: "Make sure you need each question",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users",
+    nextPage: "Use filter questions to route users"
   }) }}
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/get-the-questions-into-order.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/get-the-questions-into-order.njk
@@ -57,20 +57,17 @@
   <p>You need to understand which questions your users expect first and how they group them. One way to do this is with a <a href="/content/how-to-write-good-questions-for-forms/test-your-questions#do-a-card-sorting-exercise">card sorting exercise</a>. Test the order again when you prototype your form.</p>
   <p>For example, do users expect to give you personal details at the start or do they want to deal with the task first and give you personal details at the end?</p>
 
-  
+
 
 {% endblock %}
 
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users",
-    "previousPage": "Use filter questions to route users",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation",
-    "nextPage": "Think of the form as a conversation"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users",
+    previousPage: "Use filter questions to route users",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation",
+    nextPage: "Think of the form as a conversation"
   }) }}
 
 {% endblock %}
-
-
-

--- a/app/views/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question.njk
@@ -57,25 +57,25 @@
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {% call fieldset({
       legend: {
-        "text": "Subscribe to newsletter",
-        "classes": "nhsuk-fieldset__legend--l"
+        text: "Subscribe to newsletter",
+        classes: "nhsuk-fieldset__legend--l"
       }
     }) %}
 
       {{ input({
         label: {
-          "html": 'Name (optional)'
+          html: 'Name (optional)'
         },
-        "id": "name",
-        "name": "name"
+        id: "name",
+        name: "name"
       }) }}
 
       {{ input({
         label: {
-          "html": 'Email address'
+          html: 'Email address'
         },
-        "id": "email",
-        "name": "email"
+        id: "email",
+        name: "email"
       }) }}
 
     {% endcall %}
@@ -127,10 +127,10 @@
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions",
-    "previousPage": "Understand the problem before you write your questions",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions",
-    "nextPage": "Consider the sensitivities around your questions"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions",
+    previousPage: "Understand the problem before you write your questions",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions",
+    nextPage: "Consider the sensitivities around your questions"
   }) }}
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/test-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/test-your-questions.njk
@@ -129,18 +129,15 @@
     <li><a href="https://www.gov.uk/service-manual/user-research/using-moderated-usability-testing">Using moderated usability testing</a></li>
   </ul>
 
-  
+
 
 {% endblock %}
 
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form",
-    "previousPage": "Write the supporting content for your form"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form",
+    previousPage: "Write the supporting content for your form"
   }) }}
 
 {% endblock %}
-
-
-

--- a/app/views/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation.njk
@@ -166,10 +166,10 @@
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/get-the-questions-into-order",
-    "previousPage": "Get the questions into order",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form",
-    "nextPage": "Write the supporting content for your form"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/get-the-questions-into-order",
+    previousPage: "Get the questions into order",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form",
+    nextPage: "Write the supporting content for your form"
   }) }}
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/understand-the-problem-before-you-write-your-questions.njk
@@ -48,17 +48,17 @@
   <h2>Read more about the discovery phase</h2>
   <p>GOV.UK has some good guidance on <a href="https://www.gov.uk/service-manual/agile-delivery/how-the-discovery-phase-works">how the discovery phase works</a>.</p>
 
-  
+
 
 {% endblock %}
 
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/index",
-    "previousPage": "How to write good questions for forms home page",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question",
-    "nextPage": "Make sure you need each question"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/index",
+    previousPage: "How to write good questions for forms home page",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/make-sure-you-need-each-question",
+    nextPage: "Make sure you need each question"
   }) }}
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
@@ -33,22 +33,22 @@
   <div class="app-example">
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {{ radios({
-      "idPrefix": "example-research",
-      "name": "example-research",
-      "fieldset": {
-        "legend": {
-          "text": "Can we email you about research?",
-          "classes": "nhsuk-fieldset__legend--m"
+      idPrefix: "example-research",
+      name: "example-research",
+      fieldset: {
+        legend: {
+          text: "Can we email you about research?",
+          classes: "nhsuk-fieldset__legend--m"
         }
       },
-      "items": [
+      items: [
         {
-          "value": "yes",
-          "text": "Yes, you can contact me by email about research"
+          value: "yes",
+          text: "Yes, you can contact me by email about research"
         },
         {
-          "value": "no",
-          "text": "No, do not contact me about research"
+          value: "no",
+          text: "No, do not contact me about research"
         }
       ]
     }) }}
@@ -70,32 +70,32 @@
 
     {% call fieldset({
       legend: {
-        "text": "Do you know your NHS number?",
-        "classes": "nhsuk-fieldset__legend--m"
+        text: "Do you know your NHS number?",
+        classes: "nhsuk-fieldset__legend--m"
       }
       }) %}
       {{ hint({
-        "text": "Your NHS number is a 10 digit number, like 485 777 3456.",
-        "classes": "nhsuk-u-margin-bottom-2"
+        text: "Your NHS number is a 10 digit number, like 485 777 3456.",
+        classes: "nhsuk-u-margin-bottom-2"
       }) }}
       {{ hint({
-        "text": "You can find this on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
+        text: "You can find this on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
       }) }}
       {{ radios({
-        "idPrefix": "example-divider",
-        "name": "configStructure",
-        "items": [
+        idPrefix: "example-divider",
+        name: "configStructure",
+        items: [
       {
-        "value": "yes",
-        "text": "Yes, I know my NHS number"
+        value: "yes",
+        text: "Yes, I know my NHS number"
       },
       {
-        "value": "no",
-        "text": "No, I do not know my NHS number"
+        value: "no",
+        text: "No, I do not know my NHS number"
       },
       {
-        "value": "unsure",
-        "text": "I'm not sure"
+        value: "unsure",
+        text: "I'm not sure"
       }
     ]
     }) }}
@@ -112,22 +112,22 @@
   <div class="app-example">
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {{ radios({
-      "idPrefix": "example-registration-details",
-      "name": "example-registration-details",
-      "fieldset": {
-        "legend": {
-          "text": "Do you have your registration details?",
-          "classes": "nhsuk-fieldset__legend--m"
+      idPrefix: "example-registration-details",
+      name: "example-registration-details",
+      fieldset: {
+        legend: {
+          text: "Do you have your registration details?",
+          classes: "nhsuk-fieldset__legend--m"
         }
       },
-      "items": [
+      items: [
         {
-          "value": "yes",
-          "text": "Yes"
+          value: "yes",
+          text: "Yes"
         },
         {
-          "value": "no",
-          "text": "No, try another way"
+          value: "no",
+          text: "No, try another way"
         }
       ]
     }) }}
@@ -140,17 +140,17 @@
   <p><a href="/content/how-to-write-good-questions-for-forms/test-your-questions">Read more about testing your questions</a>.</p>
   <p>If a lot of people cannot answer "Yes" or "No", reconsider your question.</p>
 
-  
+
 
 {% endblock %}
 
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions",
-    "previousPage": "Consider the sensitivities around your questions",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/get-the-questions-into-order",
-    "nextPage": "Get the questions into order"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/consider-the-sensitivities-around-your-questions",
+    previousPage: "Consider the sensitivities around your questions",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/get-the-questions-into-order",
+    nextPage: "Get the questions into order"
   }) }}
 
 {% endblock %}

--- a/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
@@ -31,29 +31,29 @@
   <div class="app-example">
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {{ checkboxes({
-      "idPrefix": "contact",
-      "name": "contact",
-      "fieldset": {
-        "legend": {
-          "text": "How would you like to be contacted?",
-          "classes": "nhsuk-fieldset__legend--m"
+      idPrefix: "contact",
+      name: "contact",
+      fieldset: {
+        legend: {
+          text: "How would you like to be contacted?",
+          classes: "nhsuk-fieldset__legend--m"
         }
       },
-      "hint": {
-        "text": "Select all options that are relevant to you."
+      hint: {
+        text: "Select all options that are relevant to you."
       },
-      "items": [
+      items: [
         {
-          "value": "email",
-          "text": "Email"
+          value: "email",
+          text: "Email"
         },
         {
-          "value": "phone",
-          "text": "Phone"
+          value: "phone",
+          text: "Phone"
         },
         {
-          "value": "text message",
-          "text": "Text message"
+          value: "text message",
+          text: "Text message"
         }
       ]
     }) }}
@@ -78,32 +78,32 @@
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {% call fieldset({
       legend: {
-        "text": "Do you know your NHS number?",
-        "classes": "nhsuk-fieldset__legend--m"
+        text: "Do you know your NHS number?",
+        classes: "nhsuk-fieldset__legend--m"
       }
       }) %}
       {{ hint({
-        "text": "This is a 10 digit number, like 485 777 3456.",
-        "classes": "nhsuk-u-margin-bottom-2"
+        text: "This is a 10 digit number, like 485 777 3456.",
+        classes: "nhsuk-u-margin-bottom-2"
       }) }}
       {{ hint({
-        "text": "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
+        text: "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
       }) }}
       {{ radios({
-        "idPrefix": "example-divider",
-        "name": "configStructure",
-        "items": [
+        idPrefix: "example-divider",
+        name: "configStructure",
+        items: [
       {
-        "value": "yes",
-        "text": "Yes, I know my NHS number"
+        value: "yes",
+        text: "Yes, I know my NHS number"
       },
       {
-        "value": "no",
-        "text": "No, I do not know my NHS number"
+        value: "no",
+        text: "No, I do not know my NHS number"
       },
       {
-        "value": "not sure",
-        "text": "I'm not sure"
+        value: "not sure",
+        text: "I'm not sure"
       }
     ]
     }) }}
@@ -161,13 +161,10 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation",
-    "previousPage": "Think of the form as a conversation",
-    "nextUrl": "/content/how-to-write-good-questions-for-forms/test-your-questions",
-    "nextPage": "Test your questions"
+    previousUrl: "/content/how-to-write-good-questions-for-forms/think-of-the-form-as-a-conversation",
+    previousPage: "Think of the form as a conversation",
+    nextUrl: "/content/how-to-write-good-questions-for-forms/test-your-questions",
+    nextPage: "Test your questions"
   }) }}
 
 {% endblock %}
-
-
-

--- a/app/views/design-system/components/action-link/default/index.njk
+++ b/app/views/design-system/components/action-link/default/index.njk
@@ -1,6 +1,6 @@
 {% from 'action-link/macro.njk' import actionLink %}
 
 {{ actionLink({
-  "text": "Find a minor injuries unit",
-  "href": "https://www.nhs.uk/service-search/minor-injuries-unit/locationsearch/551"
+  text: "Find a minor injuries unit",
+  href: "https://www.nhs.uk/service-search/minor-injuries-unit/locationsearch/551"
 }) }}

--- a/app/views/design-system/components/back-link/button/index.njk
+++ b/app/views/design-system/components/back-link/button/index.njk
@@ -1,6 +1,6 @@
 {% from 'back-link/macro.njk' import backLink %}
 
 {{ backLink({
-  "text": "Go back",
-  "element": "button"
+  text: "Go back",
+  element: "button"
 }) }}

--- a/app/views/design-system/components/back-link/default/index.njk
+++ b/app/views/design-system/components/back-link/default/index.njk
@@ -1,6 +1,6 @@
 {% from 'back-link/macro.njk' import backLink %}
 
 {{ backLink({
-  "href": "#",
-  "text": "Go back"
+  href: "#",
+  text: "Go back"
 }) }}

--- a/app/views/design-system/components/buttons/default/index.njk
+++ b/app/views/design-system/components/buttons/default/index.njk
@@ -1,5 +1,5 @@
 {% from 'button/macro.njk' import button %}
 
 {{ button({
-  "text": "Save and continue"
+  text: "Save and continue"
 }) }}

--- a/app/views/design-system/components/buttons/prevent-double-click/index.njk
+++ b/app/views/design-system/components/buttons/prevent-double-click/index.njk
@@ -1,6 +1,6 @@
 {% from 'button/macro.njk' import button %}
 
 {{ button({
-  "text": "Save and continue",
+  text: "Save and continue",
   "preventDoubleClick": true
 }) }}

--- a/app/views/design-system/components/buttons/prevent-double-click/index.njk
+++ b/app/views/design-system/components/buttons/prevent-double-click/index.njk
@@ -2,5 +2,5 @@
 
 {{ button({
   text: "Save and continue",
-  "preventDoubleClick": true
+  preventDoubleClick: true
 }) }}

--- a/app/views/design-system/components/buttons/reverse/index.njk
+++ b/app/views/design-system/components/buttons/reverse/index.njk
@@ -1,6 +1,6 @@
 {% from 'button/macro.njk' import button %}
 
 {{ button({
-  "text": "Save and continue",
-  "classes": "nhsuk-button--reverse"
+  text: "Save and continue",
+  classes: "nhsuk-button--reverse"
 }) }}

--- a/app/views/design-system/components/buttons/secondary/index.njk
+++ b/app/views/design-system/components/buttons/secondary/index.njk
@@ -1,6 +1,6 @@
 {% from 'button/macro.njk' import button %}
 
 {{ button({
-  "text": "Find my location",
-  "classes": "nhsuk-button--secondary"
+  text: "Find my location",
+  classes: "nhsuk-button--secondary"
 }) }}

--- a/app/views/design-system/components/card/clickable/index.njk
+++ b/app/views/design-system/components/card/clickable/index.njk
@@ -1,9 +1,9 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "href": "#",
-  "clickable": "true",
-  "heading": "Introduction to care and support",
-  "headingClasses": "nhsuk-heading-m",
-  "description": "A quick guide for people who have care and support needs and their carers"
+  href: "#",
+  clickable: "true",
+  heading: "Introduction to care and support",
+  headingClasses: "nhsuk-heading-m",
+  description: "A quick guide for people who have care and support needs and their carers"
 }) }}

--- a/app/views/design-system/components/card/default/index.njk
+++ b/app/views/design-system/components/card/default/index.njk
@@ -1,7 +1,7 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "heading": "If you need help now, but it’s not an emergency",
-  "headingLevel": "3",
-  "descriptionHtml": "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a></p>"
+  heading: "If you need help now, but it’s not an emergency",
+  headingLevel: "3",
+  descriptionHtml: "<p class=\"nhsuk-card__description\">Go to <a href=\"#\">111.nhs.uk</a> or <a href=\"#\">call 111</a></p>"
 }) }}

--- a/app/views/design-system/components/card/group-half/index.njk
+++ b/app/views/design-system/components/card/group-half/index.njk
@@ -3,38 +3,38 @@
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "Introduction to care and support",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "A quick guide for people who have care and support needs and their carers"
+      href: "#",
+      clickable: "true",
+      heading: "Introduction to care and support",
+      headingClasses: "nhsuk-heading-m",
+      description: "A quick guide for people who have care and support needs and their carers"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "Help from social services and charities",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "Includes helplines, needs assessments, advocacy and reporting abuse"
+      href: "#",
+      clickable: "true",
+      heading: "Help from social services and charities",
+      headingClasses: "nhsuk-heading-m",
+      description: "Includes helplines, needs assessments, advocacy and reporting abuse"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "Money, work and benefits",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "How to pay for care and support, and where you can get help with costs"
+      href: "#",
+      clickable: "true",
+      heading: "Money, work and benefits",
+      headingClasses: "nhsuk-heading-m",
+      description: "How to pay for care and support, and where you can get help with costs"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "Care after a hospital stay",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "Includes hospital discharge and care and support afterwards"
+      href: "#",
+      clickable: "true",
+      heading: "Care after a hospital stay",
+      headingClasses: "nhsuk-heading-m",
+      description: "Includes hospital discharge and care and support afterwards"
     }) }}
   </li>
 </ul>

--- a/app/views/design-system/components/card/group-quarter/index.njk
+++ b/app/views/design-system/components/card/group-quarter/index.njk
@@ -3,26 +3,26 @@
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
     {{ card({
-      "clickable": "true",
-      "headingHtml": "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">91 <span class=\"nhsuk-u-visually-hidden\">Applicants</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Applicants</a>"
+      clickable: "true",
+      headingHtml: "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">91 <span class=\"nhsuk-u-visually-hidden\">Applicants</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Applicants</a>"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
     {{ card({
-      "clickable": "true",
-      "headingHtml": "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">23 <span class=\"nhsuk-u-visually-hidden\">Jobs</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Jobs</a>"
+      clickable: "true",
+      headingHtml: "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">23 <span class=\"nhsuk-u-visually-hidden\">Jobs</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Jobs</a>"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
     {{ card({
-      "clickable": "true",
-      "headingHtml": "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">8 <span class=\"nhsuk-u-visually-hidden\">Services</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Services</a>"
+      clickable: "true",
+      headingHtml: "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">8 <span class=\"nhsuk-u-visually-hidden\">Services</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Services</a>"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
     {{ card({
-      "clickable": "true",
-      "headingHtml": "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">33 <span class=\"nhsuk-u-visually-hidden\">Messages</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Messages</a>"
+      clickable: "true",
+      headingHtml: "<p class=\"nhsuk-heading-xl nhsuk-u-font-size-64 nhsuk-u-margin-bottom-1\">33 <span class=\"nhsuk-u-visually-hidden\">Messages</span></p><a href=\"#\" class=\"nhsuk-card__link nhsuk-u-font-weight-normal nhsuk-u-font-size-19 nhsuk-link--no-visited-state\">Messages</a>"
     }) }}
   </li>
 </ul>

--- a/app/views/design-system/components/card/group-third/index.njk
+++ b/app/views/design-system/components/card/group-third/index.njk
@@ -3,29 +3,29 @@
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "5 steps to mental wellbeing",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "Practical advice to help you feel mentally and emotionally better"
+      href: "#",
+      clickable: "true",
+      heading: "5 steps to mental wellbeing",
+      headingClasses: "nhsuk-heading-m",
+      description: "Practical advice to help you feel mentally and emotionally better"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "Healthy weight",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "Check your BMI using our healthy weight calculator and find out if you're a healthy weight"
+      href: "#",
+      clickable: "true",
+      heading: "Healthy weight",
+      headingClasses: "nhsuk-heading-m",
+      description: "Check your BMI using our healthy weight calculator and find out if you're a healthy weight"
     }) }}
   </li>
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     {{ card({
-      "href": "#",
-      "clickable": "true",
-      "heading": "Exercise",
-      "headingClasses": "nhsuk-heading-m",
-      "description": "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
+      href: "#",
+      clickable: "true",
+      heading: "Exercise",
+      headingClasses: "nhsuk-heading-m",
+      description: "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
     }) }}
   </li>
 </ul>

--- a/app/views/design-system/components/card/heading-level/index.njk
+++ b/app/views/design-system/components/card/heading-level/index.njk
@@ -1,7 +1,7 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "heading": "Heading level 3",
-  "headingLevel": "3",
-  "description": "Card description text goes here"
+  heading: "Heading level 3",
+  headingLevel: "3",
+  description: "Card description text goes here"
 }) }}

--- a/app/views/design-system/components/card/heading-size/index.njk
+++ b/app/views/design-system/components/card/heading-size/index.njk
@@ -1,7 +1,7 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "heading": "Heading level",
-  "headingClasses": "nhsuk-heading-s",
-  "description": "Card description text goes here"
+  heading: "Heading level",
+  headingClasses: "nhsuk-heading-s",
+  description: "Card description text goes here"
 }) }}

--- a/app/views/design-system/components/card/with-image/index.njk
+++ b/app/views/design-system/components/card/with-image/index.njk
@@ -2,9 +2,9 @@
 
 {{ card({
   "imgURL": "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg",
-  "href": "#",
-  "clickable": "true",
-  "heading": "Exercise",
-  "headingClasses": "nhsuk-heading-m",
-  "description": "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
+  href: "#",
+  clickable: "true",
+  heading: "Exercise",
+  headingClasses: "nhsuk-heading-m",
+  description: "Programmes, workouts and tips to get you moving and improve your fitness and wellbeing"
 }) }}

--- a/app/views/design-system/components/card/with-image/index.njk
+++ b/app/views/design-system/components/card/with-image/index.njk
@@ -1,7 +1,7 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "imgURL": "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg",
+  imgURL: "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg",
   href: "#",
   clickable: "true",
   heading: "Exercise",

--- a/app/views/design-system/components/checkboxes/conditional/index.njk
+++ b/app/views/design-system/components/checkboxes/conditional/index.njk
@@ -36,38 +36,38 @@
 
 <form>
   {{ checkboxes({
-    "idPrefix": "contact",
-    "name": "contact",
-    "fieldset": {
-      "legend": {
-        "text": "How would you prefer to be contacted?",
-        "classes": "nhsuk-fieldset__legend--l",
-        "isPageHeading": "true"
+    idPrefix: "contact",
+    name: "contact",
+    fieldset: {
+      legend: {
+        text: "How would you prefer to be contacted?",
+        classes: "nhsuk-fieldset__legend--l",
+        isPageHeading: "true"
       }
     },
-    "hint": {
-      "text": "Select all options that are relevant to you."
+    hint: {
+      text: "Select all options that are relevant to you."
     },
-    "items": [
+    items: [
       {
-        "value": "email",
-        "text": "Email",
-        "conditional": {
-          "html": emailHtml
+        value: "email",
+        text: "Email",
+        conditional: {
+          html: emailHtml
         }
       },
       {
-        "value": "phone",
-        "text": "Phone",
-        "conditional": {
-          "html": phoneHtml
+        value: "phone",
+        text: "Phone",
+        conditional: {
+          html: phoneHtml
         }
       },
       {
-        "value": "text",
-        "text": "Text message",
-        "conditional": {
-          "html": mobileHtml
+        value: "text",
+        text: "Text message",
+        conditional: {
+          html: mobileHtml
         }
       }
     ]

--- a/app/views/design-system/components/checkboxes/default/index.njk
+++ b/app/views/design-system/components/checkboxes/default/index.njk
@@ -2,30 +2,30 @@
 
 <form>
   {{ checkboxes({
-    "idPrefix": "example",
-    "name": "example",
-    "fieldset": {
-      "legend": {
-        "text": "How would you like to be contacted?",
-        "classes": "nhsuk-fieldset__legend--l",
+    idPrefix: "example",
+    name: "example",
+    fieldset: {
+      legend: {
+        text: "How would you like to be contacted?",
+        classes: "nhsuk-fieldset__legend--l",
         isPageHeading: true
       }
     },
-    "hint": {
-      "text": "Select all options that are relevant to you."
+    hint: {
+      text: "Select all options that are relevant to you."
     },
-    "items": [
+    items: [
       {
-        "value": "email",
-        "text": "Email"
+        value: "email",
+        text: "Email"
       },
       {
-        "value": "phone",
-        "text": "Phone"
+        value: "phone",
+        text: "Phone"
       },
       {
-        "value": "text message",
-        "text": "Text message"
+        value: "text message",
+        text: "Text message"
       }
     ]
   }) }}

--- a/app/views/design-system/components/checkboxes/error-messages/index.njk
+++ b/app/views/design-system/components/checkboxes/error-messages/index.njk
@@ -2,34 +2,34 @@
 
 <form>
   {{ checkboxes({
-    "idPrefix": "contact",
-    "name": "contact",
-    "fieldset": {
-      "legend": {
-        "text": "How would you like to be contacted?",
-        "classes": "nhsuk-fieldset__legend--l",
+    idPrefix: "contact",
+    name: "contact",
+    fieldset: {
+      legend: {
+        text: "How would you like to be contacted?",
+        classes: "nhsuk-fieldset__legend--l",
         isPageHeading: true
       }
     },
-    "hint": {
-      "text": "Select all options that are relevant to you."
+    hint: {
+      text: "Select all options that are relevant to you."
     },
-    "errorMessage": {
-      "text": "Select how you like to be contacted"
+    errorMessage: {
+      text: "Select how you like to be contacted"
     },
-    "items": [
+    items: [
       {
-        "value": "email",
-        "text": "Email",
+        value: "email",
+        text: "Email",
         id: "contact"
       },
       {
-        "value": "phone",
-        "text": "Phone"
+        value: "phone",
+        text: "Phone"
       },
       {
-        "value": "text message",
-        "text": "Text message"
+        value: "text message",
+        text: "Text message"
       }
     ]
   }) }}

--- a/app/views/design-system/components/checkboxes/hint/index.njk
+++ b/app/views/design-system/components/checkboxes/hint/index.njk
@@ -2,31 +2,31 @@
 
 <form>
   {{ checkboxes({
-    "idPrefix": "contact",
-    "name": "contact",
-    "fieldset": {
-      "legend": {
-        "text": "How would you like to be contacted?",
-        "classes": "nhsuk-fieldset__legend--l",
+    idPrefix: "contact",
+    name: "contact",
+    fieldset: {
+      legend: {
+        text: "How would you like to be contacted?",
+        classes: "nhsuk-fieldset__legend--l",
         isPageHeading: true
       }
     },
-    "hint": {
-      "text": "Select all options that are relevant to you."
+    hint: {
+      text: "Select all options that are relevant to you."
     },
-    "items": [
+    items: [
       {
-        "value": "email",
-        "text": "Email",
+        value: "email",
+        text: "Email",
         id: "contact"
       },
       {
-        "value": "phone",
-        "text": "Phone"
+        value: "phone",
+        text: "Phone"
       },
       {
-        "value": "text message",
-        "text": "Text message"
+        value: "text message",
+        text: "Text message"
       }
     ]
   }) }}

--- a/app/views/design-system/components/contents-list/default/index.njk
+++ b/app/views/design-system/components/contents-list/default/index.njk
@@ -14,13 +14,11 @@
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/getting-diagnosed/",
       text: "Getting diagnosed"
-    }
-    ,
+    },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/treatment/",
       text: "Treatments"
-    }
-    ,
+    },
     {
       href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/living-with-amd/",
       text: "Living with AMD"

--- a/app/views/design-system/components/date-input/default/index.njk
+++ b/app/views/design-system/components/date-input/default/index.njk
@@ -1,30 +1,30 @@
 {% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
-  "id": "example",
+  id: "example",
   "namePrefix": "example",
-  "fieldset": {
-    "legend": {
-      "text": "What is your date of birth?",
-      "classes": "nhsuk-label--l",
-      "isPageHeading": true
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?",
+      classes: "nhsuk-label--l",
+      isPageHeading: true
     }
   },
-  "hint": {
-    "text": "For example, 15 3 1984"
+  hint: {
+    text: "For example, 15 3 1984"
   },
-  "items": [
+  items: [
     {
-      "name": "day",
-      "classes": "nhsuk-input--width-2"
+      name: "day",
+      classes: "nhsuk-input--width-2"
     },
     {
-      "name": "month",
-      "classes": "nhsuk-input--width-2"
+      name: "month",
+      classes: "nhsuk-input--width-2"
     },
     {
-      "name": "year",
-      "classes": "nhsuk-input--width-4"
+      name: "year",
+      classes: "nhsuk-input--width-4"
     }
   ]
 }) }}

--- a/app/views/design-system/components/date-input/default/index.njk
+++ b/app/views/design-system/components/date-input/default/index.njk
@@ -2,7 +2,7 @@
 
 {{ dateInput({
   id: "example",
-  "namePrefix": "example",
+  namePrefix: "example",
   fieldset: {
     legend: {
       text: "What is your date of birth?",

--- a/app/views/design-system/components/date-input/with-errors/index.njk
+++ b/app/views/design-system/components/date-input/with-errors/index.njk
@@ -1,32 +1,32 @@
 {% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
-  "id": "dob-errors",
-  "fieldset": {
-    "legend": {
-      "text": "What is your date of birth?",
-      "classes": "nhsuk-label--l",
-      "isPageHeading": true
+  id: "dob-errors",
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?",
+      classes: "nhsuk-label--l",
+      isPageHeading: true
     }
   },
-  "hint": {
-    "text": "For example, 15 3 1984"
+  hint: {
+    text: "For example, 15 3 1984"
   },
-  "errorMessage": {
-    "text": "Enter your date of birth"
+  errorMessage: {
+    text: "Enter your date of birth"
   },
-  "items": [
+  items: [
     {
-      "name": "day",
-      "classes": "nhsuk-input--width-2 nhsuk-input--error"
+      name: "day",
+      classes: "nhsuk-input--width-2 nhsuk-input--error"
     },
     {
-      "name": "month",
-      "classes": "nhsuk-input--width-2 nhsuk-input--error"
+      name: "month",
+      classes: "nhsuk-input--width-2 nhsuk-input--error"
     },
     {
-      "name": "year",
-      "classes": "nhsuk-input--width-4 nhsuk-input--error"
+      name: "year",
+      classes: "nhsuk-input--width-4 nhsuk-input--error"
     }
   ]
 }) }}

--- a/app/views/design-system/components/details/default/index.njk
+++ b/app/views/design-system/components/details/default/index.njk
@@ -1,8 +1,8 @@
 {% from 'details/macro.njk' import details %}
 
 {{ details({
-  "text": "How to find your NHS number",
-  "HTML": "
+  text: "How to find your NHS number",
+  HTML: "
   <p>An NHS number is a 10 digit number, like 485 777 3456.</p>
     <p>You can find your NHS number by logging in to a GP online service or on any document the NHS has sent you, such as your:</p>
     <ul>

--- a/app/views/design-system/components/do-and-dont-lists/default/index.njk
+++ b/app/views/design-system/components/do-and-dont-lists/default/index.njk
@@ -1,37 +1,36 @@
 {% from 'do-dont-list/macro.njk' import list %}
 
 {{ list({
-  "title": "Do",
-  "type": "tick",
-  "items": [
+  title: "Do",
+  type: "tick",
+  items: [
     {
-      "item": "cover blisters that are likely to burst with a soft plaster or dressing"
+      item: "cover blisters that are likely to burst with a soft plaster or dressing"
     },
     {
-      "item": "wash your hands before touching a burst blister"
+      item: "wash your hands before touching a burst blister"
     },
     {
-      "item": "allow the fluid in a burst blister to drain before covering it with a plaster or dressing"
+      item: "allow the fluid in a burst blister to drain before covering it with a plaster or dressing"
     }
   ]
 }) }}
 
 {{ list({
-  "title": "Don't",
-  "type": "cross",
-  "items": [
+  title: "Don't",
+  type: "cross",
+  items: [
     {
-      "item": "burst a blister yourself"
+      item: "burst a blister yourself"
     },
     {
-      "item": "peel the skin off a burst blister"
+      item: "peel the skin off a burst blister"
     },
     {
-      "item": "pick at the edges of the remaining skin"
+      item: "pick at the edges of the remaining skin"
     },
     {
-      "item": "wear the shoes or use the equipment that caused your blister until it heals"
+      item: "wear the shoes or use the equipment that caused your blister until it heals"
     }
   ]
 }) }}
-

--- a/app/views/design-system/components/error-message/default/index.njk
+++ b/app/views/design-system/components/error-message/default/index.njk
@@ -1,5 +1,5 @@
 {% from 'error-message/macro.njk' import errorMessage %}
 
 {{ errorMessage({
-  "text": "Date of birth must be in the past"
+  text: "Date of birth must be in the past"
 }) }}

--- a/app/views/design-system/components/error-message/error-summary-placement-input/index.njk
+++ b/app/views/design-system/components/error-message/error-summary-placement-input/index.njk
@@ -7,9 +7,9 @@
 
 {% block beforeContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
+    href: "#",
+    text: "Go back",
+    classes: "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 
@@ -19,11 +19,11 @@
       <form>
 
         {{ errorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Enter your full name",
-              "href": "#name"
+              text: "Enter your full name",
+              href: "#name"
             }
           ]
         }) }}
@@ -31,22 +31,21 @@
         <h1 class="nhsuk-heading-l">Your details</h1>
 
         {{ input({
-          "label": {
-            "text": "Full name"
+          label: {
+            text: "Full name"
           },
-          "id": "name",
-          "name": "name",
-          "errorMessage": {
-            "text": "Enter your full name"
+          id: "name",
+          name: "name",
+          errorMessage: {
+            text: "Enter your full name"
           }
         }) }}
 
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/components/error-message/error-summary-placement-multiple/index.njk
+++ b/app/views/design-system/components/error-message/error-summary-placement-multiple/index.njk
@@ -7,9 +7,9 @@
 
 {% block beforeContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
+    href: "#",
+    text: "Go back",
+    classes: "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 
@@ -19,15 +19,15 @@
       <form>
 
         {{ errorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Enter your first  name",
-              "href": "#first-name"
+              text: "Enter your first  name",
+              href: "#first-name"
             },
             {
-              "text": "Enter your last name",
-              "href": "#last-name"
+              text: "Enter your last name",
+              href: "#last-name"
             }
           ]
         }) }}
@@ -35,33 +35,32 @@
         <h1 class="nhsuk-heading-l">Your details</h1>
 
         {{ input({
-          "label": {
-            "text": "First name"
+          label: {
+            text: "First name"
           },
-          "id": "first-name",
-          "name": "first-name",
-          "errorMessage": {
-            "text": "Enter your first name"
+          id: "first-name",
+          name: "first-name",
+          errorMessage: {
+            text: "Enter your first name"
           }
         }) }}
 
         {{ input({
-          "label": {
-            "text": "Last name"
+          label: {
+            text: "Last name"
           },
-          "id": "last-name",
-          "name": "last-name",
-          "errorMessage": {
-            "text": "Enter your last name"
+          id: "last-name",
+          name: "last-name",
+          errorMessage: {
+            text: "Enter your last name"
           }
         }) }}
 
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/components/error-message/error-summary-placement/index.njk
+++ b/app/views/design-system/components/error-message/error-summary-placement/index.njk
@@ -7,9 +7,9 @@
 
 {% block beforeContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
+    href: "#",
+    text: "Go back",
+    classes: "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 
@@ -19,54 +19,53 @@
       <form>
 
         {{ errorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Date of birth must include a year",
-              "href": "#dob-errors-year"
+              text: "Date of birth must include a year",
+              href: "#dob-errors-year"
             }
           ]
         }) }}
 
         {{ dateInput({
-          "id": "dob-errors",
-          "fieldset": {
-            "legend": {
-              "text": "What is your date of birth?",
-              "classes": "nhsuk-fieldset__legend--l",
-              "isPageHeading": true
+          id: "dob-errors",
+          fieldset: {
+            legend: {
+              text: "What is your date of birth?",
+              classes: "nhsuk-fieldset__legend--l",
+              isPageHeading: true
             }
           },
-          "hint": {
-            "text": "For example, 15 3 1984"
+          hint: {
+            text: "For example, 15 3 1984"
           },
-          "errorMessage": {
-            "text": "Date of birth must include a year"
+          errorMessage: {
+            text: "Date of birth must include a year"
           },
-          "items": [
+          items: [
             {
-              "name": "day",
-              "classes": "nhsuk-input--width-2",
+              name: "day",
+              classes: "nhsuk-input--width-2",
               value: 15
             },
             {
-              "name": "month",
-              "classes": "nhsuk-input--width-2",
+              name: "month",
+              classes: "nhsuk-input--width-2",
               value: 3
             },
             {
-              "name": "year",
-              "classes": "nhsuk-input--width-4 nhsuk-input--error"
+              name: "year",
+              classes: "nhsuk-input--width-4 nhsuk-input--error"
             }
           ]
         }) }}
 
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/components/error-message/in-context/index.njk
+++ b/app/views/design-system/components/error-message/in-context/index.njk
@@ -3,7 +3,7 @@
 
 {{ dateInput({
   id: "dob-day-error",
-  "namePrefix": "dob-day-error",
+  namePrefix: "dob-day-error",
   fieldset: {
       legend: {
       text: "What is your date of birth?",

--- a/app/views/design-system/components/error-message/in-context/index.njk
+++ b/app/views/design-system/components/error-message/in-context/index.njk
@@ -2,35 +2,35 @@
 {% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
-  "id": "dob-day-error",
+  id: "dob-day-error",
   "namePrefix": "dob-day-error",
-  "fieldset": {
-      "legend": {
-      "text": "What is your date of birth?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  fieldset: {
+      legend: {
+      text: "What is your date of birth?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
       }
   },
-  "hint": {
-      "text": "For example, 31 3 1980"
+  hint: {
+      text: "For example, 31 3 1980"
   },
-  "errorMessage": {
-      "text": "Date of birth must be in the past"
+  errorMessage: {
+      text: "Date of birth must be in the past"
   },
-  "items": [
+  items: [
       {
-      "name": "day",
-      "classes": "nhsuk-input--width-2 nhsuk-input--error",
+      name: "day",
+      classes: "nhsuk-input--width-2 nhsuk-input--error",
       value: 15
       },
       {
-      "name": "month",
-      "classes": "nhsuk-input--width-2 nhsuk-input--error",
+      name: "month",
+      classes: "nhsuk-input--width-2 nhsuk-input--error",
       value: 3
       },
       {
-      "name": "year",
-      "classes": "nhsuk-input--width-4 nhsuk-input--error",
+      name: "year",
+      classes: "nhsuk-input--width-4 nhsuk-input--error",
       value: 2084
       }
   ]

--- a/app/views/design-system/components/error-message/input/index.njk
+++ b/app/views/design-system/components/error-message/input/index.njk
@@ -1,12 +1,12 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "Full name"
+  label: {
+    text: "Full name"
   },
-  "id": "example",
-  "name": "example",
-  "errorMessage": {
-    "text": "Enter your full name"
+  id: "example",
+  name: "example",
+  errorMessage: {
+    text: "Enter your full name"
   }
 }) }}

--- a/app/views/design-system/components/error-message/radios/index.njk
+++ b/app/views/design-system/components/error-message/radios/index.njk
@@ -1,29 +1,29 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example-error",
-  "name": "example-error",
-  "errorMessage": {
-    "text": "Select yes if you have changed your name"
+  idPrefix: "example-error",
+  name: "example-error",
+  errorMessage: {
+    text: "Select yes if you have changed your name"
   },
-  "fieldset": {
-    "legend": {
-      "text": "Have you changed your name?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  fieldset: {
+    legend: {
+      text: "Have you changed your name?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "hint": {
-    "text": "This includes changing your last name or spelling your name differently."
+  hint: {
+    text: "This includes changing your last name or spelling your name differently."
   },
-  "items": [
+  items: [
     {
-      "value": "yes",
-      "text": "Yes"
+      value: "yes",
+      text: "Yes"
     },
     {
-      "value": "no",
-      "text": "No"
+      value: "no",
+      text: "No"
     }
   ]
 }) }}

--- a/app/views/design-system/components/error-summary/default/index.njk
+++ b/app/views/design-system/components/error-summary/default/index.njk
@@ -2,7 +2,7 @@
 
 {{ errorSummary({
   titleText: "There is a problem",
-  "descriptionText": "Describe the errors and how to correct them",
+  descriptionText: "Describe the errors and how to correct them",
   errorList: [
     {
       text: "Date of birth must be in the past",

--- a/app/views/design-system/components/error-summary/default/index.njk
+++ b/app/views/design-system/components/error-summary/default/index.njk
@@ -1,12 +1,12 @@
 {% from 'error-summary/macro.njk' import errorSummary %}
 
 {{ errorSummary({
-  "titleText": "There is a problem",
+  titleText: "There is a problem",
   "descriptionText": "Describe the errors and how to correct them",
-  "errorList": [
+  errorList: [
     {
-      "text": "Date of birth must be in the past",
-      "href": "#example-error-1"
+      text: "Date of birth must be in the past",
+      href: "#example-error-1"
     }
   ]
 }) }}

--- a/app/views/design-system/components/error-summary/link-input/index.njk
+++ b/app/views/design-system/components/error-summary/link-input/index.njk
@@ -2,11 +2,11 @@
 {% from 'input/macro.njk' import input %}
 
 {{ errorSummary({
-  "titleText": "There is a problem",
-  "errorList": [
+  titleText: "There is a problem",
+  errorList: [
     {
-      "text": "Enter your full name",
-      "href": "#name"
+      text: "Enter your full name",
+      href: "#name"
     }
   ]
 }) }}
@@ -14,12 +14,12 @@
 <h1 class="nhsuk-heading-l">Your details</h1>
 
 {{ input({
-  "label": {
-    "text": "Full name"
+  label: {
+    text: "Full name"
   },
-  "id": "name",
-  "name": "name",
-  "errorMessage": {
-    "text": "Enter your full name"
+  id: "name",
+  name: "name",
+  errorMessage: {
+    text: "Enter your full name"
   }
 }) }}

--- a/app/views/design-system/components/error-summary/link-multiple-input/index.njk
+++ b/app/views/design-system/components/error-summary/link-multiple-input/index.njk
@@ -2,44 +2,44 @@
 {% from 'date-input/macro.njk' import dateInput %}
 
 {{ errorSummary({
-  "titleText": "There is a problem",
-  "errorList": [
+  titleText: "There is a problem",
+  errorList: [
     {
-      "text": "Date of birth must include a year",
-      "href": "#dob-errors-year"
+      text: "Date of birth must include a year",
+      href: "#dob-errors-year"
     }
   ]
 }) }}
 
 {{ dateInput({
-  "id": "dob-errors",
-  "fieldset": {
-    "legend": {
-      "text": "What is your date of birth?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  id: "dob-errors",
+  fieldset: {
+    legend: {
+      text: "What is your date of birth?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "hint": {
-    "text": "For example, 15 3 1984"
+  hint: {
+    text: "For example, 15 3 1984"
   },
-  "errorMessage": {
-    "text": "Date of birth must include a year"
+  errorMessage: {
+    text: "Date of birth must include a year"
   },
-  "items": [
+  items: [
     {
-      "name": "day",
-      "classes": "nhsuk-input--width-2",
+      name: "day",
+      classes: "nhsuk-input--width-2",
       value: 15
     },
     {
-      "name": "month",
-      "classes": "nhsuk-input--width-2",
+      name: "month",
+      classes: "nhsuk-input--width-2",
       value: 3
     },
     {
-      "name": "year",
-      "classes": "nhsuk-input--width-4 nhsuk-input--error"
+      name: "year",
+      classes: "nhsuk-input--width-4 nhsuk-input--error"
     }
   ]
 }) }}

--- a/app/views/design-system/components/error-summary/link-options/index.njk
+++ b/app/views/design-system/components/error-summary/link-options/index.njk
@@ -2,44 +2,44 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
 {{ errorSummary({
-  "titleText": "There is a problem",
-  "errorList": [
+  titleText: "There is a problem",
+  errorList: [
     {
-      "text": "Select how you like to be contacted",
-      "href": "#contact"
+      text: "Select how you like to be contacted",
+      href: "#contact"
     }
   ]
 }) }}
 
 {{ checkboxes({
-  "idPrefix": "contact",
-  "name": "contact",
-  "fieldset": {
-    "legend": {
-      "text": "How would you like to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
+  idPrefix: "contact",
+  name: "contact",
+  fieldset: {
+    legend: {
+      text: "How would you like to be contacted?",
+      classes: "nhsuk-fieldset__legend--l",
       isPageHeading: true
     }
   },
-  "hint": {
-    "text": "Select all options that are relevant to you."
+  hint: {
+    text: "Select all options that are relevant to you."
   },
-  "errorMessage": {
-    "text": "Select how you like to be contacted"
+  errorMessage: {
+    text: "Select how you like to be contacted"
   },
-  "items": [
+  items: [
     {
-      "value": "email",
-      "text": "Email",
+      value: "email",
+      text: "Email",
       id: "contact"
     },
     {
-      "value": "phone",
-      "text": "Phone"
+      value: "phone",
+      text: "Phone"
     },
     {
-      "value": "text message",
-      "text": "Text message"
+      value: "text message",
+      text: "Text message"
     }
   ]
 }) }}

--- a/app/views/design-system/components/error-summary/placement-input/index.njk
+++ b/app/views/design-system/components/error-summary/placement-input/index.njk
@@ -7,9 +7,9 @@
 
 {% block beforeContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
+    href: "#",
+    text: "Go back",
+    classes: "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 
@@ -19,11 +19,11 @@
       <form>
 
         {{ errorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Enter your full name",
-              "href": "#name"
+              text: "Enter your full name",
+              href: "#name"
             }
           ]
         }) }}
@@ -31,22 +31,21 @@
         <h1 class="nhsuk-heading-l">Your details</h1>
 
         {{ input({
-          "label": {
-            "text": "Full name"
+          label: {
+            text: "Full name"
           },
-          "id": "name",
-          "name": "name",
-          "errorMessage": {
-            "text": "Enter your full name"
+          id: "name",
+          name: "name",
+          errorMessage: {
+            text: "Enter your full name"
           }
         }) }}
 
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/components/error-summary/placement-multiple/index.njk
+++ b/app/views/design-system/components/error-summary/placement-multiple/index.njk
@@ -7,9 +7,9 @@
 
 {% block beforeContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
+    href: "#",
+    text: "Go back",
+    classes: "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 
@@ -19,15 +19,15 @@
       <form>
 
         {{ errorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Enter your first  name",
-              "href": "#first-name"
+              text: "Enter your first  name",
+              href: "#first-name"
             },
             {
-              "text": "Enter your last name",
-              "href": "#last-name"
+              text: "Enter your last name",
+              href: "#last-name"
             }
           ]
         }) }}
@@ -35,33 +35,32 @@
         <h1 class="nhsuk-heading-l">Your details</h1>
 
         {{ input({
-          "label": {
-            "text": "First name"
+          label: {
+            text: "First name"
           },
-          "id": "first-name",
-          "name": "first-name",
-          "errorMessage": {
-            "text": "Enter your first name"
+          id: "first-name",
+          name: "first-name",
+          errorMessage: {
+            text: "Enter your first name"
           }
         }) }}
 
         {{ input({
-          "label": {
-            "text": "Last name"
+          label: {
+            text: "Last name"
           },
-          "id": "last-name",
-          "name": "last-name",
-          "errorMessage": {
-            "text": "Enter your last name"
+          id: "last-name",
+          name: "last-name",
+          errorMessage: {
+            text: "Enter your last name"
           }
         }) }}
 
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/components/error-summary/placement/index.njk
+++ b/app/views/design-system/components/error-summary/placement/index.njk
@@ -7,9 +7,9 @@
 
 {% block beforeContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
+    href: "#",
+    text: "Go back",
+    classes: "nhsuk-u-margin-bottom-0 nhsuk-u-margin-top-4"
   }) }}
 {% endblock %}
 
@@ -19,54 +19,53 @@
       <form>
 
         {{ errorSummary({
-          "titleText": "There is a problem",
-          "errorList": [
+          titleText: "There is a problem",
+          errorList: [
             {
-              "text": "Date of birth must include a year",
-              "href": "#dob-errors-year"
+              text: "Date of birth must include a year",
+              href: "#dob-errors-year"
             }
           ]
         }) }}
 
         {{ dateInput({
-          "id": "dob-errors",
-          "fieldset": {
-            "legend": {
-              "text": "What is your date of birth?",
-              "classes": "nhsuk-fieldset__legend--l",
-              "isPageHeading": true
+          id: "dob-errors",
+          fieldset: {
+            legend: {
+              text: "What is your date of birth?",
+              classes: "nhsuk-fieldset__legend--l",
+              isPageHeading: true
             }
           },
-          "hint": {
-            "text": "For example, 15 3 1984"
+          hint: {
+            text: "For example, 15 3 1984"
           },
-          "errorMessage": {
-            "text": "Date of birth must include a year"
+          errorMessage: {
+            text: "Date of birth must include a year"
           },
-          "items": [
+          items: [
             {
-              "name": "day",
-              "classes": "nhsuk-input--width-2",
+              name: "day",
+              classes: "nhsuk-input--width-2",
               value: 15
             },
             {
-              "name": "month",
-              "classes": "nhsuk-input--width-2",
+              name: "month",
+              classes: "nhsuk-input--width-2",
               value: 3
             },
             {
-              "name": "year",
-              "classes": "nhsuk-input--width-4 nhsuk-input--error"
+              name: "year",
+              classes: "nhsuk-input--width-4 nhsuk-input--error"
             }
           ]
         }) }}
 
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
 
       </form>
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/components/expander/default/index.njk
+++ b/app/views/design-system/components/expander/default/index.njk
@@ -1,9 +1,9 @@
 {% from 'details/macro.njk' import details %}
 
 {{ details({
-  "classes": "nhsuk-expander",
-  "text": "Get your medical records",
-  "HTML": "
+  classes: "nhsuk-expander",
+  text: "Get your medical records",
+  HTML: "
   <p>You can see your GP records by:</p>
   <ul>
     <li>asking for them at your GP surgery </li>

--- a/app/views/design-system/components/expander/group/index.njk
+++ b/app/views/design-system/components/expander/group/index.njk
@@ -2,9 +2,9 @@
 
 <div class="nhsuk-expander-group">
   {{ details({
-    "classes": "nhsuk-expander",
-    "text": "How to measure your blood glucose levels",
-    "HTML": "
+    classes: "nhsuk-expander",
+    text: "How to measure your blood glucose levels",
+    HTML: "
     <p>Testing your blood at home is quick and easy, although it can be uncomfortable. It does get better.</p>
     <p>You would have been given:</p>
     <ul>
@@ -16,9 +16,9 @@
     "
   }) }}
   {{ details({
-    "classes": "nhsuk-expander",
-    "text": "When to check your blood glucose level",
-    "HTML": "
+    classes: "nhsuk-expander",
+    text: "When to check your blood glucose level",
+    HTML: "
     <p>Try to check your blood:</p>
     <ul>
       <li>before meals</li>

--- a/app/views/design-system/components/fieldset/as-heading/index.njk
+++ b/app/views/design-system/components/fieldset/as-heading/index.njk
@@ -1,9 +1,9 @@
 {% from 'fieldset/macro.njk' import fieldset %}
 
 {{ fieldset({
-  "legend": {
-    "text": "What is your address?",
-    "classes": "nhsuk-fieldset__legend--xl",
-    "isPageHeading": true
+  legend: {
+    text: "What is your address?",
+    classes: "nhsuk-fieldset__legend--xl",
+    isPageHeading: true
   }
 }) }}

--- a/app/views/design-system/components/fieldset/default/index.njk
+++ b/app/views/design-system/components/fieldset/default/index.njk
@@ -3,53 +3,53 @@
 
 {% call fieldset({
   legend: {
-    "text": "What is your address?",
-    "classes": "nhsuk-fieldset__legend--l",
-    "isPageHeading": true
+    text: "What is your address?",
+    classes: "nhsuk-fieldset__legend--l",
+    isPageHeading: true
   }
 }) %}
 
   {{ input({
     label: {
-      "html": 'Building and street <span class="nhsuk-u-visually-hidden">line 1 of 2</span>'
+      html: 'Building and street <span class="nhsuk-u-visually-hidden">line 1 of 2</span>'
     },
-    "id": "address-line-1",
-    "name": "address-line-1"
+    id: "address-line-1",
+    name: "address-line-1"
   }) }}
 
   {{ input({
     label: {
-      "html": '<span class="nhsuk-u-visually-hidden">Building and street line 2 of 2</span>'
+      html: '<span class="nhsuk-u-visually-hidden">Building and street line 2 of 2</span>'
     },
-    "id": "address-line-2",
-    "name": "address-line-2"
+    id: "address-line-2",
+    name: "address-line-2"
   }) }}
 
   {{ input({
     label: {
-      "text": "Town or city"
+      text: "Town or city"
     },
-    "classes": "nhsuk-u-width-two-thirds",
-    "id": "address-town",
-    "name": "address-town"
+    classes: "nhsuk-u-width-two-thirds",
+    id: "address-town",
+    name: "address-town"
   }) }}
 
   {{ input({
     label: {
-      "text": "County"
+      text: "County"
     },
-    "classes": "nhsuk-u-width-two-thirds",
-    "id": "address-county",
-    "name": "address-county"
+    classes: "nhsuk-u-width-two-thirds",
+    id: "address-county",
+    name: "address-county"
   }) }}
 
   {{ input({
     label: {
-      "text": "Postcode"
+      text: "Postcode"
     },
-    "classes": "nhsuk-input--width-10",
-    "id": "address-postcode",
-    "name": "address-postcode"
+    classes: "nhsuk-input--width-10",
+    id: "address-postcode",
+    name: "address-postcode"
   }) }}
 
 {% endcall %}

--- a/app/views/design-system/components/footer/default/index.njk
+++ b/app/views/design-system/components/footer/default/index.njk
@@ -1,26 +1,26 @@
 {% from 'footer/macro.njk' import footer %}
 
 {{ footer({
-  "links": [
+  links: [
     {
-      "URL": "#",
-      "label": "Accessibility statement"
+      URL: "#",
+      label: "Accessibility statement"
     },
     {
-      "URL": "#",
-      "label": "Contact us"
+      URL: "#",
+      label: "Contact us"
     },
     {
-      "URL": "#",
-      "label": "Cookies"
+      URL: "#",
+      label: "Cookies"
     },
     {
-      "URL": "#",
-      "label": "Privacy policy"
+      URL: "#",
+      label: "Privacy policy"
     },
     {
-      "URL": "#",
-      "label": "Terms and conditions"
+      URL: "#",
+      label: "Terms and conditions"
     }
   ]
 })}}

--- a/app/views/design-system/components/header/default/index.njk
+++ b/app/views/design-system/components/header/default/index.njk
@@ -1,32 +1,32 @@
 {% from 'header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
-    "primaryLinks": [
+    showNav: "true",
+    showSearch: "true",
+    primaryLinks: [
       {
-        "url"  : "https://www.nhs.uk/conditions",
-        "label" : "Health A-Z"
+        url: "https://www.nhs.uk/conditions",
+        label: "Health A-Z"
       },
       {
-        'url' : 'https://www.nhs.uk/live-well/',
-        'label' : 'Live Well'
+        url: 'https://www.nhs.uk/live-well/',
+        label: 'Live Well'
       },
       {
-        'url' : 'https://www.nhs.uk/mental-health/',
-        'label' : 'Mental health'
+        url: 'https://www.nhs.uk/mental-health/',
+        label: 'Mental health'
       },
       {
-        'url'  : 'https://www.nhs.uk/conditions/social-care-and-support/',
-        'label' : 'Care and support'
+        url: 'https://www.nhs.uk/conditions/social-care-and-support/',
+        label: 'Care and support'
       },
       {
-        'url'  : 'https://www.nhs.uk/pregnancy/',
-        'label' : 'Pregnancy'
+        url: 'https://www.nhs.uk/pregnancy/',
+        label: 'Pregnancy'
       },
       {
-        'url' : 'https://www.nhs.uk/nhs-services/',
-        'label' : 'NHS services'
+        url: 'https://www.nhs.uk/nhs-services/',
+        label: 'NHS services'
       }
     ]
   })

--- a/app/views/design-system/components/header/organisational-white/index.njk
+++ b/app/views/design-system/components/header/organisational-white/index.njk
@@ -1,34 +1,34 @@
 {% from 'header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
-    "classes": "nhsuk-header--white",
-    "organisation": {
-      "name": "Anytown Anyplace",
-      "split": "Anywhere",
-      "descriptor": "NHS Foundation Trust"
+    showNav: "true",
+    showSearch: "true",
+    classes: "nhsuk-header--white",
+    organisation: {
+      name: "Anytown Anyplace",
+      split: "Anywhere",
+      descriptor: "NHS Foundation Trust"
     },
-    "primaryLinks": [
+    primaryLinks: [
       {
-        "url"  : "#",
-        "label" : "Your hospital visit"
+        url: "#",
+        label: "Your hospital visit"
       },
       {
-        'url' : '#',
-        'label' : 'Wards and departments'
+        url: '#',
+        label: 'Wards and departments'
       },
       {
-        'url'  : '#',
-        'label' : 'Conditions and treatments'
+        url: '#',
+        label: 'Conditions and treatments'
       },
       {
-        'url'  : '#',
-        'label' : 'Our people'
+        url: '#',
+        label: 'Our people'
       },
       {
-        'url' : '#',
-        'label' : 'Our research'
+        url: '#',
+        label: 'Our research'
       }
     ]
   })

--- a/app/views/design-system/components/header/organisational/index.njk
+++ b/app/views/design-system/components/header/organisational/index.njk
@@ -1,33 +1,33 @@
 {% from 'header/macro.njk' import header %}
 
 {{ header({
-    "showNav": "true",
-    "showSearch": "true",
-    "organisation": {
-      "name": "Anytown Anyplace",
-      "split": "Anywhere",
-      "descriptor": "NHS Foundation Trust"
+    showNav: "true",
+    showSearch: "true",
+    organisation: {
+      name: "Anytown Anyplace",
+      split: "Anywhere",
+      descriptor: "NHS Foundation Trust"
     },
-    "primaryLinks": [
+    primaryLinks: [
       {
-        "url"  : "#",
-        "label" : "Your hospital visit"
+        url: "#",
+        label: "Your hospital visit"
       },
       {
-        'url' : '#',
-        'label' : 'Wards and departments'
+        url: '#',
+        label: 'Wards and departments'
       },
       {
-        'url'  : '#',
-        'label' : 'Conditions and treatments'
+        url: '#',
+        label: 'Conditions and treatments'
       },
       {
-        'url'  : '#',
-        'label' : 'Our people'
+        url: '#',
+        label: 'Our people'
       },
       {
-        'url' : '#',
-        'label' : 'Our research'
+        url: '#',
+        label: 'Our research'
       }
     ]
   })

--- a/app/views/design-system/components/header/service/index.njk
+++ b/app/views/design-system/components/header/service/index.njk
@@ -1,31 +1,31 @@
 {% from 'header/macro.njk' import header %}
 
 {{ header({
-  "service": {
-    "name": "Digital service manual"
+  service: {
+    name: "Digital service manual"
   },
-  "showNav": "true",
-  "showSearch": "true",
-  "primaryLinks": [
+  showNav: "true",
+  showSearch: "true",
+  primaryLinks: [
       {
-        "url"  : "#",
-        "label" : "NHS service standard"
+        url: "#",
+        label: "NHS service standard"
       },
       {
-        'url' : '#',
-        'label' : 'Design system'
+        url: '#',
+        label: 'Design system'
       },
       {
-        'url'  : '#',
-        'label' : 'Content style guide'
+        url: '#',
+        label: 'Content style guide'
       },
       {
-        'url'  : '#',
-        'label' : 'Accessibility'
+        url: '#',
+        label: 'Accessibility'
       },
       {
-        'url' : '#',
-        'label' : 'Community and contribution'
+        url: '#',
+        label: 'Community and contribution'
       }
     ]
   })

--- a/app/views/design-system/components/header/transactional/index.njk
+++ b/app/views/design-system/components/header/transactional/index.njk
@@ -1,12 +1,11 @@
 {% from 'header/macro.njk' import header %}
 
 {{ header({
-  "transactionalService": {
-      "name": "Register with a GP",
-      "href": "https://www.nhs.uk/nhs-services/gps/how-to-register-with-a-gp-surgery/"
+  transactionalService: {
+      name: "Register with a GP",
+      href: "https://www.nhs.uk/nhs-services/gps/how-to-register-with-a-gp-surgery/"
     },
-    "showNav": "false",
-    "showSearch": "false"
+    showNav: "false",
+    showSearch: "false"
   })
 }}
-

--- a/app/views/design-system/components/hint-text/checkboxes/index.njk
+++ b/app/views/design-system/components/hint-text/checkboxes/index.njk
@@ -1,31 +1,31 @@
 {% from 'checkboxes/macro.njk' import checkboxes %}
 
 {{ checkboxes({
-  "idPrefix": "contact",
-  "name": "contact",
-  "fieldset": {
-    "legend": {
-      "text": "How would you like to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
+  idPrefix: "contact",
+  name: "contact",
+  fieldset: {
+    legend: {
+      text: "How would you like to be contacted?",
+      classes: "nhsuk-fieldset__legend--l",
       isPageHeading: true
     }
   },
-  "hint": {
-    "text": "Select all options that are relevant to you."
+  hint: {
+    text: "Select all options that are relevant to you."
   },
-  "items": [
+  items: [
     {
-      "value": "email",
-      "text": "Email",
+      value: "email",
+      text: "Email",
       id: "contact"
     },
     {
-      "value": "phone",
-      "text": "Phone"
+      value: "phone",
+      text: "Phone"
     },
     {
-      "value": "text message",
-      "text": "Text message"
+      value: "text message",
+      text: "Text message"
     }
   ]
 }) }}

--- a/app/views/design-system/components/hint-text/default/index.njk
+++ b/app/views/design-system/components/hint-text/default/index.njk
@@ -1,6 +1,5 @@
 {% from 'hint/macro.njk' import hint %}
 
 {{ hint({
-  "text": "Your NHS number is a 10 digit number that you can find on any letter the NHS has sent you. For example, 458 777 3456."
+  text: "Your NHS number is a 10 digit number that you can find on any letter the NHS has sent you. For example, 458 777 3456."
 }) }}
-

--- a/app/views/design-system/components/hint-text/input/index.njk
+++ b/app/views/design-system/components/hint-text/input/index.njk
@@ -1,11 +1,11 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "What is your NHS number?"
+  label: {
+    text: "What is your NHS number?"
   },
-    "hint": {
-    "text": "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you. For example, 485 777 3456."
+    hint: {
+    text: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you. For example, 485 777 3456."
   },
   id: "example-with-hint-text",
   name: "example-with-hint-text",

--- a/app/views/design-system/components/hint-text/radio-item-with-hints/index.njk
+++ b/app/views/design-system/components/hint-text/radio-item-with-hints/index.njk
@@ -1,28 +1,28 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example-hints",
-  "name": "example-hints",
-  "fieldset": {
-    "legend": {
-      "text": "How do you want to sign in?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  idPrefix: "example-hints",
+  name: "example-hints",
+  fieldset: {
+    legend: {
+      text: "How do you want to sign in?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "items": [
+  items: [
     {
-      "value": "gateway",
-      "text": "Sign in with NHS login",
-      "hint": {
-        "text": "You'll have a user ID if you've registered for the NHS App."
+      value: "gateway",
+      text: "Sign in with NHS login",
+      hint: {
+        text: "You'll have a user ID if you've registered for the NHS App."
       }
     },
     {
-      "value": "verify",
-      "text": "Sign in with GOV.UK Verify",
-      "hint": {
-        "text": "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+      value: "verify",
+      text: "Sign in with GOV.UK Verify",
+      hint: {
+        text: "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
       }
     }
   ]

--- a/app/views/design-system/components/hint-text/radios/index.njk
+++ b/app/views/design-system/components/hint-text/radios/index.njk
@@ -4,33 +4,33 @@
 
 {% call fieldset({
   legend: {
-    "text": "Do you know your NHS number?",
-    "classes": "nhsuk-fieldset__legend--l",
-    "isPageHeading": true
+    text: "Do you know your NHS number?",
+    classes: "nhsuk-fieldset__legend--l",
+    isPageHeading: true
   }
   }) %}
   {{ hint({
-    "text": "This is a 10 digit number, like 485 777 3456.",
-    "classes": "nhsuk-u-margin-bottom-2"
+    text: "This is a 10 digit number, like 485 777 3456.",
+    classes: "nhsuk-u-margin-bottom-2"
   }) }}
   {{ hint({
-    "text": "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
+    text: "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
   }) }}
   {{ radios({
-    "idPrefix": "example-hints",
-    "name": "example-hints",
-    "items": [
+    idPrefix: "example-hints",
+    name: "example-hints",
+    items: [
   {
-    "value": "yes",
-    "text": "Yes, I know my NHS number"
+    value: "yes",
+    text: "Yes, I know my NHS number"
   },
   {
-    "value": "no",
-    "text": "No, I do not know my NHS number"
+    value: "no",
+    text: "No, I do not know my NHS number"
   },
   {
-    "value": "not sure",
-    "text": "I'm not sure"
+    value: "not sure",
+    text: "I'm not sure"
   }
 ]
 }) }}

--- a/app/views/design-system/components/hint-text/textarea/index.njk
+++ b/app/views/design-system/components/hint-text/textarea/index.njk
@@ -1,12 +1,12 @@
 {% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
-  "name": "example",
-  "id": "example",
-  "label": {
-    "text": "Can you provide more detail?"
+  name: "example",
+  id: "example",
+  label: {
+    text: "Can you provide more detail?"
   },
-  "hint": {
-    "text": "Do not include personal or financial information, for example, your National Insurance number or credit card details."
+  hint: {
+    text: "Do not include personal or financial information, for example, your National Insurance number or credit card details."
   }
 }) }}

--- a/app/views/design-system/components/images/default/index.njk
+++ b/app/views/design-system/components/images/default/index.njk
@@ -1,7 +1,7 @@
 {% from 'images/macro.njk' import image %}
 
 {{ image({
-  "src": "https://assets.nhs.uk/prod/images/S_0318_Bullous_pemphigoid_lesions_.2e16d0ba.fill-320x213.jpg",
-  "alt": "Lots of sore red patches with small blisters spread across white skin on a woman's chest.",
-  "caption": "It can affect large areas of the body or limbs."
+  src: "https://assets.nhs.uk/prod/images/S_0318_Bullous_pemphigoid_lesions_.2e16d0ba.fill-320x213.jpg",
+  alt: "Lots of sore red patches with small blisters spread across white skin on a woman's chest.",
+  caption: "It can affect large areas of the body or limbs."
 }) }}

--- a/app/views/design-system/components/inset-text/default/index.njk
+++ b/app/views/design-system/components/inset-text/default/index.njk
@@ -1,5 +1,5 @@
 {% from 'inset-text/macro.njk' import insetText %}
 
 {{ insetText({
-  "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
+  HTML: "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
 }) }}

--- a/app/views/design-system/components/pagination/default/index.njk
+++ b/app/views/design-system/components/pagination/default/index.njk
@@ -1,8 +1,8 @@
 {% from 'pagination/macro.njk' import pagination %}
 
 {{ pagination({
-  "previousUrl": "#",
-  "previousPage": "Treatments",
-  "nextUrl": "#",
-  "nextPage": "Symptoms"
+  previousUrl: "#",
+  previousPage: "Treatments",
+  nextUrl: "#",
+  nextPage: "Symptoms"
 }) }}

--- a/app/views/design-system/components/radios/conditional/index.njk
+++ b/app/views/design-system/components/radios/conditional/index.njk
@@ -35,38 +35,38 @@
 {% endset -%}
 
 {{ radios({
-  "idPrefix": "contact",
-  "name": "contact",
-  "fieldset": {
-    "legend": {
-      "text": "How would you prefer to be contacted?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": "true"
+  idPrefix: "contact",
+  name: "contact",
+  fieldset: {
+    legend: {
+      text: "How would you prefer to be contacted?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: "true"
     }
   },
-  "hint": {
-    "text": "Select one option"
+  hint: {
+    text: "Select one option"
   },
-  "items": [
+  items: [
     {
-      "value": "email",
-      "text": "Email",
-      "conditional": {
-        "html": emailHtml
+      value: "email",
+      text: "Email",
+      conditional: {
+        html: emailHtml
       }
     },
     {
-      "value": "phone",
-      "text": "Phone",
-      "conditional": {
-        "html": phoneHtml
+      value: "phone",
+      text: "Phone",
+      conditional: {
+        html: phoneHtml
       }
     },
     {
-      "value": "text",
-      "text": "Text message",
-      "conditional": {
-        "html": mobileHtml
+      value: "text",
+      text: "Text message",
+      conditional: {
+        html: mobileHtml
       }
     }
   ]

--- a/app/views/design-system/components/radios/default/index.njk
+++ b/app/views/design-system/components/radios/default/index.njk
@@ -1,23 +1,23 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example",
-  "name": "example",
-  "fieldset": {
-    "legend": {
-      "text": "Are you 18 or over?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  idPrefix: "example",
+  name: "example",
+  fieldset: {
+    legend: {
+      text: "Are you 18 or over?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "items": [
+  items: [
     {
-      "value": "yes",
-      "text": "Yes"
+      value: "yes",
+      text: "Yes"
     },
     {
-      "value": "no",
-      "text": "No"
+      value: "no",
+      text: "No"
     }
   ]
 }) }}

--- a/app/views/design-system/components/radios/error-message/index.njk
+++ b/app/views/design-system/components/radios/error-message/index.njk
@@ -1,29 +1,29 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example-error",
-  "name": "example-error",
-  "errorMessage": {
-    "text": "Select yes if you have changed your name"
+  idPrefix: "example-error",
+  name: "example-error",
+  errorMessage: {
+    text: "Select yes if you have changed your name"
   },
-  "fieldset": {
-    "legend": {
-      "text": "Have you changed your name?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  fieldset: {
+    legend: {
+      text: "Have you changed your name?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "hint": {
-    "text": "This includes changing your last name or spelling your name differently."
+  hint: {
+    text: "This includes changing your last name or spelling your name differently."
   },
-  "items": [
+  items: [
     {
-      "value": "yes",
-      "text": "Yes"
+      value: "yes",
+      text: "Yes"
     },
     {
-      "value": "no",
-      "text": "No"
+      value: "no",
+      text: "No"
     }
   ]
 }) }}

--- a/app/views/design-system/components/radios/inline/index.njk
+++ b/app/views/design-system/components/radios/inline/index.njk
@@ -1,24 +1,24 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example-inline",
-  "name": "example-inline",
-  "classes": "nhsuk-radios--inline",
-  "fieldset": {
-    "legend": {
-      "text": "Are you 18 or over?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  idPrefix: "example-inline",
+  name: "example-inline",
+  classes: "nhsuk-radios--inline",
+  fieldset: {
+    legend: {
+      text: "Are you 18 or over?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "items": [
+  items: [
     {
-      "value": "yes",
-      "text": "Yes"
+      value: "yes",
+      text: "Yes"
     },
     {
-      "value": "no",
-      "text": "No"
+      value: "no",
+      text: "No"
     }
   ]
 }) }}

--- a/app/views/design-system/components/radios/items-with-a-text-divider/index.njk
+++ b/app/views/design-system/components/radios/items-with-a-text-divider/index.njk
@@ -1,32 +1,30 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example-divider",
-  "name": "example-divider",
-  "fieldset": {
-    "legend": {
-      "text": "How do you want to sign in?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  idPrefix: "example-divider",
+  name: "example-divider",
+  fieldset: {
+    legend: {
+      text: "How do you want to sign in?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "items": [
+  items: [
     {
-      "value": "nhsuk-login",
-      "text": "Use NHS login"
+      value: "nhsuk-login",
+      text: "Use NHS login"
     },
         {
-      "value": "government-verify",
-      "text": "Use GOV.UK Verify"
+      value: "government-verify",
+      text: "Use GOV.UK Verify"
     },
     {
-      "divider": "or"
+      divider: "or"
     },
     {
-      "value": "create-account",
-      "text": "Create an account"
+      value: "create-account",
+      text: "Create an account"
     }
   ]
 }) }}
-
-

--- a/app/views/design-system/components/radios/with-hints-options/index.njk
+++ b/app/views/design-system/components/radios/with-hints-options/index.njk
@@ -1,28 +1,28 @@
 {% from 'radios/macro.njk' import radios %}
 
 {{ radios({
-  "idPrefix": "example-hints",
-  "name": "example-hints",
-  "fieldset": {
-    "legend": {
-      "text": "How do you want to sign in?",
-      "classes": "nhsuk-fieldset__legend--l",
-      "isPageHeading": true
+  idPrefix: "example-hints",
+  name: "example-hints",
+  fieldset: {
+    legend: {
+      text: "How do you want to sign in?",
+      classes: "nhsuk-fieldset__legend--l",
+      isPageHeading: true
     }
   },
-  "items": [
+  items: [
     {
-      "value": "gateway",
-      "text": "Sign in with NHS login",
-      "hint": {
-        "text": "You'll have a user ID if you've registered for the NHS App."
+      value: "gateway",
+      text: "Sign in with NHS login",
+      hint: {
+        text: "You'll have a user ID if you've registered for the NHS App."
       }
     },
     {
-      "value": "verify",
-      "text": "Sign in with GOV.UK Verify",
-      "hint": {
-        "text": "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+      value: "verify",
+      text: "Sign in with GOV.UK Verify",
+      hint: {
+        text: "You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
       }
     }
   ]

--- a/app/views/design-system/components/radios/with-hints/index.njk
+++ b/app/views/design-system/components/radios/with-hints/index.njk
@@ -4,33 +4,33 @@
 
 {% call fieldset({
   legend: {
-    "text": "Do you know your NHS number?",
-    "classes": "nhsuk-fieldset__legend--l",
-    "isPageHeading": true
+    text: "Do you know your NHS number?",
+    classes: "nhsuk-fieldset__legend--l",
+    isPageHeading: true
   }
   }) %}
   {{ hint({
-    "text": "This is a 10 digit number, like 485 777 3456.",
-    "classes": "nhsuk-u-margin-bottom-2"
+    text: "This is a 10 digit number, like 485 777 3456.",
+    classes: "nhsuk-u-margin-bottom-2"
   }) }}
   {{ hint({
-    "text": "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
+    text: "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
   }) }}
   {{ radios({
-    "idPrefix": "example-hints",
-    "name": "example-hints",
-    "items": [
+    idPrefix: "example-hints",
+    name: "example-hints",
+    items: [
   {
-    "value": "yes",
-    "text": "Yes, I know my NHS number"
+    value: "yes",
+    text: "Yes, I know my NHS number"
   },
   {
-    "value": "no",
-    "text": "No, I do not know my NHS number"
+    value: "no",
+    text: "No, I do not know my NHS number"
   },
   {
-    "value": "not sure",
-    "text": "I'm not sure"
+    value: "not sure",
+    text: "I'm not sure"
   }
 ]
 }) }}

--- a/app/views/design-system/components/select/default/index.njk
+++ b/app/views/design-system/components/select/default/index.njk
@@ -1,25 +1,25 @@
 {% from 'select/macro.njk' import select %}
 
 {{ select({
-  "id": "select-1",
-  "name": "select-1",
-  "label": {
-    "text": "Label text goes here"
+  id: "select-1",
+  name: "select-1",
+  label: {
+    text: "Label text goes here"
   },
-  "items": [
+  items: [
     {
-      "value": 1,
-      "text": "NHS.UK frontend option 1"
+      value: 1,
+      text: "NHS.UK frontend option 1"
     },
     {
-      "value": 2,
-      "text": "NHS.UK frontend option 2",
+      value: 2,
+      text: "NHS.UK frontend option 2",
       "selected": true
     },
     {
-      "value": 3,
-      "text": "NHS.UK frontend option 3",
-      "disabled": true
+      value: 3,
+      text: "NHS.UK frontend option 3",
+      disabled: true
     }
   ]
 }) }}

--- a/app/views/design-system/components/skip-link/default/index.njk
+++ b/app/views/design-system/components/skip-link/default/index.njk
@@ -3,6 +3,6 @@
 {% from 'skip-link/macro.njk' import skipLink %}
 
 {{ skipLink({
-  "href": "#maincontent",
-  "text": "Skip to main content"
+  href: "#maincontent",
+  text: "Skip to main content"
 }) }}

--- a/app/views/design-system/components/text-input/default/index.njk
+++ b/app/views/design-system/components/text-input/default/index.njk
@@ -1,9 +1,9 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "What is your name?"
+  label: {
+    text: "What is your name?"
   },
-  "id": "example",
-  "name": "example"
+  id: "example",
+  name: "example"
 }) }}

--- a/app/views/design-system/components/text-input/error/index.njk
+++ b/app/views/design-system/components/text-input/error/index.njk
@@ -1,12 +1,12 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "Full name"
+  label: {
+    text: "Full name"
   },
-  "id": "example",
-  "name": "example",
-  "errorMessage": {
-    "text": "Enter your full name"
+  id: "example",
+  name: "example",
+  errorMessage: {
+    text: "Enter your full name"
   }
 }) }}

--- a/app/views/design-system/components/text-input/fixed-width/index.njk
+++ b/app/views/design-system/components/text-input/fixed-width/index.njk
@@ -1,50 +1,50 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-  "text": "20 character width"
+  label: {
+  text: "20 character width"
   },
-  "id": "input-width-20",
-  "name": "test-width-20",
-  "classes": "nhsuk-input--width-20"
+  id: "input-width-20",
+  name: "test-width-20",
+  classes: "nhsuk-input--width-20"
 }) }}
 {{ input({
-  "label": {
-  "text": "10 character width"
+  label: {
+  text: "10 character width"
   },
-  "id": "input-width-10",
-  "name": "test-width-10",
-  "classes": "nhsuk-input--width-10"
+  id: "input-width-10",
+  name: "test-width-10",
+  classes: "nhsuk-input--width-10"
 }) }}
 {{ input({
-  "label": {
-  "text": "5 character width"
+  label: {
+  text: "5 character width"
   },
-  "id": "input-width-5",
-  "name": "test-width-5",
-  "classes": "nhsuk-input--width-5"
+  id: "input-width-5",
+  name: "test-width-5",
+  classes: "nhsuk-input--width-5"
 }) }}
 {{ input({
-  "label": {
-  "text": "4 character width"
+  label: {
+  text: "4 character width"
   },
-  "id": "input-width-4",
-  "name": "test-width-4",
-  "classes": "nhsuk-input--width-4"
+  id: "input-width-4",
+  name: "test-width-4",
+  classes: "nhsuk-input--width-4"
 }) }}
 {{ input({
-  "label": {
-  "text": "3 character width"
+  label: {
+  text: "3 character width"
   },
-  "id": "input-width-3",
-  "name": "test-width-3",
-  "classes": "nhsuk-input--width-3"
+  id: "input-width-3",
+  name: "test-width-3",
+  classes: "nhsuk-input--width-3"
 }) }}
 {{ input({
-  "label": {
-  "text": "2 character width"
+  label: {
+  text: "2 character width"
   },
-  "id": "input-width-2",
-  "name": "test-width-2",
-  "classes": "nhsuk-input--width-2"
+  id: "input-width-2",
+  name: "test-width-2",
+  classes: "nhsuk-input--width-2"
 }) }}

--- a/app/views/design-system/components/text-input/heading/index.njk
+++ b/app/views/design-system/components/text-input/heading/index.njk
@@ -1,11 +1,11 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "What is your name?",
-    "classes": "nhsuk-label--l",
-    "isPageHeading": true
+  label: {
+    text: "What is your name?",
+    classes: "nhsuk-label--l",
+    isPageHeading: true
   },
-  "id": "example-heading",
-  "name": "example-heading"
+  id: "example-heading",
+  name: "example-heading"
 }) }}

--- a/app/views/design-system/components/text-input/hint-text/index.njk
+++ b/app/views/design-system/components/text-input/hint-text/index.njk
@@ -1,11 +1,11 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "What is your NHS number?"
+  label: {
+    text: "What is your NHS number?"
   },
-    "hint": {
-    "text": "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you. For example, 485 777 3456."
+    hint: {
+    text: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you. For example, 485 777 3456."
   },
   id: "example-with-hint-text",
   name: "example-with-hint-text",

--- a/app/views/design-system/components/text-input/number/index.njk
+++ b/app/views/design-system/components/text-input/number/index.njk
@@ -1,8 +1,8 @@
 {% from 'input/macro.njk' import input %}
 
 {{ input({
-  "label": {
-    "text": "What is your NHS number?"
+  label: {
+    text: "What is your NHS number?"
   },
   id: "example-with-hint-text",
   name: "example-with-hint-text",

--- a/app/views/design-system/components/textarea/default/index.njk
+++ b/app/views/design-system/components/textarea/default/index.njk
@@ -1,12 +1,12 @@
 {% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
-  "name": "example",
-  "id": "example",
-  "label": {
-    "text": "Can you provide more detail?"
+  name: "example",
+  id: "example",
+  label: {
+    text: "Can you provide more detail?"
   },
-  "hint": {
-    "text": "Do not include personal or financial information, for example, your National Insurance number or credit card details."
+  hint: {
+    text: "Do not include personal or financial information, for example, your National Insurance number or credit card details."
   }
 }) }}

--- a/app/views/design-system/components/textarea/error/index.njk
+++ b/app/views/design-system/components/textarea/error/index.njk
@@ -1,12 +1,12 @@
 {% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
-  "name": "example-error",
-  "id": "example-error",
-  "label": {
-    "text": "Why can't you provide a National Insurance number?"
+  name: "example-error",
+  id: "example-error",
+  label: {
+    text: "Why can't you provide a National Insurance number?"
   },
-  "errorMessage": {
-    "text": "You must provide an explanation."
+  errorMessage: {
+    text: "You must provide an explanation."
   }
 }) }}

--- a/app/views/design-system/components/textarea/longer/index.njk
+++ b/app/views/design-system/components/textarea/longer/index.njk
@@ -1,13 +1,13 @@
 {% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
-  "name": "example-longer",
-  "id": "example-longer",
+  name: "example-longer",
+  id: "example-longer",
   "rows": "10",
-  "label": {
-      "text": "Can you provide more detail?"
+  label: {
+      text: "Can you provide more detail?"
   },
-  "hint": {
-      "text": "Do not include personal or financial information, for example, your National Insurance number or credit card details."
+  hint: {
+      text: "Do not include personal or financial information, for example, your National Insurance number or credit card details."
   }
 }) }}

--- a/app/views/design-system/components/warning-callout/custom-heading/index.njk
+++ b/app/views/design-system/components/warning-callout/custom-heading/index.njk
@@ -1,6 +1,6 @@
 {% from 'warning-callout/macro.njk' import warningCallout %}
 
 {{ warningCallout({
-  "heading": "School, nursery or work",
-  "HTML": "<p>Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.</p>"
+  heading: "School, nursery or work",
+  HTML: "<p>Stay away from school, nursery or work until all the spots have crusted over. This is usually 5 days after the spots first appeared.</p>"
 }) }}

--- a/app/views/design-system/components/warning-callout/default/index.njk
+++ b/app/views/design-system/components/warning-callout/default/index.njk
@@ -1,6 +1,6 @@
 {% from 'warning-callout/macro.njk' import warningCallout %}
 
 {{ warningCallout({
-  "heading": "Important",
-  "HTML": "<p>For safety, tell your doctor or pharmacist if you're taking any other medicines, including herbal medicines, vitamins or supplements.</p>"
+  heading: "Important",
+  HTML: "<p>For safety, tell your doctor or pharmacist if you're taking any other medicines, including herbal medicines, vitamins or supplements.</p>"
 }) }}

--- a/app/views/design-system/patterns/a-to-z-page/panel/index.njk
+++ b/app/views/design-system/patterns/a-to-z-page/panel/index.njk
@@ -1,42 +1,42 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-          "feature": "true",
-          "heading": "A",
-          "headingClasses": "nhsuk-u-font-size-24",
-          "descriptionHtml": "<ul class='nhsuk-list nhsuk-list--border'>
+          feature: "true",
+          heading: "A",
+          headingClasses: "nhsuk-u-font-size-24",
+          descriptionHtml: "<ul class='nhsuk-list nhsuk-list--border'>
           <li><a href='/conditions/abdominal-aortic-aneurysm/'>AAA</a></li>
           <li><a href='/conditions/abdominal-aortic-aneurysm/'>Abdominal aortic aneurysm</a></li>
-          <li><a href='/conditions/abscess/'>Abscess</a></li> 
+          <li><a href='/conditions/abscess/'>Abscess</a></li>
         </ul>"
         }) }}
 
 {{ card({
-          "feature": "true",
-          "heading": "B",
-          "headingClasses": "nhsuk-u-font-size-24",
-          "descriptionHtml": "<ul class='nhsuk-list nhsuk-list--border'>
+          feature: "true",
+          heading: "B",
+          headingClasses: "nhsuk-u-font-size-24",
+          descriptionHtml: "<ul class='nhsuk-list nhsuk-list--border'>
           <li>There are currently no conditions listed</li>
         </ul>"
         }) }}
 
 {{ card({
-          "feature": "true",
-          "heading": "C",
-          "headingClasses": "nhsuk-u-font-size-24",
-          "descriptionHtml": "<ul class='nhsuk-list nhsuk-list--border'>
+          feature: "true",
+          heading: "C",
+          headingClasses: "nhsuk-u-font-size-24",
+          descriptionHtml: "<ul class='nhsuk-list nhsuk-list--border'>
           <li><a href='/conditions/chest-pain/'>Chest pain</a></li>
           <li><a href='/conditions/cold-sores/'>Cold sore</a></li>
         </ul>"
         }) }}
 
 {{ card({
-          "feature": "true",
-          "heading": "D",
-          "headingClasses": "nhsuk-u-font-size-24",
-          "descriptionHtml": "<ul class='nhsuk-list nhsuk-list--border'>
+          feature: "true",
+          heading: "D",
+          headingClasses: "nhsuk-u-font-size-24",
+          descriptionHtml: "<ul class='nhsuk-list nhsuk-list--border'>
           <li><a href='/conditions/dandruff/'>Dandruff</a></li>
           <li><a href='/conditions/dementia/'>Dementia</a></li>
-          <li><a href='/conditions/toothache/'>Dental pain</a></li> 
+          <li><a href='/conditions/toothache/'>Dental pain</a></li>
         </ul>"
         }) }}

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/default/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/default/index.njk
@@ -23,7 +23,7 @@
       }) }}
 
       {{ button({
-        "text": "Continue"
+        text: "Continue"
       }) }}
 
     </div>

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/error/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/error/index.njk
@@ -9,11 +9,11 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       {{ errorSummary({
-        "titleText": "There is a problem",
-        "errorList": [
+        titleText: "There is a problem",
+        errorList: [
           {
-            "text": "Your NHS number is too long",
-            "href": "#nhs-number"
+            text: "Your NHS number is too long",
+            href: "#nhs-number"
           }
         ]
       }) }}
@@ -28,7 +28,7 @@
           html: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you. For example, <span class=\"nhsuk-u-nowrap\">485 777 3456</span>."
         },
         errorMessage: {
-          "text": "Your NHS number is too long"
+          text: "Your NHS number is too long"
         },
         id: "nhs-number",
         name: "nhs-number",
@@ -37,10 +37,9 @@
       }) }}
 
       {{ button({
-        "text": "Continue"
+        text: "Continue"
       }) }}
 
     </div>
   </div>
 {% endblock %}
-

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter-single/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter-single/index.njk
@@ -23,7 +23,7 @@
       }) }}
 
       {{ button({
-        "text": "Continue"
+        text: "Continue"
       }) }}
 
    </div>

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter-third/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter-third/index.njk
@@ -11,37 +11,37 @@
 
     {% call fieldset({
       legend: {
-        "text": "Do you know your NHS number?",
-        "classes": "nhsuk-fieldset__legend--l"
+        text: "Do you know your NHS number?",
+        classes: "nhsuk-fieldset__legend--l"
       }
       }) %}
       {{ hint({
-        "html": "Your NHS number is a 10 digit number, like <span class=\"nhsuk-u-nowrap\">485 777 3456</span>.",
-        "classes": "nhsuk-u-margin-bottom-2"
+        html: "Your NHS number is a 10 digit number, like <span class=\"nhsuk-u-nowrap\">485 777 3456</span>.",
+        classes: "nhsuk-u-margin-bottom-2"
       }) }}
       {{ hint({
-        "text": "You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service."
+        text: "You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service."
       }) }}
       {{ radios({
-        "idPrefix": "nhs-number",
-        "name": "nhs-number",
-        "items": [
+        idPrefix: "nhs-number",
+        name: "nhs-number",
+        items: [
         {
-          "value": "yes",
-          "text": "Yes, I know my NHS number"
+          value: "yes",
+          text: "Yes, I know my NHS number"
         },
         {
-          "value": "no",
-          "text": "No, I do not know my NHS number"
+          value: "no",
+          text: "No, I do not know my NHS number"
         },
         {
-          "value": "unsure",
-          "text": "I'm not sure"
+          value: "unsure",
+          text: "I'm not sure"
         }
       ]
       }) }}
       {{ button({
-        "text": "Continue"
+        text: "Continue"
       }) }}
     {% endcall %}
 

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter/index.njk
@@ -11,33 +11,33 @@
 
       {% call fieldset({
         legend: {
-          "text": "Do you know your NHS number?",
-          "classes": "nhsuk-fieldset__legend--l"
+          text: "Do you know your NHS number?",
+          classes: "nhsuk-fieldset__legend--l"
         }
         }) %}
         {{ hint({
-          "html": "Your NHS number is a 10 digit number, like <span class=\"nhsuk-u-nowrap\">485 777 3456</span>.",
-          "classes": "nhsuk-u-margin-bottom-2"
+          html: "Your NHS number is a 10 digit number, like <span class=\"nhsuk-u-nowrap\">485 777 3456</span>.",
+          classes: "nhsuk-u-margin-bottom-2"
         }) }}
         {{ hint({
-          "text": "You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service."
+          text: "You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service."
         }) }}
         {{ radios({
-          "idPrefix": "nhs-number",
-          "name": "nhs-number",
-          "items": [
+          idPrefix: "nhs-number",
+          name: "nhs-number",
+          items: [
           {
-            "value": "yes",
-            "text": "Yes, I know my NHS number"
+            value: "yes",
+            text: "Yes, I know my NHS number"
           },
           {
-            "value": "no",
-            "text": "No, I do not know my NHS number"
+            value: "no",
+            text: "No, I do not know my NHS number"
           }
         ]
         }) }}
         {{ button({
-          "text": "Continue"
+          text: "Continue"
         }) }}
       {% endcall %}
 

--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/emergency/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/emergency/index.njk
@@ -1,9 +1,9 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "type": "emergency",
-  "heading": "Call 999 or go to A&E now if:",
-  "descriptionHtml": "
+  type: "emergency",
+  heading: "Call 999 or go to A&E now if:",
+  descriptionHtml: "
   <ul>
     <li>you or someone you know needs immediate help</li>
     <li>you have seriously harmed yourself – for example, by taking a drug overdose</li>

--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/non-urgent/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/non-urgent/index.njk
@@ -1,9 +1,9 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "type": "non-urgent",
-  "heading": "Speak to a GP if:",
-  "descriptionHtml": "
+  type: "non-urgent",
+  heading: "Speak to a GP if:",
+  descriptionHtml: "
   <ul>
     <li>you're not sure it's chickenpox</li>
     <li>the skin around the blisters is red, hot or painful (signs of infection)</li>

--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/two-colons/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/two-colons/index.njk
@@ -1,9 +1,9 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "type": "emergency",
-  "heading": "Call 999 if:",
-  "descriptionHtml": "
+  type: "emergency",
+  heading: "Call 999 if:",
+  descriptionHtml: "
   <p>You have sudden chest pain that:</p>
   <ul>
     <li>spreads to your arms, back, neck or jaw</li>

--- a/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/urgent/index.njk
+++ b/app/views/design-system/patterns/help-users-decide-when-and-where-to-get-care/urgent/index.njk
@@ -1,9 +1,9 @@
 {% from 'card/macro.njk' import card %}
 
 {{ card({
-  "type": "urgent",
-  "heading": "Ask for an urgent GP appointment if:",
-  "descriptionHtml": "
+  type: "urgent",
+  heading: "Ask for an urgent GP appointment if:",
+  descriptionHtml: "
   <ul>
     <li>you're an adult and have chickenpox</li>
     <li>you're pregnant and haven't had chickenpox before and you've been near someone with it </li>

--- a/app/views/design-system/patterns/mini-hub/example-symptoms/index.njk
+++ b/app/views/design-system/patterns/mini-hub/example-symptoms/index.njk
@@ -43,19 +43,19 @@
       <p>You can get it in one eye or both.</p>
 
       {{ image({
-        "src": "https://assets.nhs.uk/nhsuk-cms/images/NHSC_0218_AMD_Version2.width-320.jpg",
+        src: "https://assets.nhs.uk/nhsuk-cms/images/NHSC_0218_AMD_Version2.width-320.jpg",
         "sizes": "(min-width: 1020px) 320px, (min-width: 768px) 50vw, 100vw",
         "srcset": "https://assets.nhs.uk/nhsuk-cms/images/NHSC_0218_AMD_Version2.width-640.jpg 640w, https://assets.nhs.uk/nhsuk-cms/images/NHSC_0218_AMD_Version2.width-640.jpg 640w",
-        "alt": "Blurred book showing what vision is like for a person with early AMD",
-        "caption": "The first symptom is often a blurred or distorted area in your vision"
+        alt: "Blurred book showing what vision is like for a person with early AMD",
+        caption: "The first symptom is often a blurred or distorted area in your vision"
       }) }}
 
       {{ image({
-        "src": "https://assets.nhs.uk/nhsuk-cms/images/S_0218_AMD_C0037144.width-320.jpg",
+        src: "https://assets.nhs.uk/nhsuk-cms/images/S_0218_AMD_C0037144.width-320.jpg",
         "sizes": "(min-width: 1020px) 320px, (min-width: 768px) 50vw, 100vw",
         "srcset": "https://assets.nhs.uk/nhsuk-cms/images/S_0218_AMD_C0037144.width-640.jpg 640w, https://assets.nhs.uk/nhsuk-cms/images/S_0218_AMD_C0037144.width-767.jpg 767w",
-        "alt": "A dark patch in the vision of someone with AMD",
-        "caption": "If it gets worse, you might struggle to see anything in the middle of your vision"
+        alt: "A dark patch in the vision of someone with AMD",
+        caption: "If it gets worse, you might struggle to see anything in the middle of your vision"
       }) }}
 
       <p>AMD can make things like reading, watching TV, driving or recognising faces difficult.</p>
@@ -70,22 +70,22 @@
       <p>AMD isn't painful and doesn't affect the appearance of your eyes.</p>
 
       {{ insetText({
-        "HTML": "<p>Sometimes AMD may be found during a routine eye test before you have symptoms.</p>"
+        HTML: "<p>Sometimes AMD may be found during a routine eye test before you have symptoms.</p>"
       }) }}
 
       {{ careCard({
-        "type": "non-urgent",
-        "heading": "See an optician if you're worried about your vision",
-        "HTML": "
+        type: "non-urgent",
+        heading: "See an optician if you're worried about your vision",
+        HTML: "
         <p>If you have a problem with your eyes, early diagnosis and treatment may help stop your vision getting worse.</p>
         <p><a href=\"https://www.nhs.uk/service-search/Opticians/LocationSearch/9\">Find an opticians</a></p>
         "
       }) }}
 
       {{ careCard({
-        "type": "urgent",
-        "heading": "Ask for an urgent GP appointment if:",
-        "HTML": "
+        type: "urgent",
+        heading: "Ask for an urgent GP appointment if:",
+        HTML: "
         <ul>
           <li>your vision gets suddenly worse </li>
           <li>you have a dark \"curtain\" or shadow moving across your vision</li>
@@ -103,10 +103,10 @@
       </p>
 
       {{ pagination({
-        "previousUrl": "/design-example/patterns/mini-hub/example?fullpage=true",
-        "previousPage": "Age-related macular degeneration (AMD)",
-        "nextUrl": "#",
-        "nextPage": "Getting diagnosed"
+        previousUrl: "/design-example/patterns/mini-hub/example?fullpage=true",
+        previousPage: "Age-related macular degeneration (AMD)",
+        nextUrl: "#",
+        nextPage: "Getting diagnosed"
       }) }}
 
     </div>

--- a/app/views/design-system/patterns/mini-hub/example/index.njk
+++ b/app/views/design-system/patterns/mini-hub/example/index.njk
@@ -74,8 +74,8 @@
       </p>
 
       {{ pagination({
-        "nextUrl": "/design-example/patterns/mini-hub/example-symptoms?fullpage=true",
-        "nextPage": "Symptoms"
+        nextUrl: "/design-example/patterns/mini-hub/example-symptoms?fullpage=true",
+        nextPage: "Symptoms"
       }) }}
 
     </div>

--- a/app/views/design-system/patterns/reassure-users-that-a-page-is-up-to-date/page/index.njk
+++ b/app/views/design-system/patterns/reassure-users-that-a-page-is-up-to-date/page/index.njk
@@ -21,28 +21,28 @@
 
 {% block header %}
   {{ header({
-      "showNav": "true",
-      "showSearch": "true",
-      "primaryLinks": [
+      showNav: "true",
+      showSearch: "true",
+      primaryLinks: [
         {
-          "url"  : "#",
-          "label" : "Health A-Z"
+          url: "#",
+          label: "Health A-Z"
         },
         {
-          'url' : '#',
-          'label' : 'Live Well'
+          url: '#',
+          label: 'Live Well'
         },
         {
-          'url'  : '#',
-          'label' : 'Care and support'
+          url: '#',
+          label: 'Care and support'
         },
         {
-          'url'  : '#',
-          'label' : 'Pregnancy'
+          url: '#',
+          label: 'Pregnancy'
         },
         {
-          'url' : '#',
-          'label' : 'NHS services'
+          url: '#',
+          label: 'NHS services'
         }
       ]
     })
@@ -69,38 +69,38 @@
 
 {% block footer %}
   {{ footer({
-    "links": [
+    links: [
       {
-        "URL": "#",
-        "label": "NHS sites"
+        URL: "#",
+        label: "NHS sites"
       },
       {
-        "URL": "#",
-        "label": "About us"
+        URL: "#",
+        label: "About us"
       },
       {
-        "URL": "#",
-        "label": "Contact us"
+        URL: "#",
+        label: "Contact us"
       },
       {
-        "URL": "#",
-        "label": "Profile editor login"
+        URL: "#",
+        label: "Profile editor login"
       },
       {
-        "URL": "#",
-        "label": "Site map"
+        URL: "#",
+        label: "Site map"
       },
       {
-        "URL": "#",
-        "label": "Accessibility statement"
+        URL: "#",
+        label: "Accessibility statement"
       },
       {
-        "URL": "#",
-        "label": "Our policies"
+        URL: "#",
+        label: "Our policies"
       },
       {
-        "URL": "#",
-        "label": "Cookies"
+        URL: "#",
+        label: "Cookies"
       }
     ]
   })}}

--- a/app/views/design-system/styles/page-template/content/index.njk
+++ b/app/views/design-system/styles/page-template/content/index.njk
@@ -25,28 +25,28 @@
 
 {% block header %}
   {{ header({
-      "showNav": "true",
-      "showSearch": "true",
-      "primaryLinks": [
+      showNav: "true",
+      showSearch: "true",
+      primaryLinks: [
         {
-          "url"  : "#",
-          "label" : "Health A-Z"
+          url: "#",
+          label: "Health A-Z"
         },
         {
-          'url' : '#',
-          'label' : 'Live Well'
+          url: '#',
+          label: 'Live Well'
         },
         {
-          'url'  : '#',
-          'label' : 'Care and support'
+          url: '#',
+          label: 'Care and support'
         },
         {
-          'url'  : '#',
-          'label' : 'Pregnancy'
+          url: '#',
+          label: 'Pregnancy'
         },
         {
-          'url' : '#',
-          'label' : 'NHS services'
+          url: '#',
+          label: 'NHS services'
         }
       ]
     })
@@ -65,38 +65,38 @@
 
 {% block footer %}
   {{ footer({
-    "links": [
+    links: [
       {
-        "URL": "#",
-        "label": "NHS sites"
+        URL: "#",
+        label: "NHS sites"
       },
       {
-        "URL": "#",
-        "label": "About us"
+        URL: "#",
+        label: "About us"
       },
       {
-        "URL": "#",
-        "label": "Contact us"
+        URL: "#",
+        label: "Contact us"
       },
       {
-        "URL": "#",
-        "label": "Profile editor login"
+        URL: "#",
+        label: "Profile editor login"
       },
       {
-        "URL": "#",
-        "label": "Site map"
+        URL: "#",
+        label: "Site map"
       },
       {
-        "URL": "#",
-        "label": "Accessibility statement"
+        URL: "#",
+        label: "Accessibility statement"
       },
       {
-        "URL": "#",
-        "label": "Our policies"
+        URL: "#",
+        label: "Our policies"
       },
       {
-        "URL": "#",
-        "label": "Cookies"
+        URL: "#",
+        label: "Cookies"
       }
     ]
   })}}

--- a/app/views/design-system/styles/page-template/transactional/index.njk
+++ b/app/views/design-system/styles/page-template/transactional/index.njk
@@ -10,20 +10,20 @@
 
 {% block outerContent %}
   {{ backLink({
-    "href": "#",
-    "text": "Back",
-    "classes": "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
+    href: "#",
+    text: "Back",
+    classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
   }) }}
 {% endblock %}
 
 {% block header %}
   {{ header({
-    "transactionalService": {
-        "name": "Service name here",
-        "href": "#"
+    transactionalService: {
+        name: "Service name here",
+        href: "#"
       },
-      "showNav": "false",
-      "showSearch": "false"
+      showNav: "false",
+      showSearch: "false"
     })
   }}
 {% endblock %}
@@ -40,26 +40,26 @@
 
 {% block footer %}
   {{ footer({
-    "links": [
+    links: [
       {
-        "URL": "#",
-        "label": "Accessibility statement"
+        URL: "#",
+        label: "Accessibility statement"
       },
       {
-        "URL": "#",
-        "label": "Contact us"
+        URL: "#",
+        label: "Contact us"
       },
       {
-        "URL": "#",
-        "label": "Cookies"
+        URL: "#",
+        label: "Cookies"
       },
       {
-        "URL": "#",
-        "label": "Privacy policy"
+        URL: "#",
+        label: "Privacy policy"
       },
       {
-        "URL": "#",
-        "label": "Terms and conditions"
+        URL: "#",
+        label: "Terms and conditions"
       }
     ]
   })}}

--- a/app/views/includes/_header.njk
+++ b/app/views/includes/_header.njk
@@ -2,73 +2,73 @@
 
 {%- if disableSearch %}
   {{ header({
-    "homeHref": "/",
-    "ariaLabel": "NHS digital service manual homepage",
-    "classes": "nhsuk-header--white",
-    "service": {
-      "name": "Digital service manual",
-      "longName": "true"
+    homeHref: "/",
+    ariaLabel: "NHS digital service manual homepage",
+    classes: "nhsuk-header--white",
+    service: {
+      name: "Digital service manual",
+      longName: "true"
     },
-    "showNav": "true",
-    "showSearch": "false",
-    "searchAction": "/search/",
-    "searchInputName": "search-field",
-    "primaryLinks": [
+    showNav: "true",
+    showSearch: "false",
+    searchAction: "/search/",
+    searchInputName: "search-field",
+    primaryLinks: [
       {
-        "url"  : "/service-standard",
-        "label" : "NHS service standard"
+        url: "/service-standard",
+        label: "NHS service standard"
       },
       {
-        'url' : '/design-system',
-        'label' : 'Design system'
+        url: '/design-system',
+        label: 'Design system'
       },
       {
-        'url'  : '/content',
-        'label' : 'Content style guide'
+        url: '/content',
+        label: 'Content style guide'
       },
       {
-        'url'  : '/accessibility',
-        'label' : 'Accessibility'
+        url: '/accessibility',
+        label: 'Accessibility'
       },
       {
-        'url' : '/community-and-contribution',
-        'label' : 'Community and contribution'
+        url: '/community-and-contribution',
+        label: 'Community and contribution'
       }
     ]
     })
   }}
 {% else %}
   {{ header({
-    "homeHref": "/",
-    "ariaLabel": "NHS digital service manual homepage",
-    "service": {
-      "name": "Digital service manual",
-      "longName": "true"
+    homeHref: "/",
+    ariaLabel: "NHS digital service manual homepage",
+    service: {
+      name: "Digital service manual",
+      longName: "true"
     },
-    "showNav": "true",
-    "showSearch": "true",
-    "searchAction": "/search/",
-    "searchInputName": "search-field",
-    "primaryLinks": [
+    showNav: "true",
+    showSearch: "true",
+    searchAction: "/search/",
+    searchInputName: "search-field",
+    primaryLinks: [
       {
-        "url"  : "/service-standard",
-        "label" : "NHS service standard"
+        url: "/service-standard",
+        label: "NHS service standard"
       },
       {
-        'url' : '/design-system',
-        'label' : 'Design system'
+        url: '/design-system',
+        label: 'Design system'
       },
       {
-        'url'  : '/content',
-        'label' : 'Content style guide'
+        url: '/content',
+        label: 'Content style guide'
       },
       {
-        'url'  : '/accessibility',
-        'label' : 'Accessibility'
+        url: '/accessibility',
+        label: 'Accessibility'
       },
       {
-        'url' : '/community-and-contribution',
-        'label' : 'Community and contribution'
+        url: '/community-and-contribution',
+        label: 'Community and contribution'
       }
     ]
     })

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -193,9 +193,9 @@
 
   {%- if subSection == "Styles" %}
     {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
+      href: "/design-system",
+      text: "Design system",
+      classes: "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
     }) }}
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
@@ -207,9 +207,9 @@
 
   {%- if subSection == "Components" %}
     {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
+      href: "/design-system",
+      text: "Design system",
+      classes: "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
     }) }}
     <h2 class="app-side-nav__heading">Form elements</h2>
     <ul class="nhsuk-list app-side-nav__list">
@@ -235,9 +235,9 @@
 
   {%- if subSection == "Patterns" %}
     {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
+      href: "/design-system",
+      text: "Design system",
+      classes: "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
     }) }}
     <h2 class="app-side-nav__heading">Tasks</h2>
     <ul class="nhsuk-list app-side-nav__list">
@@ -280,9 +280,9 @@
 
     {%- if subSection == "Inclusive content" %}
     {{ backLink({
-      "href": "/content",
-      "text": "Content style guide",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
+      href: "/content",
+      text: "Content style guide",
+      classes: "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
     }) }}
     <h2 class="app-side-nav__heading">Inclusive content <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
@@ -294,9 +294,9 @@
 
   {%- if subSection == "How to write good questions for forms" %}
     {{ backLink({
-      "href": "/content",
-      "text": "Content style guide",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
+      href: "/content",
+      text: "Content style guide",
+      classes: "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
     }) }}
     <h2 class="app-side-nav__heading">How to write good questions for forms <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
@@ -308,9 +308,9 @@
 
   {%- if subSection == "Health literacy" %}
     {{ backLink({
-      "href": "/content/health-literacy",
-      "text": "Health literacy",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
+      href: "/content/health-literacy",
+      text: "Health literacy",
+      classes: "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
     }) }}
     <h2 class="app-side-nav__heading">Health literacy <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">

--- a/app/views/includes/design-example-wrapper-full.njk
+++ b/app/views/includes/design-example-wrapper-full.njk
@@ -31,8 +31,8 @@
     {% from 'header/macro.njk' import header %}
 
     {{ header({
-        "showNav": "false",
-        "showSearch": "false"
+        showNav: "false",
+        showSearch: "false"
       })
     }}
 

--- a/app/views/standards-and-technology/service-standard-points/1-understand-users-and-their-needs-context-health-and-care.njk
+++ b/app/views/standards-and-technology/service-standard-points/1-understand-users-and-their-needs-context-health-and-care.njk
@@ -67,8 +67,8 @@
 {% block afterContact %}
 
 {{ pagination({
-    "nextUrl": "/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience",
-    "nextPage": "Points 2 and 3"
+    nextUrl: "/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience",
+    nextPage: "Points 2 and 3"
   }) }}
 
 {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
+++ b/app/views/standards-and-technology/service-standard-points/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing.njk
@@ -54,10 +54,10 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/9-respect-and-protect-users-confidentiality-and-privacy",
-    "previousPage": "Point 9",
-    "nextUrl": "/standards-and-technology/service-standard-points/11-choose-the-right-tools-and-technology",
-    "nextPage": "Point 11"
+    previousUrl: "/standards-and-technology/service-standard-points/9-respect-and-protect-users-confidentiality-and-privacy",
+    previousPage: "Point 9",
+    nextUrl: "/standards-and-technology/service-standard-points/11-choose-the-right-tools-and-technology",
+    nextPage: "Point 11"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/11-choose-the-right-tools-and-technology.njk
+++ b/app/views/standards-and-technology/service-standard-points/11-choose-the-right-tools-and-technology.njk
@@ -59,10 +59,10 @@
 {% block afterContact %}
 
   {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing",
-    "previousPage": "Point 10",
-    "nextUrl": "/standards-and-technology/service-standard-points/12-make-new-source-code-open",
-    "nextPage": "Point 12"
+    previousUrl: "/standards-and-technology/service-standard-points/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing",
+    previousPage: "Point 10",
+    nextUrl: "/standards-and-technology/service-standard-points/12-make-new-source-code-open",
+    nextPage: "Point 12"
   }) }}
 
 

--- a/app/views/standards-and-technology/service-standard-points/12-make-new-source-code-open.njk
+++ b/app/views/standards-and-technology/service-standard-points/12-make-new-source-code-open.njk
@@ -49,10 +49,10 @@
 {% block afterContact %}
 
     {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/11-choose-the-right-tools-and-technology",
-    "previousPage": "Point 11",
-    "nextUrl": "/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns",
-    "nextPage": "Point 13"
+    previousUrl: "/standards-and-technology/service-standard-points/11-choose-the-right-tools-and-technology",
+    previousPage: "Point 11",
+    nextUrl: "/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns",
+    nextPage: "Point 13"
   }) }}
 
 

--- a/app/views/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns.njk
+++ b/app/views/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns.njk
@@ -48,10 +48,10 @@
 {% block afterContact %}
 
   {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/12-make-new-source-code-open",
-    "previousPage": "Point 12",
-    "nextUrl": "/standards-and-technology/service-standard-points/14-operate-a-reliable-service",
-    "nextPage": "Point 14"
+    previousUrl: "/standards-and-technology/service-standard-points/12-make-new-source-code-open",
+    previousPage: "Point 12",
+    nextUrl: "/standards-and-technology/service-standard-points/14-operate-a-reliable-service",
+    nextPage: "Point 14"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/14-operate-a-reliable-service.njk
+++ b/app/views/standards-and-technology/service-standard-points/14-operate-a-reliable-service.njk
@@ -42,10 +42,10 @@
 {% block afterContact %}
 
   {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns",
-    "previousPage": "Point 13",
-    "nextUrl": "/standards-and-technology/service-standard-points/15-support-a-culture-of-care",
-    "nextPage": "Point 15"
+    previousUrl: "/standards-and-technology/service-standard-points/13-use-and-contribute-to-open-standards-common-components-and-patterns",
+    previousPage: "Point 13",
+    nextUrl: "/standards-and-technology/service-standard-points/15-support-a-culture-of-care",
+    nextPage: "Point 15"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/15-support-a-culture-of-care.njk
+++ b/app/views/standards-and-technology/service-standard-points/15-support-a-culture-of-care.njk
@@ -63,10 +63,10 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/14-operate-a-reliable-service",
-    "previousPage": "Point 14",
-    "nextUrl": "/standards-and-technology/service-standard-points/16-make-your-service-clinically-safe",
-    "nextPage": "Point 16"
+    previousUrl: "/standards-and-technology/service-standard-points/14-operate-a-reliable-service",
+    previousPage: "Point 14",
+    nextUrl: "/standards-and-technology/service-standard-points/16-make-your-service-clinically-safe",
+    nextPage: "Point 16"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/16-make-your-service-clinically-safe.njk
+++ b/app/views/standards-and-technology/service-standard-points/16-make-your-service-clinically-safe.njk
@@ -56,10 +56,10 @@
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/15-support-a-culture-of-care",
-    "previousPage": "Point 15",
-    "nextUrl": "/standards-and-technology/service-standard-points/17-make-your-service-interoperable",
-    "nextPage": "Point 17"
+    previousUrl: "/standards-and-technology/service-standard-points/15-support-a-culture-of-care",
+    previousPage: "Point 15",
+    nextUrl: "/standards-and-technology/service-standard-points/17-make-your-service-interoperable",
+    nextPage: "Point 17"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/17-make-your-service-interoperable.njk
+++ b/app/views/standards-and-technology/service-standard-points/17-make-your-service-interoperable.njk
@@ -63,8 +63,8 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/16-make-your-service-clinically-safe",
-    "previousPage": "Point 16"
+    previousUrl: "/standards-and-technology/service-standard-points/16-make-your-service-clinically-safe",
+    previousPage: "Point 16"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
+++ b/app/views/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
@@ -17,8 +17,8 @@
   <p class="nhsuk-lede-text app-lede-text">Collaborate across team, programme and organisational boundaries and create a service that meets users' needs across all channels.</p>
 
   {{ insetText({
-    "HTML": "<p>In the GOV.UK service standard, these are 2 separate points but our user research showed that it helped digital teams working in health to deal with them together.</p>",
-    "classes": "nhsuk-u-margin-top-0"
+    HTML: "<p>In the GOV.UK service standard, these are 2 separate points but our user research showed that it helped digital teams working in health to deal with them together.</p>",
+    classes: "nhsuk-u-margin-top-0"
   }) }}
 
   <h2>Why it's important</h2>
@@ -61,10 +61,10 @@
 {% block afterContact %}
 
 {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/1-understand-users-and-their-needs-context-health-and-care",
-    "previousPage": "Point 1",
-    "nextUrl": "/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use",
-    "nextPage": "Point 4"
+    previousUrl: "/standards-and-technology/service-standard-points/1-understand-users-and-their-needs-context-health-and-care",
+    previousPage: "Point 1",
+    nextUrl: "/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use",
+    nextPage: "Point 4"
   }) }}
 
 {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use.njk
+++ b/app/views/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use.njk
@@ -45,10 +45,10 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience",
-    "previousPage": "Points 2 and 3",
-    "nextUrl": "/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service",
-    "nextPage": "Point 5"
+    previousUrl: "/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience",
+    previousPage: "Points 2 and 3",
+    nextUrl: "/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service",
+    nextPage: "Point 5"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service.njk
@@ -71,10 +71,10 @@
 {% block afterContact %}
 
   {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use",
-    "previousPage": "Point 4",
-    "nextUrl": "/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives",
-    "nextPage": "Point 6"
+    previousUrl: "/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use",
+    previousPage: "Point 4",
+    nextUrl: "/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives",
+    nextPage: "Point 6"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
+++ b/app/views/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
@@ -51,10 +51,10 @@
 {% block afterContact %}
 
    {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service",
-    "previousPage": "Point 5",
-    "nextUrl": "/standards-and-technology/service-standard-points/7-use-agile-ways-of-working",
-    "nextPage": "Point 7"
+    previousUrl: "/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service",
+    previousPage: "Point 5",
+    nextUrl: "/standards-and-technology/service-standard-points/7-use-agile-ways-of-working",
+    nextPage: "Point 7"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/7-use-agile-ways-of-working.njk
+++ b/app/views/standards-and-technology/service-standard-points/7-use-agile-ways-of-working.njk
@@ -48,10 +48,10 @@
 {% block afterContact %}
 
   {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives",
-    "previousPage": "Point 6",
-    "nextUrl": "/standards-and-technology/service-standard-points/8-iterate-and-improve-frequently",
-    "nextPage": "Point 8"
+    previousUrl: "/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives",
+    previousPage: "Point 6",
+    nextUrl: "/standards-and-technology/service-standard-points/8-iterate-and-improve-frequently",
+    nextPage: "Point 8"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/8-iterate-and-improve-frequently.njk
+++ b/app/views/standards-and-technology/service-standard-points/8-iterate-and-improve-frequently.njk
@@ -46,10 +46,10 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/7-use-agile-ways-of-working",
-    "previousPage": "Point 7",
-    "nextUrl": "/standards-and-technology/service-standard-points/9-respect-and-protect-users-confidentiality-and-privacy",
-    "nextPage": "Point 9"
+    previousUrl: "/standards-and-technology/service-standard-points/7-use-agile-ways-of-working",
+    previousPage: "Point 7",
+    nextUrl: "/standards-and-technology/service-standard-points/9-respect-and-protect-users-confidentiality-and-privacy",
+    nextPage: "Point 9"
   }) }}
 
   {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/9-respect-and-protect-users-confidentiality-and-privacy.njk
+++ b/app/views/standards-and-technology/service-standard-points/9-respect-and-protect-users-confidentiality-and-privacy.njk
@@ -60,10 +60,10 @@
 {% block afterContact %}
 
  {{ pagination({
-    "previousUrl": "/standards-and-technology/service-standard-points/8-iterate-and-improve-frequently",
-    "previousPage": "Point 8",
-    "nextUrl": "/standards-and-technology/service-standard-points/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing",
-    "nextPage": "Point 10"
+    previousUrl: "/standards-and-technology/service-standard-points/8-iterate-and-improve-frequently",
+    previousPage: "Point 8",
+    nextUrl: "/standards-and-technology/service-standard-points/10-define-what-success-looks-like-and-be-open-about-how-your-service-is-performing",
+    nextPage: "Point 10"
   }) }}
 
   {% endblock %}


### PR DESCRIPTION
This relates to https://github.com/nhsuk/nhsuk-frontend/issues/855

Nunjucks are unnecessarily quoted in the design system examples, they do not need to be quoted.

Current guidance is inconsistent:

- some are double quoted
- some are single quoted
- others already have no quotes

This PR makes all keys unquoted, making them consistent and keeping inline with GDS.

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
