### PR TITLE
Change 'open in new window' to 'a new tab'

### DIFF
--- a/app/views/includes/design-example.njk
+++ b/app/views/includes/design-example.njk
@@ -49,7 +49,7 @@
 
     {% if showExample %}
       <a href="{{ standaloneURL }}" class="design-example__pop-out" target="_blank" rel="noopener noreferrer">
-        Open this<span class="nhsuk-u-visually-hidden"> {{ exampleTitle }}</span> example in new window
+        Open this<span class="nhsuk-u-visually-hidden"> {{ exampleTitle }}</span> example in a new tab
       </a>
       <div class="code-embed">
         <iframe title="{{ params.type }}" src="{{ standaloneURL }}" class="design-example-frame"></iframe>


### PR DESCRIPTION
This more accurately describes what the link does, now that most browsers have tabs.

Also follows the convention set by the GOV.UK Design System.