### PR TITLE
Add `open` macro option to details component

### DIFF
--- a/app/views/design-system/components/details/macro-options.json
+++ b/app/views/design-system/components/details/macro-options.json
@@ -13,6 +13,12 @@
       "description": "HTML content to be displayed within the details component."
     },
     {
+      "name": "open",
+      "type": "boolean",
+      "required": false,
+      "description": "If true, details element will be expanded."
+    },
+    {
       "name": "classes",
       "type": "string",
       "required": false,

--- a/app/views/design-system/components/details/macro-options.json
+++ b/app/views/design-system/components/details/macro-options.json
@@ -13,6 +13,12 @@
       "description": "HTML content to be displayed within the details component."
     },
     {
+      "name": "id",
+      "type": "string",
+      "required": false,
+      "description": "Id to add to the details element."
+    },
+    {
       "name": "open",
       "type": "boolean",
       "required": false,

--- a/app/views/design-system/components/expander/macro-options.json
+++ b/app/views/design-system/components/expander/macro-options.json
@@ -13,12 +13,6 @@
       "description": "HTML content to be displayed within the details component."
     },
     {
-      "name": "id",
-      "type": "string",
-      "required": false,
-      "description": "Id to add to the details element."
-    },
-    {
       "name": "open",
       "type": "boolean",
       "required": false,

--- a/app/views/design-system/components/expander/macro-options.json
+++ b/app/views/design-system/components/expander/macro-options.json
@@ -13,6 +13,12 @@
       "description": "HTML content to be displayed within the details component."
     },
     {
+      "name": "id",
+      "type": "string",
+      "required": false,
+      "description": "Id to add to the details element."
+    },
+    {
       "name": "open",
       "type": "boolean",
       "required": false,


### PR DESCRIPTION
## Description

Document the addition of a `details` macro option – it's been added to `nhsuk-frontend` to align with the GOV.UK design system. This option already shows for the expander.

### Related issue

This corresponds with https://github.com/nhsuk/nhsuk-frontend/pull/857

(Which is now merged and due for release with version 7)

## Checklist

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
