### PR TITLE
Update page template examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+:wrench: **Maintenance**
+- Update page template examples to make the default example size l and inside the grid system
+
 ## 6.3.0 – 17 April 2024
 :new: **New features**
 - Add page on new accessibility requirements: WCAG 2.2

--- a/app/views/design-system/styles/page-template/content/index.njk
+++ b/app/views/design-system/styles/page-template/content/index.njk
@@ -56,7 +56,7 @@
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h1>
+      <h1 class="nhsuk-heading-xl">
         Content page template
       </h1>
     </div>

--- a/app/views/design-system/styles/page-template/default/index.njk
+++ b/app/views/design-system/styles/page-template/default/index.njk
@@ -1,5 +1,11 @@
 {% extends "includes/template.njk" %}
 
 {% block content %}
-  <h1>Default page template</h1>
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-l">
+        Default page template
+      </h1>
+    </div>
+  </div>
 {% endblock %}

--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -78,6 +78,8 @@
 
   <p>The content page template example includes navigation and search in the <a href="/design-system/components/header">header</a> and a <a href="/design-system/components/back-link">breadcrumbs</a> component.</p>
 
+  <p>The <code>{{ "<h1>" | escape }}</code> uses a class of <code>.nhsuk-heading-xl</code> as content pages are often have more content than transactional pages and may have need for more heading sizes.</p>
+
   {{ designExample({
     group: "styles",
     item: "page-template",


### PR DESCRIPTION
## Description
Related to #1974, this makes a few updates to the page template examples:
* Make the default example use `nhsuk-heading-l` and put it inside a 2/3 column grid.
* Add some guidance about using `nhsuk-heading-xl` to the content page example

Fixes #1969 

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
