### PR TITLE
Add curly brace to prototyping guidance

### DIFF
--- a/app/views/design-system/prototyping.njk
+++ b/app/views/design-system/prototyping.njk
@@ -36,6 +36,6 @@
 
   <h2 id="using-nunjucks-macros">Using Nunjucks macros</h2>
   <p>A Nunjucks macro is a simple template that generates more complex HTML. However, macros are more sensitive to mistakes than HTML, so it’s worth saving and previewing.</p>
-  <p>When using Nunjucks macros in the prototype kit leave out the first line that starts with <code>% from ...</code>.</p>
+  <p>When using Nunjucks macros in the prototype kit leave out the first line that starts with <code>{% raw %}{% from ...{% endraw %}</code>.</p>
 
 {% endblock %}


### PR DESCRIPTION
The line this refers to starts with a `{` but this wasn’t included.

It needs to be escaped with `{% raw %}` to avoid being interpreted by Nunjucks.