### PR TITLE
Remove mini hub symptoms link

### DIFF
--- a/app/views/design-system/patterns/mini-hub/example/index.njk
+++ b/app/views/design-system/patterns/mini-hub/example/index.njk
@@ -41,7 +41,7 @@
             current: "true"
           },
           {
-            href: "/design-example/patterns/mini-hub/example-symptoms?fullpage=true",
+            href: "#",
             text: "Symptoms"
           },
           {
@@ -74,7 +74,7 @@
       </p>
 
       {{ pagination({
-        "nextUrl": "/design-example/patterns/mini-hub/example-symptoms?fullpage=true",
+        "nextUrl": "#",
         "nextPage": "Symptoms"
       }) }}
 


### PR DESCRIPTION
## Description
This link is coded href="/design-example/patterns/mini-hub/example-symptoms?fullpage=true"while it should be href="#".


## Checklist
- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
