### PR TITLE
Import and initialise error summary JS and set focusOnPageLoad to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## 5.9.2 - 22 May 2023
+## 5.9.2 -  TBC 22 May 2023
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS digital service manual Changelog
 
+## 5.9.2 - 22 May 2023
+
+:wrench: **Fixes**
+
+- Import and initialise the Error Summary JavaScript, and set focusOnPageLoad to false, so the component example works as expected [NHS.UK frontend issue #766](https://github.com/nhsuk/nhsuk-frontend/issues/766)
+
+
 ## 5.9.1 - 3 May 2023
 
 :wrench: **Maintenance**

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -8,6 +8,7 @@ import Checkboxes from 'nhsuk-frontend/packages/components/checkboxes/checkboxes
 import Radios from 'nhsuk-frontend/packages/components/radios/radios';
 import Tabs from 'nhsuk-frontend/packages/components/tabs/tabs';
 import CharacterCount from 'nhsuk-frontend/packages/components/character-count/character-count';
+import ErrorSummary from '../../node_modules/nhsuk-frontend/packages/components/error-summary/error-summary';
 
 import AutoComplete from './autocomplete/autoCompleteConfig';
 
@@ -43,6 +44,7 @@ Checkboxes();
 Radios();
 Tabs();
 CharacterCount();
+ErrorSummary({focusOnPageLoad: false})
 
 // Initialise NHS digital service manual components
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -8,7 +8,7 @@ import Checkboxes from 'nhsuk-frontend/packages/components/checkboxes/checkboxes
 import Radios from 'nhsuk-frontend/packages/components/radios/radios';
 import Tabs from 'nhsuk-frontend/packages/components/tabs/tabs';
 import CharacterCount from 'nhsuk-frontend/packages/components/character-count/character-count';
-import ErrorSummary from '../../node_modules/nhsuk-frontend/packages/components/error-summary/error-summary';
+import ErrorSummary from 'nhsuk-frontend/packages/components/error-summary/error-summary';
 
 import AutoComplete from './autocomplete/autoCompleteConfig';
 
@@ -44,7 +44,7 @@ Checkboxes();
 Radios();
 Tabs();
 CharacterCount();
-ErrorSummary({focusOnPageLoad: false})
+ErrorSummary({ focusOnPageLoad: false });
 
 // Initialise NHS digital service manual components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.8.0",
+  "version": "5.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nhsuk-service-manual",
-      "version": "5.8.0",
+      "version": "5.9.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description
Import and initialise error summary JS and set focusOnPageLoad to false so that the Error Summary examples work as expected.

### Related issue
Resolves NHSUK Frontend Issue [#766](https://github.com/nhsuk/nhsuk-frontend/issues/766).

## Checklist
- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
- [ ] Page updated date
