### PR TITLE
Document black sass colour

### DIFF
--- a/app/views/design-system/styles/colour/index.njk
+++ b/app/views/design-system/styles/colour/index.njk
@@ -287,6 +287,16 @@
 
       <tr class="app-colour-list__row">
         <th class="app-colour-list__column app-colour-list__column--name" scope="row">
+          <span class="app-colour-list__swatch" style="background-color:#212b32"></span>
+          <code>$color_nhsuk-black</code>
+        </th>
+        <td class="app-colour-list__column app-colour-list__column--colour">
+          #212b32
+        </td>
+      </tr>
+
+      <tr class="app-colour-list__row">
+        <th class="app-colour-list__column app-colour-list__column--name" scope="row">
           <span class="app-colour-list__swatch" style="background-color:#4c6272"></span>
           <code>$color_nhsuk-grey-1</code>
         </th>


### PR DESCRIPTION
## Description
`$color_nhsuk-black` is NHSUK-Frontend, but doesn't seem to be documented in the design system. I assume this is a mistake. This PR adds it in.

![Screenshot 2024-07-09 at 14 22 05](https://github.com/nhsuk/nhsuk-service-manual/assets/2204224/ab213998-51d6-4876-a668-ce2acaba42ae)
