### PR TITLE
Use correct IDs on summary list docs

### DIFF
--- a/app/views/design-system/components/summary-list/index.njk
+++ b/app/views/design-system/components/summary-list/index.njk
@@ -55,7 +55,7 @@
     type: "default"
   }) }}
 
-  <h3 id="label-text-inputs">Summary list with actions</h3>
+  <h3 id="summary-list-with-actions">Summary list with actions</h3>
   <p>You can add actions to a summary list, like a "Change" link to let users go back and edit their answer.</p>
   
   <div class="nhsuk-inset-text app-wcag-inset-text app-wcag-22" id="wcag-interact-row-actions" role="note">
@@ -84,7 +84,7 @@
     type: "default"
   }) }}
 
-  <h3 id="label-text-inputs">Summary list without actions</h3>
+  <h3 id="summary-list-without-actions">Summary list without actions</h3>
 
   {{ designExample({
     group: "components",
@@ -92,7 +92,7 @@
     type: "without-action"
   }) }}
 
-  <h3 id="label-text-inputs">Summary list without actions or borders</h3>
+  <h3 id="summary-list-without-actions-or-borders">Summary list without actions or borders</h3>
   <p class="rich-text">If you do not include actions in your summary list and it would be better for your design to remove the separating borders, use the <code>nhsuk-summary-list--no-border</code> class.</p>
 
   {{ designExample({


### PR DESCRIPTION
## Description
The IDs used in the summary list headings seem to relate to another page. This updates them to match the heading text.