### PR TITLE
Revert "Remove unused import of 'iframeResize'"

### DIFF
--- a/app/scripts/design-example.js
+++ b/app/scripts/design-example.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 
+import * as iframeResize from 'iframe-resizer/js/iframeResizer'
+
 class DesignExample {
 
     static selector() {


### PR DESCRIPTION
Reverts nhsuk/nhsuk-service-manual#1968

This broke the autoresizing of the design examples. I've tested by restoring it locally and checking they now work.