### PR TITLE
Use lowercase argument for inset text

### DIFF
--- a/app/views/design-system/components/inset-text/default/index.njk
+++ b/app/views/design-system/components/inset-text/default/index.njk
@@ -1,5 +1,5 @@
 {% from 'inset-text/macro.njk' import insetText %}
 
 {{ insetText({
-  "HTML": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
+  "html": "<p>You can report any suspected side effect to the <a href=\"https://yellowcard.mhra.gov.uk/\" title=\"External website\">UK safety scheme</a>.</p>"
 }) }}


### PR DESCRIPTION
## Description

Use a lowercase argument for html rather than uppercase. This goes alongside [this PR](https://github.com/nhsuk/nhsuk-frontend/pull/951) on NHS Frontend (released).