### PR TITLE
TM-3174 responsive tables

### DIFF
--- a/app/views/accessibility/partials/use-tables-to-show-relationships-between-data.njk
+++ b/app/views/accessibility/partials/use-tables-to-show-relationships-between-data.njk
@@ -12,7 +12,7 @@
   <div class="nhsuk-details__text">
 
     <p>Here is an example from the <a href="/design-system/components/table">tables component</a> in the service manual.</p>
-      <table class="nhsuk-table nhsuk-table-responsive nhsuk-u-margin-bottom-5" role="table">
+      <table class="nhsuk-table nhsuk-table-responsive nhsuk-u-margin-bottom-5">
         <caption class="nhsuk-table__caption">Skin symptoms and possible causes</caption>
         <thead class="nhsuk-table__head" role="rowgroup">
           <tr class="nhsuk-table__row" role="row">

--- a/app/views/cookie-policy.njk
+++ b/app/views/cookie-policy.njk
@@ -37,7 +37,7 @@
       </summary>
       <div class="nhsuk-details__text">
 
-          <table class="nhsuk-table nhsuk-table-responsive" role="table">
+          <table class="nhsuk-table nhsuk-table-responsive">
             <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Cookie names and purposes</caption>
             <thead class="nhsuk-table__head" role="rowgroup">
               <tr class="nhsuk-table__row" role="row">
@@ -71,7 +71,7 @@
       </summary>
       <div class="nhsuk-details__text">
 
-          <table class="nhsuk-table nhsuk-table-responsive" role="table">
+          <table class="nhsuk-table nhsuk-table-responsive">
             <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Cookie names and purposes</caption>
             <thead class="nhsuk-table__head" role="rowgroup">
               <tr class="nhsuk-table__row" role="row">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
A recent accessibility audit raised an issue with some of our tables, flagging that their content overflows and runs out of the viewport. 

This PR addresses this by refactoring some of the tables in the service manual to make use of the responsive table styles from nhsuk-frontend. 

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
