### PR TITLE
Update radio with hint example to call fieldset correctly from radios

### DIFF
--- a/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
@@ -68,23 +68,25 @@
   <div class="app-example">
     <strong class="nhsuk-tag app-example__heading">Example</strong>
 
-    {% call fieldset({
-      legend: {
-        "text": "Do you know your NHS number?",
-        "classes": "nhsuk-fieldset__legend--m"
-      }
-      }) %}
-      {{ hint({
-        "text": "Your NHS number is a 10 digit number, like 485 777 3456.",
-        "classes": "nhsuk-u-margin-bottom-2"
-      }) }}
-      {{ hint({
-        "text": "You can find this on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
-      }) }}
-      {{ radios({
-        "idPrefix": "example-divider",
-        "name": "configStructure",
-        "items": [
+    {% set hintHtml -%}
+      <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
+      <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+    {%- endset %}
+
+    {{ radios({
+      "idPrefix": "example-hints",
+      "name": "example-hints",
+      "fieldset": {
+        "legend": {
+          "text": "Do you know your NHS number?",
+          "classes": "nhsuk-fieldset__legend--l",
+          "isPageHeading": true
+        }
+      },
+      "hint": {
+        "html": hintHtml
+      },
+      "items": [
       {
         "value": "yes",
         "text": "Yes, I know my NHS number"
@@ -94,12 +96,11 @@
         "text": "No, I do not know my NHS number"
       },
       {
-        "value": "unsure",
+        "value": "not sure",
         "text": "I'm not sure"
       }
     ]
     }) }}
-    {% endcall %}
   </div>
 
   <p>Having a 3rd option means that you can give people extra information, for example, about their NHS number and where to find it. Our pattern for <a href="/design-system/patterns/ask-users-for-their-nhs-number">asking users for their NHS number</a> explains more about this.</p>

--- a/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form.njk
@@ -76,23 +76,26 @@
 
   <div class="app-example">
     <strong class="nhsuk-tag app-example__heading">Example</strong>
-    {% call fieldset({
-      legend: {
-        "text": "Do you know your NHS number?",
-        "classes": "nhsuk-fieldset__legend--m"
-      }
-      }) %}
-      {{ hint({
-        "text": "This is a 10 digit number, like 485 777 3456.",
-        "classes": "nhsuk-u-margin-bottom-2"
-      }) }}
-      {{ hint({
-        "text": "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
-      }) }}
-      {{ radios({
-        "idPrefix": "example-divider",
-        "name": "configStructure",
-        "items": [
+
+    {% set hintHtml -%}
+      <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
+      <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+    {%- endset %}
+
+    {{ radios({
+      "idPrefix": "example-hints",
+      "name": "example-hints",
+      "fieldset": {
+        "legend": {
+          "text": "Do you know your NHS number?",
+          "classes": "nhsuk-fieldset__legend--l",
+          "isPageHeading": true
+        }
+      },
+      "hint": {
+        "html": hintHtml
+      },
+      "items": [
       {
         "value": "yes",
         "text": "Yes, I know my NHS number"
@@ -107,7 +110,6 @@
       }
     ]
     }) }}
-    {% endcall %}
   </div>
 
   <p>Good help text saves having to write <a href="#error-messages">error messages</a>.</p>

--- a/app/views/design-system/components/hint-text/radios/index.njk
+++ b/app/views/design-system/components/hint-text/radios/index.njk
@@ -2,24 +2,25 @@
 {% from 'fieldset/macro.njk' import fieldset %}
 {% from 'hint/macro.njk' import hint %}
 
-{% call fieldset({
-  legend: {
-    "text": "Do you know your NHS number?",
-    "classes": "nhsuk-fieldset__legend--l",
-    "isPageHeading": true
-  }
-  }) %}
-  {{ hint({
-    "text": "This is a 10 digit number, like 485 777 3456.",
-    "classes": "nhsuk-u-margin-bottom-2"
-  }) }}
-  {{ hint({
-    "text": "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
-  }) }}
-  {{ radios({
-    "idPrefix": "example-hints",
-    "name": "example-hints",
-    "items": [
+{% set hintHtml -%}
+  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
+  <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+{%- endset %}
+
+{{ radios({
+  "idPrefix": "example-hints",
+  "name": "example-hints",
+  "fieldset": {
+    "legend": {
+      "text": "Do you know your NHS number?",
+      "classes": "nhsuk-fieldset__legend--l",
+      "isPageHeading": true
+    }
+  },
+  "hint": {
+    "html": hintHtml
+  },
+  "items": [
   {
     "value": "yes",
     "text": "Yes, I know my NHS number"
@@ -34,4 +35,3 @@
   }
 ]
 }) }}
-{% endcall %}

--- a/app/views/design-system/components/radios/with-hints/index.njk
+++ b/app/views/design-system/components/radios/with-hints/index.njk
@@ -2,24 +2,25 @@
 {% from 'fieldset/macro.njk' import fieldset %}
 {% from 'hint/macro.njk' import hint %}
 
-{% call fieldset({
-  legend: {
-    "text": "Do you know your NHS number?",
-    "classes": "nhsuk-fieldset__legend--l",
-    "isPageHeading": true
-  }
-  }) %}
-  {{ hint({
-    "text": "This is a 10 digit number, like 485 777 3456.",
-    "classes": "nhsuk-u-margin-bottom-2"
-  }) }}
-  {{ hint({
-    "text": "You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service."
-  }) }}
-  {{ radios({
-    "idPrefix": "example-hints",
-    "name": "example-hints",
-    "items": [
+{% set hintHtml -%}
+  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
+  <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+{%- endset %}
+
+{{ radios({
+  "idPrefix": "example-hints",
+  "name": "example-hints",
+  "fieldset": {
+    "legend": {
+      "text": "Do you know your NHS number?",
+      "classes": "nhsuk-fieldset__legend--l",
+      "isPageHeading": true
+    }
+  },
+  "hint": {
+    "html": hintHtml
+  },
+  "items": [
   {
     "value": "yes",
     "text": "Yes, I know my NHS number"
@@ -34,4 +35,3 @@
   }
 ]
 }) }}
-{% endcall %}

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter-third/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter-third/index.njk
@@ -9,22 +9,24 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-    {% call fieldset({
-      legend: {
-        "text": "Do you know your NHS number?",
-        "classes": "nhsuk-fieldset__legend--l"
-      }
-      }) %}
-      {{ hint({
-        "html": "Your NHS number is a 10 digit number, like <span class=\"nhsuk-u-nowrap\">485 777 3456</span>.",
-        "classes": "nhsuk-u-margin-bottom-2"
-      }) }}
-      {{ hint({
-        "text": "You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service."
-      }) }}
+      {% set hintHtml -%}
+        <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
+        <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+      {%- endset %}
+
       {{ radios({
-        "idPrefix": "nhs-number",
-        "name": "nhs-number",
+        "idPrefix": "example-hints",
+        "name": "example-hints",
+        "fieldset": {
+          "legend": {
+            "text": "Do you know your NHS number?",
+            "classes": "nhsuk-fieldset__legend--l",
+            "isPageHeading": true
+          }
+        },
+        "hint": {
+          "html": hintHtml
+        },
         "items": [
         {
           "value": "yes",
@@ -35,15 +37,11 @@
           "text": "No, I do not know my NHS number"
         },
         {
-          "value": "unsure",
+          "value": "not sure",
           "text": "I'm not sure"
         }
       ]
       }) }}
-      {{ button({
-        "text": "Continue"
-      }) }}
-    {% endcall %}
 
    </div>
   </div>

--- a/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter/index.njk
+++ b/app/views/design-system/patterns/ask-users-for-their-nhs-number/filter/index.njk
@@ -9,37 +9,39 @@
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      {% call fieldset({
-        legend: {
-          "text": "Do you know your NHS number?",
-          "classes": "nhsuk-fieldset__legend--l"
-        }
-        }) %}
-        {{ hint({
-          "html": "Your NHS number is a 10 digit number, like <span class=\"nhsuk-u-nowrap\">485 777 3456</span>.",
-          "classes": "nhsuk-u-margin-bottom-2"
-        }) }}
-        {{ hint({
-          "text": "You can find it on any letter the NHS has sent you, on a prescription, or by logging in to a GP practice online service."
-        }) }}
-        {{ radios({
-          "idPrefix": "nhs-number",
-          "name": "nhs-number",
-          "items": [
-          {
-            "value": "yes",
-            "text": "Yes, I know my NHS number"
-          },
-          {
-            "value": "no",
-            "text": "No, I do not know my NHS number"
+      {% set hintHtml -%}
+        <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
+        <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+      {%- endset %}
+
+      {{ radios({
+        "idPrefix": "example-hints",
+        "name": "example-hints",
+        "fieldset": {
+          "legend": {
+            "text": "Do you know your NHS number?",
+            "classes": "nhsuk-fieldset__legend--l",
+            "isPageHeading": true
           }
-        ]
-        }) }}
-        {{ button({
-          "text": "Continue"
-        }) }}
-      {% endcall %}
+        },
+        "hint": {
+          "html": hintHtml
+        },
+        "items": [
+        {
+          "value": "yes",
+          "text": "Yes, I know my NHS number"
+        },
+        {
+          "value": "no",
+          "text": "No, I do not know my NHS number"
+        },
+        {
+          "value": "not sure",
+          "text": "I'm not sure"
+        }
+      ]
+      }) }}
 
     </div>
   </div>


### PR DESCRIPTION
## Description
The existing [radio with hint example](https://service-manual.nhs.uk/design-system/components/radios#radios-with-hints) uses `call` with Fieldset, which I think is an older pattern for using this component. By using it this way, the hint doesn't get semantically linked with the fieldset as it should. It also uses two separate divs for each line of the hint, which isn't the markup I would have expected.

This updates the example in all the places it exists to follow all the other radio examples.

I think there's a wider question of whether this hint is a bit long for an example, but for now I think it's better to update the macro so the correct markup for hints is shown.

### Related issue
Fixes #1962 

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
