### PR TITLE
Update GitHub links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@
 ## Checklist
 <!-- Ensure each of the points below have been considered and completed where applicable -->
 
-- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
-- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
+- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
+- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
 - [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
 - [ ] CHANGELOG entry
 - [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,7 +629,7 @@
 
 :new: **New features**
 
-- Install [NHS.UK frontend v4.1.0](https://github.com/nhsuk/nhsuk-frontend/blob/master/CHANGELOG.md#410---21-january-2021)
+- Install [NHS.UK frontend v4.1.0](https://github.com/nhsuk/nhsuk-frontend/blob/main/CHANGELOG.md#410---21-january-2021)
 - Add guidance for asking for whole numbers using the text input component
 - Update code examples with inputmode numeric for the ask users for their NHS number pattern and date input component
 

--- a/app/views/accessibility/partials/make-your-research-more-accessible-on-the-day.njk
+++ b/app/views/accessibility/partials/make-your-research-more-accessible-on-the-day.njk
@@ -5,6 +5,6 @@
   <li>Give them plenty of time to settle in. Tell them that they can end the session at any time or take a break during it if they need to. Leave enough time between sessions.</li>
   <li>Make sure there's a seat for a helper or interpreter.</li>
   <li>Reassure people that there are no right or wrong answers and that if something isn't working, it's not their fault.</li>
-  <li>Make sure that any colleagues who are attending know how to be a considerate observer. Give them a copy of the <a href="https://github.com/alphagov/govdesign/blob/master/Poster_UserResearchTips.pdf">GDS user researcher tips (PDF, 161KB)</a>.</li>
+  <li>Make sure that any colleagues who are attending know how to be a considerate observer. Give them a copy of the <a href="https://github.com/alphagov/govdesign/blob/main/Poster_UserResearchTips.pdf">GDS user researcher tips (PDF, 161KB)</a>.</li>
 </ul>
 

--- a/app/views/community-and-contribution/contribution-criteria.njk
+++ b/app/views/community-and-contribution/contribution-criteria.njk
@@ -68,7 +68,7 @@
       <td class="nhsuk-table__cell">
       <p>It uses <a href="/design-system/components">existing styles and components</a> in the service manual where relevant.</p>
       <p>The guidance and any content in examples follow the <a href="/content">content guide</a>.</p>
-      <p>If there is code, it follows <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md">the NHS.UK frontend coding standards</a> and is ready to merge into the NHS.UK frontend library.</p>
+      <p>If there is code, it follows <a href="https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md">the NHS.UK frontend coding standards</a> and is ready to merge into the NHS.UK frontend library.</p>
       </td>
     </tr>
     <tr class="nhsuk-table__row">

--- a/app/views/design-system/components/buttons/index.njk
+++ b/app/views/design-system/components/buttons/index.njk
@@ -96,7 +96,7 @@
 
   <h3>Disabled buttons</h3>
   <p>Disabled buttons have poor contrast and can confuse some users. Only use them if user research shows it makes things easier for users to understand.</p>
-  <p>We have developed disabled versions of the 3 buttons but we haven't tested them yet. You can <a href="https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/components/button">get the latest disabled button code</a> in the NHS.UK frontend library in GitHub.</p>
+  <p>We have developed disabled versions of the 3 buttons but we haven't tested them yet. You can <a href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/components/button">get the latest disabled button code</a> in the NHS.UK frontend library in GitHub.</p>
 
   <h3>Colour contrast</h3>
   <p>All 3 active buttons pass AAA guidelines for colour contrast. The colour contrast ratio between text and background colour is as follows:</p>

--- a/app/views/design-system/production.njk
+++ b/app/views/design-system/production.njk
@@ -18,7 +18,7 @@
   <p>There are 2 ways to do this. You can either install it using node package manager (npm) or include the compiled files in your application.</p>
 
   <h3 id="option-1-install-using-npm">Option 1: install using npm</h3>
-  <p>We recommend <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-with-npm.md">installing the NHS.UK frontend library using npm</a>.</p>
+  <p>We recommend <a href="https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/installation/installing-with-npm.md">installing the NHS.UK frontend library using npm</a>.</p>
   <p>Using this option, you will be able to:</p>
   <ul>
     <li>selectively include the CSS or JavaScript for individual components</li>
@@ -28,7 +28,7 @@
   </ul>
 
   <h3 id="option-2-include-compiled-files">Option 2: include compiled files</h3>
-  <p>If your project does not use npm, or if you want to try out the NHS.UK frontend library in your project without installing it through npm, you can <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-compiled.md">download and include compiled stylesheets, JavaScript and the asset files</a>.</p>
+  <p>If your project does not use npm, or if you want to try out the NHS.UK frontend library in your project without installing it through npm, you can <a href="https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/installation/installing-compiled.md">download and include compiled stylesheets, JavaScript and the asset files</a>.</p>
   <p>Using this option, you will be able to include all the CSS and JavaScript of the NHS.UK frontend library in your project.</p>
   <p>You will not be able to:</p>
   <ul>
@@ -69,7 +69,7 @@
 
 
   <h2>Keeping your code up to date</h2>
-  <p>We update the NHS.UK frontend library from time to time. Check for recent releases in the <a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/CHANGELOG.md">NHS.UK frontend changelog</a>.</p>
+  <p>We update the NHS.UK frontend library from time to time. Check for recent releases in the <a href="https://github.com/nhsuk/nhsuk-frontend/blob/main/CHANGELOG.md">NHS.UK frontend changelog</a>.</p>
 
 
 {% endblock %}

--- a/app/views/design-system/styles/focus-state/index.njk
+++ b/app/views/design-system/styles/focus-state/index.njk
@@ -81,7 +81,7 @@
   <h2 id="if-you-do-not-use-sass">If you do not use Sass</h2>
   <p>To make a component's focus state accessible without using Sass, you can:</p>
   <ul>
-    <li class="rich-text">see how the <code>nhsuk-focused-text</code> mixin works from the <a href="https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/core/tools/_focused.scss#L12-L23">NHS.UK frontend source code</a></li>
+    <li class="rich-text">see how the <code>nhsuk-focused-text</code> mixin works from the <a href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/core/tools/_focused.scss#L12-L23">NHS.UK frontend source code</a></li>
     <li class="rich-text">get the values for <code>$nhsuk-focus-color</code> and <code>$nhsuk-focus-text-color</code> from the <a href="/design-system/styles/colour">colour page</a></li>
   </ul>
 

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -43,7 +43,7 @@
           </svg>
         </td>
         <td>Search</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-search.svg">icon-search.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-search.svg">icon-search.svg</a></td>
         <td><a href="/design-system/components/header">Header</a></td>
       </tr>
       <tr>
@@ -53,7 +53,7 @@
           </svg>
         </td>
         <td>Chevron left</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-chevron-left.svg">icon-chevron-left.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-chevron-left.svg">icon-chevron-left.svg</a></td>
         <td><a href="/design-system/components/breadcrumbs">Breadcrumbs</a> (on mobile screens)</td>
       </tr>
       <tr>
@@ -63,7 +63,7 @@
           </svg>
         </td>
         <td>Chevron right</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-chevron-right.svg">icon-chevron-right.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-chevron-right.svg">icon-chevron-right.svg</a></td>
         <td>Mobile menu, and primary <a href="/design-system/components/card">card</a> and <a href="/design-system/components/breadcrumbs">breadcrumb</a> on desktop</td>
       </tr>
       <tr>
@@ -73,7 +73,7 @@
           </svg>
         </td>
         <td>Close</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-close.svg">icon-close.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-close.svg">icon-close.svg</a></td>
         <td>Mobile menu</td>
       </tr>
       <tr>
@@ -84,7 +84,7 @@
           </svg>
         </td>
         <td>Cross (don't)</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-cross.svg">icon-cross.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-cross.svg">icon-cross.svg</a></td>
         <td><a href="/design-system/components/do-and-dont-lists">Do and Don't lists</a></td>
       </tr>
       <tr>
@@ -94,7 +94,7 @@
           </svg>
         </td>
         <td>Tick (do)</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-tick.svg">icon-tick.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-tick.svg">icon-tick.svg</a></td>
         <td><a href="/design-system/components/do-and-dont-lists">Do and Don't lists</a></td>
       </tr>
       <tr>
@@ -105,7 +105,7 @@
           </svg>
         </td>
         <td>Arrow right circle</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-arrow-right-circle.svg">icon-arrow-right-circle.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-arrow-right-circle.svg">icon-arrow-right-circle.svg</a></td>
         <td><a href="/design-system/components/action-link">Action link</a></td>
       </tr>
       <tr>
@@ -115,7 +115,7 @@
           </svg>
         </td>
         <td>Arrow right</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-arrow-right.svg">icon-arrow-right.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-arrow-right.svg">icon-arrow-right.svg</a></td>
         <td>Next page (<a href="/design-system/components/pagination">pagination</a>)</td>
       </tr>
       <tr>
@@ -125,7 +125,7 @@
           </svg>
         </td>
         <td>Arrow left</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-arrow-left.svg">icon-arrow-left.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-arrow-left.svg">icon-arrow-left.svg</a></td>
         <td>Previous page (<a href="/design-system/components/pagination">pagination</a>)</td>
       </tr>
       <tr>
@@ -136,7 +136,7 @@
           </svg>
         </td>
         <td>Plus</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-plus.svg">icon-plus.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-plus.svg">icon-plus.svg</a></td>
         <td><a href="/design-system/components/expander">Expander</a></td>
       </tr>
       <tr>
@@ -147,13 +147,13 @@
           </svg>
         </td>
         <td>Minus</td>
-        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/assets/icons/icon-minus.svg">icon-minus.svg</a></td>
+        <td><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/assets/icons/icon-minus.svg">icon-minus.svg</a></td>
         <td><a href="/design-system/components/expander">Expander</a></td>
       </tr>
     </tbody>
   </table>
 
-  <p>You can find all the SVG icons code in the <a href="https://github.com/nhsuk/nhsuk-frontend/tree/master/packages/assets/icons">NHS.UK frontend library on GitHub</a>.</p>
+  <p>You can find all the SVG icons code in the <a href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/assets/icons">NHS.UK frontend library on GitHub</a>.</p>
 
   <h2 id="when-to-use-these-icons">When to use these icons</h2>
   <p>Use these icons to mark important parts of the page and highlight things you want users to do.</p>

--- a/app/views/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use.njk
+++ b/app/views/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use.njk
@@ -31,7 +31,7 @@
   <h2>Guidance</h2>
   <h3>NHS digital service manual</h3>
   <ul>
-    <li><a href="https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md#screen-resolution-testing">Testing for screen resolution, browser support and assistive technology support</a> - NHS.UK frontend on GitHub</li>
+    <li><a href="https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md#screen-resolution-testing">Testing for screen resolution, browser support and assistive technology support</a> - NHS.UK frontend on GitHub</li>
   </ul>
 
   <h3>GOV.UK resources</h3>


### PR DESCRIPTION
In the `nhsuk-frontend` and `govdesign` repositories, `master` has been renamed to `main`.

(The URLs were redirecting, but updating the links avoids a banner appearing)