### PR TITLE
Mention nhsuk-javascript does the focusing of the error summary

### DIFF
--- a/app/views/design-system/components/error-summary/index.njk
+++ b/app/views/design-system/components/error-summary/index.njk
@@ -29,7 +29,7 @@
     <ul>
       <li class="rich-text">add "Error: " to the beginning of the <code>&lt;title&gt;</code> so screen readers read it out as soon as possible</li>
       <li>show an error summary at the top of a page</li>
-      <li>move the keyboard focus to the error summary (the NHS.UK frontend javascript will do this for you)</li>
+      <li>move the keyboard focus to the error summary (the NHS.UK frontend JavaScript will do this for you)</li>
       <li>include the heading "There is a problem"</li>
       <li>link to each of the answers that have validation errors</li>
       <li>show the same error messages next to the inputs with errors</li>

--- a/app/views/design-system/components/error-summary/index.njk
+++ b/app/views/design-system/components/error-summary/index.njk
@@ -29,7 +29,7 @@
     <ul>
       <li class="rich-text">add "Error: " to the beginning of the <code>&lt;title&gt;</code> so screen readers read it out as soon as possible</li>
       <li>show an error summary at the top of a page</li>
-      <li>move the keyboard focus to the error summary</li>
+      <li>move the keyboard focus to the error summary (the nhsuk-frontend javascript will do this for you)</li>
       <li>include the heading "There is a problem"</li>
       <li>link to each of the answers that have validation errors</li>
       <li>show the same error messages next to the inputs with errors</li>

--- a/app/views/design-system/components/error-summary/index.njk
+++ b/app/views/design-system/components/error-summary/index.njk
@@ -29,7 +29,7 @@
     <ul>
       <li class="rich-text">add "Error: " to the beginning of the <code>&lt;title&gt;</code> so screen readers read it out as soon as possible</li>
       <li>show an error summary at the top of a page</li>
-      <li>move the keyboard focus to the error summary (the nhsuk-frontend javascript will do this for you)</li>
+      <li>move the keyboard focus to the error summary (the NHS.UK frontend javascript will do this for you)</li>
       <li>include the heading "There is a problem"</li>
       <li>link to each of the answers that have validation errors</li>
       <li>show the same error messages next to the inputs with errors</li>


### PR DESCRIPTION
## Description
The guidance for errorSummary says that you need to focus the error summary on page load - but doesn't mention that the nhsuk-frontend javascript will do this for you - most services shouldn't need to do anything. Adding this text should hopefully make that clearer.