### PR TITLE
Scope width overrides

### DIFF
--- a/app/styles/app/_container.scss
+++ b/app/styles/app/_container.scss
@@ -20,15 +20,13 @@ $service-manual-container-size: 1100px;
 
 // Apply container size to header and footer components
 
-.nhsuk-header__navigation-list {
-  max-width: $service-manual-container-size;
+.app-header__container {
+  .nhsuk-header__container, .nhsuk-header__navigation-list {
+    max-width: $service-manual-container-size;
+  }
 }
 
-.nhsuk-header__container {
-  max-width: $service-manual-container-size;
-}
-
-.nhsuk-footer-container {
+.app-footer__container {
   .nhsuk-width-container {
     max-width: $service-manual-container-size;
   }

--- a/app/styles/app/_container.scss
+++ b/app/styles/app/_container.scss
@@ -21,7 +21,8 @@ $service-manual-container-size: 1100px;
 // Apply container size to header and footer components
 
 .app-header__container {
-  .nhsuk-header__container, .nhsuk-header__navigation-list {
+  .nhsuk-header__container,
+  .nhsuk-header__navigation-list {
     max-width: $service-manual-container-size;
   }
 }

--- a/app/views/includes/_footer.njk
+++ b/app/views/includes/_footer.njk
@@ -1,5 +1,5 @@
 <footer role="contentinfo">
-  <div class="nhsuk-footer-container">
+  <div class="app-footer__container nhsuk-footer-container">
     <div class="nhsuk-width-container">
       <h2 class="nhsuk-u-visually-hidden">Support links</h2>
       <ul class="nhsuk-footer__list">

--- a/app/views/includes/_header.njk
+++ b/app/views/includes/_header.njk
@@ -8,6 +8,7 @@
       "name": "Digital service manual",
       "longName": "true"
     },
+    "classes": "app-header__container",
     "showNav": "true",
     "showSearch": "false",
     "searchAction": "/search/",
@@ -44,6 +45,7 @@
       "name": "Digital service manual",
       "longName": "true"
     },
+    "classes": "app-header__container",
     "showNav": "true",
     "showSearch": "true",
     "searchAction": "/search/",


### PR DESCRIPTION
## Description
The service manual overrides the default page width - in some cases styling existing design system classes, in some cases scoping them under app specific classes.

This causes pages to look out of alignment in the page templates section:

![Screenshot 2024-06-18 at 16 04 53](https://github.com/nhsuk/nhsuk-service-manual/assets/2204224/324a9881-38ba-41af-b8cc-21dbc336fcf5)

This adds extra scoping so the revised width is only used where an app specific class is used. This is added to the service manual header and footer, but doesn't get used by the page template examples so those now look correct.

Arguably a better solution might be for nhs-frontend to support setting the page width like GOV.UK does - that could come as a followup pr.