### PR TITLE
Improve requirements for clarity

### DIFF
--- a/app/views/accessibility/what-all-NHS-services-need-to-do.njk
+++ b/app/views/accessibility/what-all-NHS-services-need-to-do.njk
@@ -16,7 +16,7 @@
 
   <h2 id="accessibility-and-the-law">Accessibility and the law</h2>
   <p>If your service isn’t accessible to everyone who needs it, you may be breaking the <a href="https://www.legislation.gov.uk/ukpga/2010/15/contents">2010 Equality Act</a>.</p>
-  <p>New accessibility regulations say that public sector websites must meet accessibility standards and publish an accessibility statement. You can find out <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">more about the new regulations on GOV.UK</a>.</p>
+  <p>Public sector accessibility regulations say that public sector websites must meet accessibility standards and publish an accessibility statement. You can find out <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">more about the new regulations on GOV.UK</a>.</p>
 
   <h2 id="meeting-the-requirements">Meeting the requirements</h2>
   <p>NHS digital services must:</p>
@@ -24,6 +24,7 @@
     <li>meet at least level AA of the Web Content Accessibility Guidelines (<a href="https://www.w3.org/TR/WCAG21/">WCAG 2.1</a>) - and aim for AAA where possible</li>
     <li>work on the most commonly used assistive technologies - including screen magnifiers </li>
     <li>include people with access needs in user research</li>
+    <li>have an <a href="https://www.gov.uk/guidance/make-your-website-or-app-accessible-and-publish-an-accessibility-statement#publish-your-accessibility-statement">accessibility statement</a> that explains how accessible the service is</li>
   </ul>
 
   <h3 id="internal-services">Internal services</h3>


### PR DESCRIPTION
1. Remove the usage of 'new' when talking about the regulations as they're now not new.
2. Add the requirement for the accessibility statement listed in the paragraph above clearly in the list.

Mirrors https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction#meeting-government-accessibility-requirements
