### PR TITLE
Remove embedded link from contents list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add side nav link for "Standard for creating health content" to "Numbers, measurements, dates and time" page
 - Added minimum width limit to "A to Z" navigation links
 - Remove redundant back link in content guide
+- Remove embedded link from contents list design example
 
 ## 6.1.0 - 18 January 2024 
 

--- a/app/views/content/a-to-z-of-nhs-health-writing.njk
+++ b/app/views/content/a-to-z-of-nhs-health-writing.njk
@@ -1,7 +1,7 @@
 {% set pageTitle = "A to Z of NHS health writing" %}
 {% set pageSection = "Content guide" %}
 {% set pageDescription = "Words and phrases we use to make our content about health and the NHS easy to understand." %}
-{% set dateUpdated = "February 2024" %}
+{% set dateUpdated = "January 2024" %}
 {% set backlog_issue_id = "318" %}
 
 {% block extraMeta %}

--- a/app/views/design-system/components/contents-list/default/index.njk
+++ b/app/views/design-system/components/contents-list/default/index.njk
@@ -3,26 +3,26 @@
 {{ contentsList({
   items: [
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/",
+      href: "#",
       text: "What is AMD?",
       current: "true"
     },
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/symptoms/",
+      href: "#",
       text: "Symptoms"
     },
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/getting-diagnosed/",
+      href: "#",
       text: "Getting diagnosed"
     }
     ,
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/treatment/",
+      href: "#",
       text: "Treatments"
     }
     ,
     {
-      href: "https://www.nhs.uk/conditions/age-related-macular-degeneration-amd/living-with-amd/",
+      href: "#",
       text: "Living with AMD"
     }
   ]

--- a/app/views/design-system/patterns/a-to-z-page/index.njk
+++ b/app/views/design-system/patterns/a-to-z-page/index.njk
@@ -3,7 +3,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Patterns" %}
 {% set theme = "Page types" %}
-{% set dateUpdated = "February 2024" %}
+{% set dateUpdated = "August 2023" %}
 {% set backlog_issue_id = "96" %}
 
 {% extends "includes/app-layout.njk" %}


### PR DESCRIPTION
## Description
The links in the contents list design example were causing errors when clicked on in [this page](https://service-manual.nhs.uk/design-system/components/contents-list). These have been removed.

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
