### PR TITLE
Tm 3171 code colour contrast

### DIFF
--- a/app/styles/design-example/govuk/_syntax-highlighting.scss
+++ b/app/styles/design-example/govuk/_syntax-highlighting.scss
@@ -8,7 +8,7 @@
 
 .hljs-comment,
 .hljs-quote {
-  color: #998; // sass-lint:disable-line no-color-hex no-color-literals
+  color: tint($color_nhsuk-grey-1, 10%); // sass-lint:disable-line no-color-hex no-color-literals
   font-style: italic;
 }
 
@@ -24,12 +24,12 @@
 .hljs-variable,
 .hljs-template-variable,
 .hljs-tag .hljs-attr {
-  color: #007F80; // sass-lint:disable-line no-color-hex no-color-literals
+  color: $color_nhsuk-green; // sass-lint:disable-line no-color-hex no-color-literals
 }
 
 .hljs-string,
 .hljs-doctag {
-  color: #d14; // sass-lint:disable-line no-color-hex no-color-literals
+  color: $color_nhsuk-red; // sass-lint:disable-line no-color-hex no-color-literals
 }
 
 .hljs-title,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Dig report, flags issue of low contrast for some colours used in code examples: https://alpha.hugr.app/view/7e2117#DIG601

Change colour scheme of code examples used in the design system, as it currently doesn't pass WCAG minimum contrast of 4.5. 

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
