### PR TITLE
Increase max width for header and footer

### DIFF
--- a/app/styles/app/_container.scss
+++ b/app/styles/app/_container.scss
@@ -18,3 +18,18 @@ $service-manual-container-size: 1100px;
   max-width: $service-manual-container-size + nhsuk-spacing(9);
 }
 
+// Apply container size to header and footer components
+
+.nhsuk-header__navigation-list {
+  max-width: $service-manual-container-size;
+}
+
+.nhsuk-header__container {
+  max-width: $service-manual-container-size;
+}
+
+.nhsuk-footer-container {
+  .nhsuk-width-container {
+    max-width: $service-manual-container-size;
+  }
+}


### PR DESCRIPTION
## Description
The header and footer in the service manual is too narrow when on desktop. 

![image](https://github.com/nhsuk/nhsuk-service-manual/assets/119668404/1de27c63-9412-40fe-9e3c-aec632c5d159)

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)

