### PR TITLE
fix app-header__container bug

### DIFF
--- a/app/styles/app/_container.scss
+++ b/app/styles/app/_container.scss
@@ -25,6 +25,10 @@ $service-manual-container-size: 1100px;
   .nhsuk-header__navigation-list {
     max-width: $service-manual-container-size;
   }
+
+  @media (min-width: 1024px) and (max-width: 1164px) {
+    padding: 0 nhsuk-spacing(5);
+  }
 }
 
 .app-footer__container {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix layout bug with header

Before:
![image](https://github.com/user-attachments/assets/069f7b53-061a-49c2-a308-e5176901aea4)
After: 
![image](https://github.com/user-attachments/assets/19b26786-643a-4322-bbba-9d6752774532)


Adds media query to add missing padding for screens over 1024px wide until padding is no longer needed. 
### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
