### PR TITLE
Add section break guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 6.3.0 – 17 April 2024
 :new: **New features**
+- Add section break to design system styles
 - Add page on new accessibility requirements: WCAG 2.2
 - Add sections on making sure your service meets WCAG 2.2 for: Product and delivery and Design, Development and Testing
 - Add list of changes to meet new accessibility requirements to design system index page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # NHS digital service manual Changelog
 
-## 6.3.0 – 17 April 2024
+## 6.4.0 – 26 April 2024
 :new: **New features**
 - Add section break to design system styles
+
+## 6.3.0 – 17 April 2024
+:new: **New features**
 - Add page on new accessibility requirements: WCAG 2.2
 - Add sections on making sure your service meets WCAG 2.2 for: Product and delivery and Design, Development and Testing
 - Add list of changes to meet new accessibility requirements to design system index page

--- a/app/styles/app/_side-nav.scss
+++ b/app/styles/app/_side-nav.scss
@@ -14,11 +14,6 @@
   }
 }
 
-.app-side-nav__back {
-  border-bottom: 1px solid $nhsuk-border-color;
-  padding-bottom: nhsuk-spacing(3);
-}
-
 .app-side-nav__list {
   @include nhsuk-font(16, $line-height: 1.3);
   margin-bottom: 0;

--- a/app/views/design-system/styles/layout/index.njk
+++ b/app/views/design-system/styles/layout/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/design-system/styles/layout/index.njk
+++ b/app/views/design-system/styles/layout/index.njk
@@ -45,6 +45,8 @@
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/page-template">Page template</a></li>
 
+    <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/section-break">Section break</a></li>
+
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/spacing">Spacing</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/typography">Typography</a></li>

--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -36,6 +36,8 @@
 
     <li class="app-side-nav__item app-side-nav__item--current"><a class="app-side-nav__link" href="/design-system/styles/page-template">Page template</a></li>
 
+    <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/section-break">Section break</a></li>
+
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/spacing">Spacing</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/typography">Typography</a></li>

--- a/app/views/design-system/styles/section-break/default/index.njk
+++ b/app/views/design-system/styles/section-break/default/index.njk
@@ -1,0 +1,4 @@
+<hr class="nhsuk-section-break nhsuk-section-break--xl nhsuk-section-break--visible">
+<hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible">
+<hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
+<hr class="nhsuk-section-break nhsuk-section-break--visible">

--- a/app/views/design-system/styles/section-break/index.njk
+++ b/app/views/design-system/styles/section-break/index.njk
@@ -1,0 +1,27 @@
+{% set pageTitle = "Section break" %}
+{% set pageDescription = "You can use the section break to create a thematic break between sections of content." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Styles" %}
+{% set dateUpdated = "April 2024" %}
+{% set backlog_issue_id = "2" %}
+
+{% extends "includes/app-layout.njk" %}
+
+{% block breadcrumb %}
+  {% include "design-system/styles/_breadcrumb.njk" %}
+{% endblock %}
+
+{% block bodyContent %}
+
+<p>The section break has class-based modifiers for different size margins.</p>
+
+<p>By default <code>nhsuk-section-break</code> is only visible by its margin. You can add the <code>nhsuk-section-break--visible</code> class to make it visible with a separator line.</p>
+
+{{ designExample({
+  group: "styles",
+  item: "section-break",
+  type: "default",
+  htmlOnly: true
+}) }}
+
+{% endblock %}

--- a/app/views/design-system/styles/section-break/index.njk
+++ b/app/views/design-system/styles/section-break/index.njk
@@ -3,7 +3,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Styles" %}
 {% set dateUpdated = "April 2024" %}
-{% set backlog_issue_id = "2" %}
+{% set backlog_issue_id = "516" %}
 
 {% extends "includes/app-layout.njk" %}
 

--- a/app/views/design-system/styles/spacing/index.njk
+++ b/app/views/design-system/styles/spacing/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/design-system/styles/spacing/index.njk
+++ b/app/views/design-system/styles/spacing/index.njk
@@ -36,6 +36,8 @@
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/page-template">Page template</a></li>
 
+    <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/section-break">Section break</a></li>
+
     <li class="app-side-nav__item app-side-nav__item--current"><a class="app-side-nav__link" href="/design-system/styles/spacing">Spacing</a>
       <ul class="app-side-nav__list app-side-nav__list--nested">
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#spacing-scale">The responsive spacing scale</a></li>

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>
@@ -35,6 +27,8 @@
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/layout">Layout</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/page-template">Page template</a></li>
+
+    <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/scetion-break">Section break</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/spacing">Spacing</a></li>
 

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -81,6 +81,7 @@
   { title: "Icons", url: "/design-system/styles/icons" },
   { title: "Layout", url: "/design-system/styles/layout" },
   { title: "Page template", url: "/design-system/styles/page-template" },
+  { title: "Section break", url: "/design-system/styles/section-break" },
   { title: "Spacing", url: "/design-system/styles/spacing" },
   { title: "Typography", url: "/design-system/styles/typography" }
 ] %}

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -198,11 +198,6 @@
   {% endif %}
 
   {%- if subSection == "Styles" %}
-    {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in styles %}
@@ -212,11 +207,6 @@
   {% endif %}
 
   {%- if subSection == "Components" %}
-    {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Form elements</h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in formElements %}
@@ -240,11 +230,6 @@
   {% endif %}
 
   {%- if subSection == "Patterns" %}
-    {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Tasks</h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in askUsers %}
@@ -303,11 +288,6 @@
   {% endif %}
 
   {%- if subSection == "Health literacy" %}
-    {{ backLink({
-      "href": "/content/health-literacy",
-      "text": "Health literacy",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Health literacy <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in healthLiteracy %}

--- a/app/views/site-map.njk
+++ b/app/views/site-map.njk
@@ -69,6 +69,7 @@
             <li><a href="/design-system/styles/icons">Icons</a></li>
             <li><a href="/design-system/styles/layout">Layout</a></li>
             <li><a href="/design-system/styles/page-template">Page template</a></li>
+            <li><a href="/design-system/styles/section-break">Section break</a></li>
             <li><a href="/design-system/styles/spacing">Spacing</a></li>
             <li><a href="/design-system/styles/typography">Typography</a></li>
           </ul>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -29,6 +29,7 @@
     <tr>
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
+        <p>Added <a href="/design-system/styles/section-break">section break</a> to styles</p>
         <p>Added list of changes to meet new accessibility requirements to <a href="/design-system">design system</a></p>
         <p>Updated components and styles for WCAG 2.2:</p>
         <ul>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -23,7 +23,6 @@
     <tr>
       <td class="nhsuk-table__cell">Accessibility guidance</td>
       <td class="nhsuk-table__cell">
-        <p>Added <a href="/design-system/styles/section-break">section break</a> to styles</p>
         <p>Added <a href="/accessibility/new-accessibility-requirements-wcag-2-2">new accessibility requirements: WCAG 2.2</a></p>
         <p>Added sections on making sure your service meets WCAG 2.2 for: <a href="/accessibility/product-and-delivery">Product and delivery</a> and <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a> and <a href="/accessibility/testing">Testing</a></p>
       </td>
@@ -31,6 +30,7 @@
     <tr>
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
+        <p>Added <a href="/design-system/styles/section-break">section break</a> to styles</p>
         <p>Added list of changes to meet new accessibility requirements to <a href="/design-system">design system</a></p>
         <p>Updated components and styles for WCAG 2.2:</p>
         <ul>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -23,6 +23,7 @@
     <tr>
       <td class="nhsuk-table__cell">Accessibility guidance</td>
       <td class="nhsuk-table__cell">
+        <p>Added <a href="/design-system/styles/section-break">section break</a> to styles</p>
         <p>Added <a href="/accessibility/new-accessibility-requirements-wcag-2-2">new accessibility requirements: WCAG 2.2</a></p>
         <p>Added sections on making sure your service meets WCAG 2.2 for: <a href="/accessibility/product-and-delivery">Product and delivery</a> and <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a> and <a href="/accessibility/testing">Testing</a></p>
       </td>

--- a/middleware/page-index-additions.js
+++ b/middleware/page-index-additions.js
@@ -31,6 +31,7 @@ const additionalIndices = {
   '/design-system/patterns/reassure-users-that-a-page-is-up-to-date': ['review date, date updated'],
   '/design-system/styles/colour': ['palette'],
   '/design-system/styles/layout': ['grid'],
+  '/design-system/styles/section-break': ['divider line'],
   '/design-system/styles/spacing': ['margin, padding'],
   '/get-in-touch': ['contact, contact us, support, get in touch'],
   '/whats-new/blog-posts': ['news, updates'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nhsuk-service-manual",
-      "version": "6.2.0",
+      "version": "6.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "NHS digital service manual",
   "main": "app.js",
   "directories": {


### PR DESCRIPTION
## Description
- Added section break guidance to styles in the design system
- Removed back link from side nav (no need for it because of the breadcrumb)

### Related issue
https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/516

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
