### PR TITLE
Add guidance for headings with captions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+:wrench: **Maintenance**
+- Add guidance for using headings with captions
+
+
 ## 6.3.0 – 17 April 2024
 :new: **New features**
 - Add page on new accessibility requirements: WCAG 2.2

--- a/app/views/design-system/styles/typography/headings-with-caption-inside/index.njk
+++ b/app/views/design-system/styles/typography/headings-with-caption-inside/index.njk
@@ -1,0 +1,4 @@
+<h1 class="nhsuk-heading-l">
+  <span class="nhsuk-caption-l">nhsuk-caption-l</span>
+  nhsuk-heading-l
+</h1>

--- a/app/views/design-system/styles/typography/headings-with-caption/index.njk
+++ b/app/views/design-system/styles/typography/headings-with-caption/index.njk
@@ -1,0 +1,8 @@
+<span class="nhsuk-caption-xl">nhsuk-caption-xl</span>
+<h1 class="nhsuk-heading-xl">nhsuk-heading-xl</h1>
+
+<span class="nhsuk-caption-l">nhsuk-caption-l</span>
+<h1 class="nhsuk-heading-l">nhsuk-heading-l</h1>
+
+<span class="nhsuk-caption-m">nhsuk-caption-m</span>
+<h1 class="nhsuk-heading-m">nhsuk-heading-m</h1>

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -90,7 +90,7 @@
     htmlOnly: true
   }) }}
 
-  <p>If the caption should be considered part of the page heading, you can also nest the caption within the <code>{{ "<h1>" | escape }}</code>.</p>
+  <p>If the caption should be considered part of the page heading, you can also nest the caption within the <code>{{ "<h1>" | escape }}</code>, using the appropriate heading and caption classes.</p>
 
   {{ designExample({
     group: "styles",

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -79,6 +79,26 @@
     htmlOnly: true
   }) }}
 
+  <h2 id="headings-with-captions">Headings with captions</h2>
+
+  <p>Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption above or below it.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "typography",
+    type: "headings-with-caption",
+    htmlOnly: true
+  }) }}
+
+  <p>If the caption should be considered part of the page heading, you can also nest the caption within the <code>{{ "<h1>" | escape }}</code>.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "typography",
+    type: "headings-with-caption-inside",
+    htmlOnly: true
+  }) }}
+
   <h2 id="paragraphs">Paragraphs</h2>
 
   <h3 id="body">Body</h3>

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -79,7 +79,7 @@
     htmlOnly: true
   }) }}
 
-  <h2 id="headings-with-captions">Headings with captions</h2>
+  <h3 id="headings-with-captions">Headings with captions</h3>
 
   <p>Sometimes you may need to make it clear that a page is part of a larger section or group. To do this, you can use a heading with a caption above or below it.</p>
 


### PR DESCRIPTION
## Description
Adds guidance for using headings with captions. The content is copied from GOV.UK but I've noted captions can be used below the heading (example) as well as above.

There might want to be some future work looking at the margins where it's used below the heading - but I think a good start is to document what we have and have parity with GOV.UK.

![Screenshot 2024-05-28 at 11 07 40](https://github.com/nhsuk/nhsuk-service-manual/assets/2204224/be44f41c-09ed-49bc-8e53-309e9d5ebf67)

### Related issue
[Existing backlog issue](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/178)

## Checklist
- [x] CHANGELOG entry

