### PR TITLE
Remove unused import of 'iframeResize'

### DIFF
--- a/app/scripts/design-example.js
+++ b/app/scripts/design-example.js
@@ -1,7 +1,5 @@
 /* eslint-disable */
 
-import * as iframeResize from 'iframe-resizer/js/iframeResizer'
-
 class DesignExample {
 
     static selector() {


### PR DESCRIPTION
## Description
Remove unused import of 'iframeResize'

### Related issue
[TM-2995](https://nhsd-jira.digital.nhs.uk/browse/TM-2995)

## Checklist
- [X] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [N\A] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [N\A] CHANGELOG entry
- [N\A] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
