### PR TITLE
Removes duplicate back links in side nav on design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+:wrench: **Maintenance**
+- Removed duplicate links in design system side navigation
+
 ## 6.3.0 – 17 April 2024
 :new: **New features**
 - Add page on new accessibility requirements: WCAG 2.2

--- a/app/styles/app/_side-nav.scss
+++ b/app/styles/app/_side-nav.scss
@@ -14,11 +14,6 @@
   }
 }
 
-.app-side-nav__back {
-  border-bottom: 1px solid $nhsuk-border-color;
-  padding-bottom: nhsuk-spacing(3);
-}
-
 .app-side-nav__list {
   @include nhsuk-font(16, $line-height: 1.3);
   margin-bottom: 0;

--- a/app/views/design-system/styles/layout/index.njk
+++ b/app/views/design-system/styles/layout/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/design-system/styles/spacing/index.njk
+++ b/app/views/design-system/styles/spacing/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -16,14 +16,6 @@
 
   <ul class="nhsuk-list app-side-nav__list">
 
-    <div class="nhsuk-back-link app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4">
-      <a class="nhsuk-back-link__link" href="/design-system">
-      <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-        <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-      </svg>
-      Design system</a>
-    </div>
-
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -197,11 +197,6 @@
   {% endif %}
 
   {%- if subSection == "Styles" %}
-    {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in styles %}
@@ -211,11 +206,6 @@
   {% endif %}
 
   {%- if subSection == "Components" %}
-    {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Form elements</h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in formElements %}
@@ -239,11 +229,6 @@
   {% endif %}
 
   {%- if subSection == "Patterns" %}
-    {{ backLink({
-      "href": "/design-system",
-      "text": "Design system",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Tasks</h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in askUsers %}
@@ -302,11 +287,6 @@
   {% endif %}
 
   {%- if subSection == "Health literacy" %}
-    {{ backLink({
-      "href": "/content/health-literacy",
-      "text": "Health literacy",
-      "classes": "app-u-hide-mobile app-side-nav__back nhsuk-u-margin-bottom-4"
-    }) }}
     <h2 class="app-side-nav__heading">Health literacy <span class="nhsuk-u-visually-hidden">navigation</span></h2>
     <ul class="nhsuk-list app-side-nav__list">
     {% for item in healthLiteracy %}

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -7,53 +7,26 @@
 
 {% block bodyContent %}
 
-<h2>Latest updates</h2>
+  <h2>Latest updates</h2>
 
-<h3>April 2024</h3>
-<table class="nhsuk-table">
-  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in April 2024</caption>
-  <thead class="nhsuk-table__head">
-    <tr class="nhsuk-table__row">
-      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
-      <th class="nhsuk-table__header" scope="col">Update</th>
-    </tr>
-  </thead>
-  <tbody class="nhsuk-table__body">
-    <tr>
-      <td class="nhsuk-table__cell">Accessibility guidance</td>
-      <td class="nhsuk-table__cell">
-        <p>Added <a href="/accessibility/new-accessibility-requirements-wcag-2-2">new accessibility requirements: WCAG 2.2</a></p>
-        <p>Added sections on making sure your service meets WCAG 2.2 for: <a href="/accessibility/product-and-delivery">Product and delivery</a> and <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a> and <a href="/accessibility/testing">Testing</a></p>
-      </td>
-    </tr>
-    <tr>
-      <td class="nhsuk-table__cell">Design system</td>
-      <td class="nhsuk-table__cell">
-        <p>Added list of changes to meet new accessibility requirements to <a href="/design-system">design system</a></p>
-        <p>Updated components and styles for WCAG 2.2:</p>
-        <ul>
-          <li><a href="/design-system/components/back-link">Back link</a>: guidance on positioning and keeping data the user has entered</li>
-          <li><a href="/design-system/components/breadcrumbs">Breadcrumbs</a>: guidance on positioning</li>
-          <li><a href="/design-system/components/buttons">Buttons</a>: guidance on minimum target size</li>
-          <li><a href="/design-system/components/error-message">Error message</a>: guidance on not clearing data the user has entered</li>
-          <li><a href="/design-system/components/footer">Footer</a>: guidance on placing help links</li>
-          <li><a href="/design-system/components/header">Header</a>: guidance on placing help links and not hiding content that has a focus applied</li>
-          <li><a href="/design-system/components/select">Select</a>: guidance on avoiding click and drag</li>
-          <li><a href="/design-system/components/summary-list">Summary list</a>: guidance on action link target size and keeping data the user has entered</li>
-          <li><a href="/design-system/components/tag">Tag</a>: guidance on avoiding click and drag</li>
-          <li><a href="/design-system/styles/focus-state">Focus state</a>: guidance on not hiding content that has a focus applied</li>
-          <li><a href="/design-system/styles/icons">Icons</a>: guidance on minimum target size</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td class="nhsuk-table__cell">Other</td>
-      <td class="nhsuk-table__cell">
-        <p>Updated <a href="/site-map">site map</a></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <h3>TBC 2024</h3>
+  <table class="nhsuk-table">
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in MONTH 2024</caption>
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+        <th class="nhsuk-table__header" scope="col">Update</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+      <tr>
+        <td class="nhsuk-table__cell">Design System</td>
+        <td class="nhsuk-table__cell">
+          <p>Removed duplicate links in design system side navigation</p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
   <p><a href="/whats-new/updates">See all updates</a></p>
 

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,9 +9,9 @@
 
   <h2>Latest updates</h2>
 
-  <h3>TBC 2024</h3>
+  <h3>April 2024</h3>
   <table class="nhsuk-table">
-    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in MONTH 2024</caption>
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in April 2024</caption>
     <thead class="nhsuk-table__head">
       <tr class="nhsuk-table__row">
         <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
@@ -20,9 +20,36 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr>
-        <td class="nhsuk-table__cell">Design System</td>
+        <td class="nhsuk-table__cell">Accessibility guidance</td>
         <td class="nhsuk-table__cell">
-          <p>Removed duplicate links in design system side navigation</p>
+          <p>Added <a href="/accessibility/new-accessibility-requirements-wcag-2-2">new accessibility requirements: WCAG 2.2</a></p>
+          <p>Added sections on making sure your service meets WCAG 2.2 for: <a href="/accessibility/product-and-delivery">Product and delivery</a> and <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a> and <a href="/accessibility/testing">Testing</a></p>
+        </td>
+      </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Design system</td>
+        <td class="nhsuk-table__cell">
+          <p>Added list of changes to meet new accessibility requirements to <a href="/design-system">design system</a></p>
+          <p>Updated components and styles for WCAG 2.2:</p>
+          <ul>
+            <li><a href="/design-system/components/back-link">Back link</a>: guidance on positioning and keeping data the user has entered</li>
+            <li><a href="/design-system/components/breadcrumbs">Breadcrumbs</a>: guidance on positioning</li>
+            <li><a href="/design-system/components/buttons">Buttons</a>: guidance on minimum target size</li>
+            <li><a href="/design-system/components/error-message">Error message</a>: guidance on not clearing data the user has entered</li>
+            <li><a href="/design-system/components/footer">Footer</a>: guidance on placing help links</li>
+            <li><a href="/design-system/components/header">Header</a>: guidance on placing help links and not hiding content that has a focus applied</li>
+            <li><a href="/design-system/components/select">Select</a>: guidance on avoiding click and drag</li>
+            <li><a href="/design-system/components/summary-list">Summary list</a>: guidance on action link target size and keeping data the user has entered</li>
+            <li><a href="/design-system/components/tag">Tag</a>: guidance on avoiding click and drag</li>
+            <li><a href="/design-system/styles/focus-state">Focus state</a>: guidance on not hiding content that has a focus applied</li>
+            <li><a href="/design-system/styles/icons">Icons</a>: guidance on minimum target size</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td class="nhsuk-table__cell">Other</td>
+        <td class="nhsuk-table__cell">
+          <p>Updated <a href="/site-map">site map</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,6 +10,25 @@
 
 {% block bodyContent %}
 
+<h2>TBC 2024</h2>
+<table class="nhsuk-table">
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in MONTH 2024</caption>
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+      <th class="nhsuk-table__header" scope="col">Update</th>
+    </tr>
+  </thead>
+  <tbody class="nhsuk-table__body">
+    <tr>
+      <td class="nhsuk-table__cell">Design System</td>
+      <td class="nhsuk-table__cell">
+        <p>Removed duplicate links in design system side navigation</p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <h2>April 2024</h2>
 <table class="nhsuk-table">
   <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in April 2024</caption>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,25 +10,6 @@
 
 {% block bodyContent %}
 
-<h2>TBC 2024</h2>
-<table class="nhsuk-table">
-  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in MONTH 2024</caption>
-  <thead class="nhsuk-table__head">
-    <tr class="nhsuk-table__row">
-      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
-      <th class="nhsuk-table__header" scope="col">Update</th>
-    </tr>
-  </thead>
-  <tbody class="nhsuk-table__body">
-    <tr>
-      <td class="nhsuk-table__cell">Design System</td>
-      <td class="nhsuk-table__cell">
-        <p>Removed duplicate links in design system side navigation</p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 <h2>April 2024</h2>
 <table class="nhsuk-table">
   <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in April 2024</caption>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
A mobile backlink was showing on the sidebar, even on desktop, it duplicates functionality from the breadcrumbs, so it's been removed.

| Before | After |
|--------|--------|
| ![image](https://github.com/nhsuk/nhsuk-service-manual/assets/159916913/094adcf4-a3be-419a-8f41-15bb8eefe650) | ![image](https://github.com/nhsuk/nhsuk-service-manual/assets/159916913/c91d5c32-71d4-46e6-aa82-4ecf160a23ea) |

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
