### PR TITLE
Add draft accessibility updates, change NHSD to NHSE 

### DIFF
--- a/app/views/accessibility/content.njk
+++ b/app/views/accessibility/content.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Accessibility" %}
 {% set pageDescription = "What content designers, writers and editors need to do to make digital services accessible." %}
 {% set theme = "Accessibility guidance for:" %}
-{% set dateUpdated = "February 2022" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "347" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -13,6 +13,8 @@
 {% endblock %}
 
 {% block bodyContent %}
+
+  <p>For a full list of WCAG 2.1 success criteria and guidance for levels A and AA and some level AAA success criteria and best practice, <a href="https://nhsdigital.github.io/accessibility-checklist/">use the NHS accessibility checklist</a>.</p>
 
   {% include "./partials/write-content-thats-easy-to-understand.njk" %}
   {% include "./partials/set-page-titles.njk" %}

--- a/app/views/accessibility/design.njk
+++ b/app/views/accessibility/design.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Accessibility" %}
 {% set pageDescription = "What graphic and interaction designers need to do to make digital services accessible." %}
 {% set theme = "Accessibility guidance for:" %}
-{% set dateUpdated = "February 2022" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "349" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -14,6 +14,9 @@
 
 {% block bodyContent %}
 
+  <p>For a full list of WCAG 2.1 success criteria and guidance for levels A and AA and some level AAA success criteria and best practice, <a href="https://nhsdigital.github.io/accessibility-checklist/">use the NHS accessibility checklist</a>.</p>
+
+  {% include "./partials/do-not-use-accessibility-overlays-or-widgets.njk" %}
   {% include "./partials/define-page-structure.njk" %}
   {% include "./partials/define-skip-links.njk" %}
   {% include "./partials/use-headings-correctly.njk" %}

--- a/app/views/accessibility/development.njk
+++ b/app/views/accessibility/development.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Accessibility" %}
 {% set pageDescription = "What developers need to do to make digital services accessible." %}
 {% set theme = "Accessibility guidance for:" %}
-{% set dateUpdated = "January 2022" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "348" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -14,6 +14,9 @@
 
 {% block bodyContent %}
 
+  <p>For a full list of WCAG 2.1 success criteria and guidance for levels A and AA and some level AAA success criteria and best practice, <a href="https://nhsdigital.github.io/accessibility-checklist/">use the NHS accessibility checklist</a>.</p>
+
+  {% include "./partials/do-not-use-accessibility-overlays-or-widgets.njk" %}
   {% include "./partials/check-keyboard-accessibility.njk" %}
   {% include "./partials/set-page-titles.njk" %}
   {% include "./partials/set-language.njk" %}

--- a/app/views/accessibility/how-to-make-digital-services-accessible.njk
+++ b/app/views/accessibility/how-to-make-digital-services-accessible.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Accessibility" %}
 {% set pageDescription = "Our approach to accessibility." %}
 {% set theme = "Everyone needs to know" %}
-{% set dateUpdated = "July 2019" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "351" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -17,9 +17,7 @@
   <h2 id="consider-accessibility-at-every-stage">Consider accessibility at every stage</h2>
   <p>Think about how you are going to address accessibility at the beginning and at every stage of your project.</p>
   <p>It's much harder to make a service accessible if you only address it later on.</p>
-  <ul>
-    <li><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#what-to-do-in-discovery">Making your service accessible: an introduction</a> (GOV.UK service manual) explains what to do at different stages.</li>
-  </ul>
+  <p><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#what-to-do-in-discovery">Making your service accessible: an introduction (GOV.UK service manual)</a> explains what to do at different stages.</p>
 
   <h2 id="make-it-the-whole-teams-responsibility">Make it the whole team's responsibility</h2>
   <p>Every member of the team should contribute to making your service inclusive.</p>
@@ -33,23 +31,26 @@
   <h2 id="research-with-users-with-access-needs">Research with users with access needs</h2>
   <p>Involve people with access needs, including disabled people, in every round of user research.</p>
   <p>Consider cognitive and physical impairments, visual impairments, and temporary or permanent access needs.</p>
-  <ul>
-    <li>Follow our <a href="user-research">guidance on user research</a>.</li>
-  </ul>
+  <p>Follow our <a href="user-research">guidance on user research</a>.</p>
 
   <h2 id="use-progressive-enhancement">Use progressive enhancement</h2>
   <p>Progressive enhancement is about making your page work with just HTML, before adding anything else like cascading style sheets (CSS) and Javascript. That helps people who live in areas with slow connections or whose devices or browsers fail to load or recognise something.</p>
-  <p>The <a href="/design-system/production">NHS.UK frontend library</a> uses JavaScript for "enhancement" - as an extra. It works without it.</p>
+  <p>The <a href="/design-system/production">NHS.UK frontend library</a> uses JavaScript for "enhancement" – as an extra. It works without it.</p>
+  <p>See <a href="https://www.gov.uk/service-manual/technology/using-progressive-enhancement">Building a resilient frontend using progressive enhancement (GOV.UK service manual)</a>.</p>
+
+  <h2 id="follow-NHS-accessibility-guidance">Follow NHS accessibility guidance</h2>
+  <p>Use this accessibility guidance to get started.</p>
+  <p>For more detail, follow <a href="https://nhsdigital.github.io/accessibility-checklist/">the NHS accessibility checklist</a>. The checklist contains:</p>
   <ul>
-    <li><a href="https://www.gov.uk/service-manual/technology/using-progressive-enhancement">Building a resilient frontend using progressive enhancement</a> (GOV.UK service manual)</li>
+    <li>a full list of WCAG 2.1 success criteria and guidance for levels A and AA that NHS websites and public mobile apps need to conform to</li>
+    <li>some level AAA success criteria and best practice to improve accessibility</li>
   </ul>
 
   <h2 id="test-throughout-and-consider-an-independent-audit">Test throughout and consider an independent audit</h2>
   <p>An expert audit can help find accessibility problems with your service and make sure it meets accessibility requirements. If you run your own tests regularly, the audit should find very little that needs changing.</p>
-  <ul>
-    <li>Follow our <a href="testing">guidance on testing</a> and our guidance on <a href="/accessibility/product-and-delivery#monitor-and-record-your-work">monitoring and recording accessibility testing</a> (for product and delivery managers)</li>
-    <li><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/getting-an-accessibility-audit">Getting an accessibility audit</a> (GOV.UK service manual)</li>
-  </ul>
+  <p>Follow our <a href="testing">guidance on testing</a> and our guidance on <a href="/accessibility/product-and-delivery#monitor-and-record-your-work">monitoring and recording accessibility testing</a> (for product and delivery managers).</p>
+  <p>Find out about <a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/getting-an-accessibility-audit">getting an accessibility audit (GOV.UK service manual)</a>.</li>
+
 
 {% endblock %}
 

--- a/app/views/accessibility/partials/do-not-use-accessibility-overlays-or-widgets.njk
+++ b/app/views/accessibility/partials/do-not-use-accessibility-overlays-or-widgets.njk
@@ -1,0 +1,22 @@
+<h2 id="do-not-use-accessibility-overlays-or-widgets">Do not use accessibility overlays or widgets</h2>
+<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a></p>
+
+<details class="nhsuk-details">
+  <summary class="nhsuk-details__summary">
+    <span class="nhsuk-details__summary-text">
+      What are accessibility overlays and widgets?
+    </span>
+  </summary>
+  <div class="nhsuk-details__text">
+    <p>Accessibility overlays are toolbars or plugins that let users customise the web page display.</p>
+    <p>They typically sit in the banner or a corner of the page, sometimes obscuring key functionality. They often use icons that can be difficult for users to understand. When clicked on, an overlay may pop up and create a barrier that users can't get past.</p>
+  </div>
+</details>
+
+<p>Overlays and widgets can create problems for people when they get tapped accidentally or when they cover up information. People find them confusing and unhelpful.</p>
+<p>People with access needs often use their preferred assistive technologies across all websites. Widgets only meet some access needs and only deal with one part of a user journey. They cannot hand over from one system or site to another. What helps people with access needs more are well-designed, well-structured websites that are:</p>
+<ul>
+  <li>built from the bottom up with accessibility-tested code and designs, like the <a href="/design-system/production">NHS production code</a> and <a href="/design-system">design system</a></li>
+  <li>tested with users with access needs – find out more in the section on <a href="/accessibility/user-research">user research</a></li>
+</ul>
+<p>Accessibility overlays and widgets cannot make a website fully compliant with accessibility standards or protect you from legal action.</p>

--- a/app/views/accessibility/what-all-NHS-services-need-to-do.njk
+++ b/app/views/accessibility/what-all-NHS-services-need-to-do.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Accessibility" %}
 {% set pageDescription = "The NHS is for everyone, so NHS digital services should be accessible to everyone too." %}
 {% set theme = "Everyone needs to know" %}
-{% set dateUpdated = "July 2019" %}
+{% set dateUpdated = "February 2023" %}
 {% set hideContact = "true" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -15,15 +15,26 @@
 {% block bodyContent %}
 
   <h2 id="accessibility-and-the-law">Accessibility and the law</h2>
-  <p>If your service isn’t accessible to everyone who needs it, you may be breaking the <a href="https://www.legislation.gov.uk/ukpga/2010/15/contents">2010 Equality Act</a>.</p>
-  <p>New accessibility regulations say that public sector websites must meet accessibility standards and publish an accessibility statement. You can find out <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">more about the new regulations on GOV.UK</a>.</p>
+  <p>If your service isn't accessible to everyone who needs it, you may be breaking the <a href="https://www.legislation.gov.uk/ukpga/2010/15/contents">2010 Equality Act</a>.</p>
+  <p>Public sector websites must meet accessibility standards and publish an accessibility statement. Find out <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">accessibility requirements for public sector bodies on GOV.UK</a>.</p>
 
   <h2 id="meeting-the-requirements">Meeting the requirements</h2>
   <p>NHS digital services must:</p>
   <ul>
-    <li>meet at least level AA of the Web Content Accessibility Guidelines (<a href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</a>) - and aim for AAA where possible</li>
-    <li>work on the most commonly used assistive technologies - including screen magnifiers </li>
+    <li>meet at least level AA of the Web Content Accessibility Guidelines (<a href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</a>) and aim for AAA where possible</li>
+    <li>work on the most commonly used assistive technologies, including screen magnifiers </li>
     <li>include people with access needs in user research</li>
+  </ul>
+
+  <h3 id="teams-on-short-deadlines">Teams on short deadlines</h3>
+  <ul>
+    <li>Check the <a href="https://www.gov.uk/service-manual/agile-delivery/making-services-in-an-emergency">GOV.UK guidance on making services in an emergency</a>.</li>
+    <li>Consider exclusion as you design your service, for example, with <a href="https://www.gov.uk/government/publications/understanding-disabilities-and-impairments-user-profiles">GOV.UK's user profiles for understanding disabilities and impairments</a>.</li>
+    <li>Use the <a href="/design-system/production">NHS production code</a> and <a href="/design-system">design system</a>.</li>
+    <li>Set up automated accessibility testing and fix issues you identify.</li>
+    <li>Use the <a href="https://nhsdigital.github.io/accessibility-checklist/">NHS accessibility checklist</a> to carry out an initial WCAG evaluation
+    <li>Test service journeys with a range of assistive technologies.</li>
+    <li>Plan user research to identify and remove barriers.</li>
   </ul>
 
   <h3 id="internal-services">Internal services</h3>
@@ -35,7 +46,7 @@
 
   <h2 id="why-its-important">Why it's important</h2>
   <p>In the UK, almost 1 in 5 people have a disability of some kind. Many more have temporary or situational disabilities, like an illness or injury.</p>
-  <p>When you’re working on NHS services, think about how people with different needs might use what you’re making.</p>
+  <p>When you're working on NHS services, think about how people with different needs might use what you're making.</p>
   <p>For example, can someone with dyslexia read your content easily? Or how would someone with a broken arm interact on a mobile device?</p>
 
 {% endblock %}

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -2,7 +2,7 @@
 {% set pageDescription = "Our fonts and typographic styles, and how to apply them." %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Styles" %}
-{% set dateUpdated = "January 2022" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "1" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -62,7 +62,7 @@
 
   <h3>Frutiger</h3>
   <p>Frutiger has been the NHS brand font since 1999. We use the web font for consistency between online and offline materials.</p>
-  <p>NHS Digital has a licence for the Frutiger webfont that any services on the nhs.uk domain can use. The web font is hosted on nhs.uk and  referenced in the NHS.UK frontend.</p>
+  <p>NHS England has a licence for the Frutiger webfont that any services on the nhs.uk domain can use. The web font is hosted on nhs.uk and  referenced in the NHS.UK frontend.</p>
   <p>If you have a service that is on another domain, you will have to buy your own Frutiger webfont licence.</p>
   <p>If you’re not sure whether you should be using Frutiger, you can email the service manual team at <a href="mailto:service-manual@nhs.net">service-manual@nhs.net</a>.</p>
 

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -87,7 +87,7 @@
         <div class="nhsuk-grid-column-two-thirds">
 
           <h2>Support</h2>
-          <p>The manual is maintained by the <a href="/service-manual-team">service manual team at NHS Digital</a>. If you've got a question or want to feedback, you can <a href="/get-in-touch">get in touch</a>.</p>
+          <p>The manual is maintained by the <a href="/service-manual-team">service manual team at NHS England</a>. If you've got a question or want to feedback, you can <a href="/get-in-touch">get in touch</a>.</p>
         </div>
       </div>
     </div>

--- a/app/views/service-manual-team.njk
+++ b/app/views/service-manual-team.njk
@@ -1,6 +1,6 @@
 {% set pageTitle = "Service manual team" %}
-{% set pageDescription = "The service manual team at NHS Digital maintains the service manual." %}
-{% set dateUpdated = "January 2023" %}
+{% set pageDescription = "The service manual team at NHS England maintains the service manual." %}
+{% set dateUpdated = "February 2023" %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}
 

--- a/app/views/standards-and-technology/about-the-service-standard.njk
+++ b/app/views/standards-and-technology/about-the-service-standard.njk
@@ -4,7 +4,7 @@
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "The NHS service standard is designed to help teams meet the GOV.UK service standard in the context of health and care." %}
 {% set hideContact = "true" %}
-{% set dateUpdated = "February 2022" %}
+{% set dateUpdated = "February 2023" %}
 
 {% extends "includes/app-layout.njk" %}
 
@@ -27,7 +27,7 @@
     <li>examples drawn from the NHS</li>
   </ul>
 
-  <p>The NHS service standard and the guidance in the NHS digital service manual are designed to help teams build and run services that improve health outcomes, people's experience of health and care, and the efficiency of the health service.</p>
+  <p>The NHS service standard and the guidance in the NHS digital service manual are designed to help teams build and run services that improve health outcomes, people's experience of health and care, and the efficiency of the health service. They are informed by and support the <a href="https://www.gov.uk/government/publications/the-nhs-constitution-for-england/the-nhs-constitution-for-england">NHS Constitution (GOV.UK)</a>.</p>
 
   <h2>What is different about the NHS?</h2>
   <p>There is a lot that is the same across Government and the NHS but this guidance also takes account of what's different in health.</p>

--- a/app/views/standards-and-technology/service-standard-points/17-make-your-service-interoperable.njk
+++ b/app/views/standards-and-technology/service-standard-points/17-make-your-service-interoperable.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Standards and technology" %}
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "In an organisation as diverse and complex as the NHS, we need systems and services which talk to each other. Build for interoperability to share patient records and get data quickly from one place to another." %}
-{% set dateUpdated = "January 2023" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "360" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -21,11 +21,11 @@
   <ul>
     <li>you work to open standards and the Technology Code of Practice</li>
     <li>you have checked the <a href="https://data.standards.nhs.uk/">NHS data standards directory</a> for relevant standards</li>
-    <li>you maximise flexibility and make content, tools and services available through well-designed APIs to reach more people</li>
+    <li>you maximise flexibility and make content, tools and services available to more people through well-designed APIs, following the <a href="https://digital.nhs.uk/developer/guides-and-documentation/api-policies-and-best-practice">API policies and best practice (NHS Digital)</a></li>
     <li>you use agreed <a href="https://digital.nhs.uk/developer/api-catalogue?filter=fhir">FHIR-based APIs (from NHS Digital's API catalogue, filtered by FHIR)</a> to join up care for patients</li>
     <li>where appropriate, you use the <a href="https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/isb-0149-nhs-number">NHS number (NHS Digital)</a> and NHS data registers and comply with NHS clinical information standards</li>
     <li>for disease information in mortality and morbidity statistics, you use <a href="https://icd.who.int/browse10/2016/en">ICD-10 (the World Health Organization's International Classification of Diseases, version 10)</a></li>
-    <li>for electronic care records, you use the structured clinical vocabulary <a href="https://digital.nhs.uk/services/terminology-and-classifications/snomed-ct">SNOMED CT (on NHS Digital's website)</a></li>
+    <li>for electronic care records, you use the structured clinical vocabulary <a href="https://digital.nhs.uk/services/terminology-and-classifications/snomed-ct">SNOMED CT (NHS Digital)</a></li>
     <li>if you create any data sets that could be useful to others, you publish them in an open machine-readable format, under an <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>, unless they contain personally identifiable information, sensitive information, or where publishing the data would infringe the intellectual property rights of someone outside the NHS or government</li>
     <li>if you use barcodes or similar identifiers, you comply with the <a href="https://www.gs1.org/standards/barcodes">GS1 barcodes standard</a> as set out in <a href="https://www.scan4safety.nhs.uk/">Scan4Safety</a></li>
     <li>where relevant, you comply with the <a href="https://www.gov.uk/government/publications/open-standards-for-government">standards published by the Open Standards Board on GOV.UK</a></li>
@@ -47,15 +47,16 @@
   <h3>Read more about this</h3>
   <ul>
     <li><a href="https://developer.nhs.uk/apis">The API catalogue (NHS Digital)</a></li>
-    <li><a href="https://www.gov.uk/government/publications/code-of-conduct-for-data-driven-health-and-care-technology/initial-code-of-conduct-for-data-driven-health-and-care-technology">A guide to good practice for digital and data-driven health technologies (on GOV.UK)</a></li>
-    <li><a href="https://digital.nhs.uk/services/data-registers-service">Data registers service (NHS Digital)</a> </li>
+    <li><a href="https://digital.nhs.uk/developer/guides-and-documentation/api-policies-and-best-practice">API policies and best practice (NHS Digital)</li>
+    <li><a href="https://www.gov.uk/government/publications/code-of-conduct-for-data-driven-health-and-care-technology/initial-code-of-conduct-for-data-driven-health-and-care-technology">A guide to good practice for digital and data-driven health technologies (GOV.UK)</a></li>
+    <li><a href="https://digital.nhs.uk/services/data-registers-service">Data registers service (NHS Digital)</a></li>
     <li><a href="https://digital.nhs.uk/services/fhir-apis">FHIR (Fast Healthcare Interoperability Resources, NHS Digital)</a></li>
-    <li><a href="https://icd.who.int/browse10/2016/en">ICD-10, version: 2016</a> - the World Health Organization's International Classification of Diseases (WHO)</li>
-    <li><a href="https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/isb-0149-nhs-number">ISB 0149 NHS number (NHS Digital)</a> - this information standard sets out the scope and use of the NHS number</li>
-    <li><a href="https://data.standards.nhs.uk/">NHS data standards directory</a> - nationally recognised standards that support interoperability in health and adult social care, including the NHS number, SNOMED CT and FHIR-based APIs</li>
+    <li><a href="https://icd.who.int/browse10/2016/en">ICD-10, version: 2016</a> – the World Health Organization's International Classification of Diseases (WHO)</li>
+    <li><a href="https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/isb-0149-nhs-number">ISB 0149 NHS number (NHS Digital)</a> – the information standard for the NHS number</li>
+    <li><a href="https://data.standards.nhs.uk/">NHS data standards directory</a> – nationally recognised standards that support interoperability in health and adult social care, including the NHS number, SNOMED CT and FHIR-based APIs</li>
     <li><a href="https://developer.api.nhs.uk/">NHS website developer portal (NHS.UK)</a></li>
-    <li><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a> (The National Archives)</li>
-    <li><a href="https://digital.nhs.uk/services/terminology-and-classifications/snomed-ct">SNOMED CT (on NHS Digital's website)</a> - a structured clinical vocabulary for use in an electronic health record</li>
+    <li><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence (The National Archives)</a></li>
+    <li><a href="https://digital.nhs.uk/services/terminology-and-classifications/snomed-ct">SNOMED CT (NHS Digital)</a> – a structured clinical vocabulary for use in an electronic health record</li>
   </ul>
 
 {% endblock %}

--- a/app/views/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service.njk
+++ b/app/views/standards-and-technology/service-standard-points/5-make-sure-everyone-can-use-the-service.njk
@@ -2,7 +2,7 @@
 {% set pageSection = "Standards and technology" %}
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "Make sure people with different physical, mental health, social, cultural or learning needs can use your service, whether it's for the public or staff." %}
-{% set dateUpdated = "January 2022" %}
+{% set dateUpdated = "February 2023" %}
 {% set backlog_issue_id = "339" %}
 
 {% extends "includes/app-layout.njk" %}
@@ -16,7 +16,7 @@
   <p class="nhsuk-lede-text app-lede-text">Also people who do not have access to the internet or lack the skills or confidence to use it.</p>
   <p class="nhsuk-lede-text app-lede-text">Build an inclusive service so that everyone gets the care they need.</p>
   <h2>Why it's important</h2>
-  <p>NHS services are for everyone. We have a duty to consider everyone’s needs when we’re designing and delivering services.</p>
+  <p>The <a href="https://www.gov.uk/government/publications/the-nhs-constitution-for-england/the-nhs-constitution-for-england">NHS Constitution (GOV.UK)</a> says that NHS services are for everyone. We have a duty to consider everyone’s needs when we’re designing and delivering services.</p>
   <p>Inclusive, accessible services are better for everyone. For example, using simple words helps people who are sick or stressed as well as people who have a learning disability.</p>
   <h3>What we mean by inclusion and accessibility</h3>
   <p>Inclusion is about responding to people's differences so that everyone:</p>

--- a/app/views/terms-and-conditions.njk
+++ b/app/views/terms-and-conditions.njk
@@ -1,6 +1,6 @@
 {% set pageTitle = "Terms and conditions" %}
-{% set pageDescription = "This website is operated by NHS Digital. These terms govern your use of the NHS digital service manual." %}
-{% set dateUpdated = "January 2020" %}
+{% set pageDescription = "This website is operated by NHS England. These terms govern your use of the NHS digital service manual." %}
+{% set dateUpdated = "February 2023" %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}
 
@@ -15,7 +15,7 @@
   <h2>Terms of use</h2>
   <p>References to 'the NHS' mean 'the NHS in England' unless otherwise stated. Service descriptions, entitlements and costs refer to services in England and arrangements may differ elsewhere in the UK.</p>
   <p>We cannot guarantee uninterrupted access to the website, or the sites to which it links. We accept no responsibility for any damage arising from the unavailability of this website or the information it contains.</p>
-  <p>This website contains links to other sites. We are not responsible for the content of any third party website and a link to another site does not mean NHS Digital endorses their site or content.</p>
+  <p>This website contains links to other sites. We are not responsible for the content of any third party website and a link to another site does not mean NHS England endorses their site or content.</p>
   <p>You may link to our website, provided you do so in a way that is fair and legal and does not damage our reputation or take advantage of it. You must not make a link in such a way as to suggest any form of association, approval or endorsement on our part. We reserve the right to withdraw linking permission without notice.</p>
   <p>If you submit personal information to us through this website, it will be used in line with our <a href="/your-privacy">privacy policy</a>.</p>
   <p>We do not guarantee that this website will be secure or free from bugs or viruses. You are responsible for configuring your information technology, computer programmes and platform to access our site. You should use your own virus protection software.</p>

--- a/app/views/your-privacy.njk
+++ b/app/views/your-privacy.njk
@@ -1,6 +1,6 @@
 {% set pageTitle = "Your privacy" %}
 {% set pageDescription = "Your privacy is important to us. This privacy policy covers what we collect and how we use, share and store your information." %}
-{% set dateUpdated = "February 2020" %}
+{% set dateUpdated = "February 2023" %}
 
 {% extends "includes/app-layout-two-thirds.njk" %}
 
@@ -55,7 +55,7 @@
   <p>If you shared your email with us as part of a survey, we will delete it after 2 years. At that point no one can identify you in the survey data.</p>
 
   <h2>Data sharing</h2>
-  <p>NHS Digital may share anonymous information on how the service is used with the Department of Health and Social Care, NHS England, clinical commissioning groups (CCGs), and the National Clinical Governance Group.</p>
+  <p>NHS England may share anonymous information on how the service is used with the Department of Health and Social Care, integrated care boards (ICBs), and national governance groups.</p>
 
   <h3>Legal powers</h3>
   <p>When you give us personal information, we may pass it on if the law says we must.</p>
@@ -68,6 +68,6 @@
     <li>find out what information we hold about you, ask us to correct it if it's wrong, or delete it by emailing <a href="mailto:enquiries@nhsdigital.nhs.uk">enquiries@nhsdigital.nhs.uk</a></li>
     <li>contact the <a href="https://ico.org.uk/">Information Commissioner's Office</a>, Wycliffe House Water Lane, Wilmslow SK9 5AF if you want to make a complaint about how we have managed your data</li>
   </ul>
-  <p>NHS Digital, 1 Trevelyan Square, Boar Lane, Leeds, LS1 6AE is the Data Controller for the NHS digital service manual under data protection legislation. We will process your data in line with data protection legislation.</p>
+  <p>NHS Digital (NHS England), 1 Trevelyan Square, Boar Lane, Leeds, LS1 6AE is the Data Controller for the NHS digital service manual under data protection legislation. We will process your data in line with data protection legislation.</p>
 
 {% endblock %}


### PR DESCRIPTION

## Description
- Add links to accessibility checklist plus new section on accessibility widgets plus new section for teams under tight deadlines - DRAFT
- Change references to NHSD so they refer to NHSE instead
- Add mentions of NHS Constitution in service standard

### Related issue
- https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/449
- https://github.com/nhsuk/nhsuk-service-manual/issues/1863
- https://github.com/nhsuk/nhsuk-service-manual/issues/1854

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry - not yet
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - not yet
- [x] Page updated date
