### PR TITLE
Remove same page profession links in accessibility section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 :wrench: **Maintenance**
-- Remove same page profession links from accessibility section
+- Remove same-page profession links from accessibility section
 
 ## 7.3.0 - 17 December 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:wrench: **Maintenance**
+- Remove same page profession links from accessibility section
+
 ## 7.3.0 - 17 December 2024
 
 :wrench: **Maintenance**

--- a/app/views/accessibility/partials/ask-questions-at-the-start-of-the-project.njk
+++ b/app/views/accessibility/partials/ask-questions-at-the-start-of-the-project.njk
@@ -1,5 +1,4 @@
 <h2 id="ask-questions-at-the-start-of-the-project">Ask questions at the start of the project</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/product-and-delivery">Product and delivery</a></p>
 <p>Ask yourself:</p>
 <ul>
   <li>how your project will affect people with access needs</li>

--- a/app/views/accessibility/partials/avoid-accessibility-overlays-or-widgets.njk
+++ b/app/views/accessibility/partials/avoid-accessibility-overlays-or-widgets.njk
@@ -1,6 +1,4 @@
 <h2 id="do-not-use-accessibility-overlays-or-widgets">Avoid accessibility widgets</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a></p>
-
 <p>Accessibility widgets are plugins that display as buttons, toolbars or overlays.</p>
 <p>The widgets let users adapt the display to make it easier to read the text or have it read out to them. Some widget providers claim they make your website accessible.</p>
 

--- a/app/views/accessibility/partials/check-autocomplete-in-forms.njk
+++ b/app/views/accessibility/partials/check-autocomplete-in-forms.njk
@@ -1,5 +1,4 @@
 <h2 id="check-autocomplete-in-forms">Check autocomplete in forms</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>If you need information only from the person who is filling the form, make sure it has the autocomplete attribute.</p>
 <p>The <a href="https://www.w3.org/TR/html52/sec-forms.html#sec-autofill">W3C autofill table</a> tells you which attribute to use for each type of form field.</p>
 <p>If the form can be filled in for someone else, this isn't necessary.</p>

--- a/app/views/accessibility/partials/check-colour-contrast.njk
+++ b/app/views/accessibility/partials/check-colour-contrast.njk
@@ -1,5 +1,4 @@
 <h2 id="check-colour-contrast">Check colour contrast</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>It's easier for people to read and interact with content if you use colours that contrast well. The NHS meets at least level AA for contrast and we aim for AAA where possible.</p>
 <p>Find out more about colour contrast in the <a href="/design-system/styles/colour#accessibility">accessibility section of the colour page</a> in the design system.</p>
 

--- a/app/views/accessibility/partials/check-flashes-and-animation.njk
+++ b/app/views/accessibility/partials/check-flashes-and-animation.njk
@@ -1,5 +1,4 @@
 <h2 id="check-flashes-and-animation">Check flashes and animation</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Make sure that users can pause, hide or stop anything that moves, blinks or scrolls automatically and lasts more than 5 seconds.</p>
 <p>Pages should not contain anything that flashes more than 3 times in any 1 second. Or the flash should be below the general flash and red flash thresholds.</p>
 <p>Read more about the <a href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html">3 flashes or below threshold</a> on the W3C website.</p>

--- a/app/views/accessibility/partials/check-keyboard-accessibility.njk
+++ b/app/views/accessibility/partials/check-keyboard-accessibility.njk
@@ -1,5 +1,4 @@
 <h2 id="check-keyboard-accessibility">Check keyboard accessibility</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Keyboard accessibility is one of the most important parts of accessibility. It enables other input methods, including switches, speech input and screen readers.</p>
 <p>The starting point for keyboard accessibility is to use the correct HTML for links, buttons and form controls. Use <a href="/design-system/components">components from the service manual</a>, if you can. They've already been tested for keyboard accessibility.</p>
 

--- a/app/views/accessibility/partials/check-orientation-is-not-locked.njk
+++ b/app/views/accessibility/partials/check-orientation-is-not-locked.njk
@@ -1,4 +1,3 @@
 <h2 id="check-orientation-is-not-locked">Check orientation is not locked</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Use a mobile device and switch from portrait to landscape and back again. You should be able to see all the content and functionality.</p>
 

--- a/app/views/accessibility/partials/check-that-accessibility-is-done.njk
+++ b/app/views/accessibility/partials/check-that-accessibility-is-done.njk
@@ -1,5 +1,4 @@
 <h2 id="check-that-accessibility-is-done">Check that accessibility is "done"</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/product-and-delivery">Product and delivery</a></p>
 <p>It's the product or delivery manager's responsibility to make sure that the product or service is accessible. In most cases it's a matter of making sure that the team is checking their work as they go along.</p>
 <p>If in doubt, <a href="#ask-questions-at-the-start-of-the-project">ask questions early</a>. The sooner you consider accessibility requirements, the easier it is.</p>
 

--- a/app/views/accessibility/partials/define-focus-styles.njk
+++ b/app/views/accessibility/partials/define-focus-styles.njk
@@ -1,5 +1,4 @@
 <h2 id="define-focus-styles">Define focus styles</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a></p>
 <p>Everyone should be able to access all interactive components with a keyboard or a similar device. It must be obvious to them which element or link is the current focus position on the page. The browser default is generally not good enough.</p>
 <p>Make sure that the focus is clearly visible. You can do this by adding something, like an outline or icon, or changing the colour of part of the component. <a href="#check-colour-contrast">Check the colour contrast</a>.</p>
 <p>We recommend <a href="/design-system/styles/focus-state">the focus state styles</a> in the service manual.</p>

--- a/app/views/accessibility/partials/define-page-structure.njk
+++ b/app/views/accessibility/partials/define-page-structure.njk
@@ -1,5 +1,4 @@
 <h2 id="define-page-structure">Define page structure</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>You can help people who use assistive technologies understand the structure of the page and navigate it by including "landmarks" (hidden labels for sections of the page). Landmarks also help users looking at multiple pages skip repetitive sections.</p>
 <p>Use ARIA landmarks to identify the regions of a page.</p>
 

--- a/app/views/accessibility/partials/define-skip-links.njk
+++ b/app/views/accessibility/partials/define-skip-links.njk
@@ -1,5 +1,4 @@
 <h2 id="define-skip-links">Define skip links</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Use a skip link to help keyboard-only users skip to the main content on a page.</p>
 <p>Also add a skip link at the start of a long list of links or form fields (for example, over 20 checkboxes in a filter). This lets people who use keyboard-style access with a switch or head-wand skip to the end and avoid having to keep pressing the same key.</p>
 <p>Skip links can be invisible by default, but must be very visible when focused.</p>

--- a/app/views/accessibility/partials/discuss-any-custom-components.njk
+++ b/app/views/accessibility/partials/discuss-any-custom-components.njk
@@ -1,5 +1,4 @@
 <h2 id="discuss-any-custom-components">Discuss any custom components</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a></p>
 <p>The <a href="/design-system/components">components in the service manual</a> are well tested and ready to use. Before you design a new component, please test an existing component and show that there's a clear need for something new.</p>
 <p>Discuss any new components with other members of your team. You need to make sure that:</p>
 <ul>

--- a/app/views/accessibility/partials/do-not-add-keyboard-shortcuts.njk
+++ b/app/views/accessibility/partials/do-not-add-keyboard-shortcuts.njk
@@ -1,5 +1,4 @@
 <h2 id="do-not-add-keyboard-shortcuts">Do not add keyboard shortcuts</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Do not use single letter keyboard shortcuts. (Gmail, for example, uses the "j" and "k" keys to move between emails.)</p>
 <p>Keyboard shortcuts which use single numbers, punctuation, lowercase letters, uppercase letters or symbol characters can interfere with voice input software.</p>
 

--- a/app/views/accessibility/partials/do-not-include-text-in-images.njk
+++ b/app/views/accessibility/partials/do-not-include-text-in-images.njk
@@ -1,5 +1,4 @@
 <h2 id="do-not-include-text-in-images">Do not include text in images</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Users need as much information as possible in text format, so that they can adjust its size, spacing or formatting.</p>
 <p>Do not include text in graphical (raster) formats like PNG, JPEG or GIF. They do not work well when users zoom in. Instead put text in HTML (styled with CSS) or use SVG.</p>
 <p>This does not apply to logos.</p>

--- a/app/views/accessibility/partials/do-not-override-visible-labels.njk
+++ b/app/views/accessibility/partials/do-not-override-visible-labels.njk
@@ -1,4 +1,3 @@
 <h2 id="do-not-override-visible-labels">Do not override visible labels</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Make sure that ARIA or HTML labels for buttons, links or anchors match or contain the same words as visible labels. That applies whether the visible label is in text or an image of text.</p>
 

--- a/app/views/accessibility/partials/do-not-play-audio-automatically.njk
+++ b/app/views/accessibility/partials/do-not-play-audio-automatically.njk
@@ -1,4 +1,3 @@
 <h2 id="do-not-play-audio-automatically">Do not play audio automatically</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Audio must not play automatically for more than 3 seconds. It makes it hard for people to hear their screen reader.</p>
 

--- a/app/views/accessibility/partials/do-not-rely-on-colour-or-position-alone.njk
+++ b/app/views/accessibility/partials/do-not-rely-on-colour-or-position-alone.njk
@@ -1,5 +1,4 @@
 <h2 id="do-not-rely-on-colour-or-position-alone">Do not rely on colour or position alone</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Do not rely on colour to convey meaning, for example, an instruction. To communicate with people who cannot see well or distinguish colours, you may need to:</p>
 <ul>
   <li>word things differently</li>

--- a/app/views/accessibility/partials/do-not-rely-on-motion-sensors.njk
+++ b/app/views/accessibility/partials/do-not-rely-on-motion-sensors.njk
@@ -1,5 +1,4 @@
 <h2 id="do-not-rely-on-motion-sensors">Do not rely on motion sensors</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>If you have any functionality that is triggered by device or user motion (like shaking or tilting), you must provide another way for users to activate it. For example, let the user press a button.</p>
 <p>Also make sure that users can disable motion actions.</p>
 

--- a/app/views/accessibility/partials/do-not-rely-on-touch-gestures.njk
+++ b/app/views/accessibility/partials/do-not-rely-on-touch-gestures.njk
@@ -1,5 +1,4 @@
 <h2 id="do-not-rely-on-touch-gestures">Do not rely on touch gestures</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Do not rely on touch, even for interfaces designed for touch screens. You can use touch gestures but you need a standard fallback.</p>
 <p>For example, if you swipe between images, you also need a button that does the same thing for people using switch access or screen readers.</p>
 

--- a/app/views/accessibility/partials/do-not-trigger-pop-ups-by-hover-or-focus.njk
+++ b/app/views/accessibility/partials/do-not-trigger-pop-ups-by-hover-or-focus.njk
@@ -1,5 +1,4 @@
 <h2 id="do-not-trigger-pop-ups-by-hover-or-focus">Do not trigger pop-ups by hover or focus</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Do not trigger additional content by mouse hover or keyboard focus. It causes problems for people using zoom or a screen magnifier.</p>
 <p>If you use 3rd party content which does this, make sure you give users a way to dismiss the content without moving the mouse or focus. For example, use the ESC key.</p>
 

--- a/app/views/accessibility/partials/do-not-use-onkeydown-or-onmousedown-for-links-and-buttons.njk
+++ b/app/views/accessibility/partials/do-not-use-onkeydown-or-onmousedown-for-links-and-buttons.njk
@@ -1,4 +1,3 @@
 <h2 id="do-not-use-onkeydown-or-onmousedown-for-links-and-buttons">Do not use "onkeydown" or "onmousedown" for links and buttons</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>For interactive elements, only trigger actions once the user takes their finger or pointer away from the activation target. This gives users a chance to cancel or avoid activating the trigger.</p>
 

--- a/app/views/accessibility/partials/for-small-or-specialist-user-groups-focus-on-testing-the-interface.njk
+++ b/app/views/accessibility/partials/for-small-or-specialist-user-groups-focus-on-testing-the-interface.njk
@@ -1,5 +1,4 @@
 <h2 id="for-small-or-specialist-user-groups-focus-on-testing-the-interface">For small or specialist user groups, focus on testing the interface</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>It can be difficult to find people in small or specialist target audiences who also have access needs. In that case, focus on testing the interface with people with access needs.</p>
 
 <details class="nhsuk-details">

--- a/app/views/accessibility/partials/give-users-time-to-read-and-act.njk
+++ b/app/views/accessibility/partials/give-users-time-to-read-and-act.njk
@@ -1,5 +1,4 @@
 <h2 id="give-users-time-to-read-and-act">Give users time to read and act</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>If you have set a time limit for inactivity (for example, on a multi-step form), make it at least 20 hours.</p>
 <p>If you use 3rd party content that has a time limit, it should warn users clearly how much time they have left and let them extend or turn off the time limit.</p>
 <p>There are exceptions to this when the time limit is essential, for  example, for an online test or real-time event.</p>

--- a/app/views/accessibility/partials/highlight-errors-in-forms.njk
+++ b/app/views/accessibility/partials/highlight-errors-in-forms.njk
@@ -1,5 +1,4 @@
 <h2 id="highlight-errors-in-forms">Highlight errors in forms</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Make sure that error messages clearly describe what went wrong and how to fix the problem.</p>
 <p>Include an error message wherever there's a problem with the input and check that it's visibly obvious that the message is connected to that input.</p>
 <p>If you have an error summary at the top of a form, check that each error in the list has a link that moves the focus to the relevant form field. This helps users who rely on keyboard navigation.</p>

--- a/app/views/accessibility/partials/identify-target-groups-and-accessibility-challenges.njk
+++ b/app/views/accessibility/partials/identify-target-groups-and-accessibility-challenges.njk
@@ -1,5 +1,4 @@
 <h2 id="identify-target-groups-and-accessibility-challenges">Identify target groups and accessibility challenges</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>In the discovery part of the project, you need to understand how it will affect people with access needs. Consider:</p>
 <ul>
   <li>whether it will cause particular accessibility challenges, for example for people who can't read text</li>

--- a/app/views/accessibility/partials/involve-people-with-access-needs-at-every-stage.njk
+++ b/app/views/accessibility/partials/involve-people-with-access-needs-at-every-stage.njk
@@ -1,5 +1,4 @@
 <h2 id="involve-people-with-access-needs-at-every-stage">Involve people with access needs at every stage</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>In the UK, almost 1 in 5 people have a disability of some kind. Many more have a temporary impairment like an illness or injury. Try to include 1 person with access needs in every 5 people you research with.</p>
 <p>Involving people with access needs in user research doesn't just help identify accessibility issues. It shows up general issues that affect everyone.</p>
 

--- a/app/views/accessibility/partials/label-form-fields-clearly.njk
+++ b/app/views/accessibility/partials/label-form-fields-clearly.njk
@@ -1,5 +1,4 @@
 <h2 id="label-form-fields-clearly">Label form fields clearly</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Make sure that every form field has a label that tells users what information they need to enter.</p>
 
 <details class="nhsuk-details">

--- a/app/views/accessibility/partials/look-after-your-team.njk
+++ b/app/views/accessibility/partials/look-after-your-team.njk
@@ -1,5 +1,4 @@
 <h2 id="look-after-your-team">Look after your team</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>It's important that the team supports one another. User research in health can be tiring and emotional. Sometimes users might tell you stories that are hard to hear or you might see them struggle.</p>
 <p>It's OK to take some time out during a day of research or, as a user researcher, to ask for someone to stand in for you.</p>
 <p>Check in with your team mates during and after research and take time to reflect together.</p>

--- a/app/views/accessibility/partials/make-sure-everyone-knows-their-responsibilities.njk
+++ b/app/views/accessibility/partials/make-sure-everyone-knows-their-responsibilities.njk
@@ -1,4 +1,3 @@
 <h2 id="make-sure-everyone-knows-their-responsibilities">Make sure everyone knows their responsibilities</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/product-and-delivery">Product and delivery</a></p>
 <p>Make sure everyone in the team knows what they need to do and is checking their work, using the guidance for different activities.</p>
 <p>If a team member doesn't have a basic understanding already, help them <a href="/accessibility/getting-started">get started with accessibility</a>.</p>

--- a/app/views/accessibility/partials/make-sure-navigation-is-consistent.njk
+++ b/app/views/accessibility/partials/make-sure-navigation-is-consistent.njk
@@ -1,5 +1,4 @@
 <h2 id="make-sure-navigation-is-consistent">Make sure navigation is consistent</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Identify any navigational mechanisms (navigation bars, search fields, and skip links) that appear on multiple pages.</p>
 <p>Check that the links or buttons are presented in the same order each time they appear, even if other items are removed or added between them.</p>
 <p>If the navigation is defined by templates, you only need to check 1 or 2 pages.</p>

--- a/app/views/accessibility/partials/make-sure-your-service-meets-wcag-2-2.njk
+++ b/app/views/accessibility/partials/make-sure-your-service-meets-wcag-2-2.njk
@@ -1,6 +1,4 @@
 <h2 id="make-sure-your-service-meets-wcag-2-2">Make sure your service meets WCAG 2.2</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a>, <a href="/accessibility/product-and-delivery">Product and delivery</a>, <a href="/accessibility/testing">Testing</a></p>
-
 <p>
     <strong class="nhsuk-tag">
         WCAG 2.2

--- a/app/views/accessibility/partials/make-users-aware-of-status-updates-away-from-current-focus.njk
+++ b/app/views/accessibility/partials/make-users-aware-of-status-updates-away-from-current-focus.njk
@@ -1,5 +1,4 @@
 <h2 id="make-users-aware-of-status-updates-away-from-current-focus">Make users aware of status updates away from current focus</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>Make screen reader users aware of important changes in content during an action in a way that does not interrupt their journey.</p>
 <p>If you need to let users know the results of an action (for example, updated search results or that they have successfully submitted a form), convey this information programmatically.</p>
 

--- a/app/views/accessibility/partials/make-video-and-other-multimedia-content-accessible.njk
+++ b/app/views/accessibility/partials/make-video-and-other-multimedia-content-accessible.njk
@@ -1,5 +1,4 @@
 <h2 id="make-video-and-other-multimedia-content-accessible">Make video and other multimedia content accessible</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Consider using video as well as text. Some people find it easier to understand.</p>
 <p>With all video and animation, make sure that:</p>
 <ul>

--- a/app/views/accessibility/partials/make-your-research-more-accessible-on-the-day.njk
+++ b/app/views/accessibility/partials/make-your-research-more-accessible-on-the-day.njk
@@ -1,5 +1,4 @@
 <h2 id="make-your-research-more-accessible-on-the-day">Make your research more accessible on the day</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <ul>
   <li>Meet people at the front door of the building and escort them to the room.</li>
   <li>Give them plenty of time to settle in. Tell them that they can end the session at any time or take a break during it if they need to. Leave enough time between sessions.</li>

--- a/app/views/accessibility/partials/monitor-and-record-your-work.njk
+++ b/app/views/accessibility/partials/monitor-and-record-your-work.njk
@@ -1,5 +1,4 @@
 <h2 id="monitor-and-record-your-work">Monitor and record your work</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/product-and-delivery">Product and delivery</a></p>
 <p>You must show that your team:</p>
 <ul>
   <li>has carried out accessibility tests at each stage of the project</li>

--- a/app/views/accessibility/partials/publish-an-accessibility-statement.njk
+++ b/app/views/accessibility/partials/publish-an-accessibility-statement.njk
@@ -1,5 +1,4 @@
 <h2 id="publish-an-accessibility-statement">Publish an accessibility statement</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/product-and-delivery">Product and delivery</a></p>
 <p>All websites must have an accessibility statement, in line with with accessibility regulations. Read more about <a href="https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps">the accessibility requirements for public sector bodies on GOV.UK</a>.</p>
 <p>For the statement, you must test every area of your product or service and report on issues that people with access needs might face. You should have as few accessibility issues as possible. Following this accessibility guidance will help you with that.</p>
 <p>GOV.UK has published a <a href="https://www.gov.uk/government/publications/sample-accessibility-statement/sample-accessibility-statement-for-a-fictional-public-sector-website">sample accessibility statement</a>. You can see a live example on the <a href="https://your-data-matters.service.nhs.uk/accessibility-statement">NHS Your data matters service.</a></p>

--- a/app/views/accessibility/partials/recruit-people-with-access-needs.njk
+++ b/app/views/accessibility/partials/recruit-people-with-access-needs.njk
@@ -1,6 +1,4 @@
 <h2 id="recruit-people-with-access-needs">Recruit people with access needs</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
-
 <h3>Recruitment agencies</h3>
 <p>Ask your agency to include people with access needs. If they say it's too hard or want to charge extra for this, get quotes from other recruiters. You should be able to find an agency that will recruit people with different needs at no extra cost.</p>
 
@@ -24,4 +22,3 @@
     </ul>
   </div>
 </details>
-

--- a/app/views/accessibility/partials/run-technical-tests-for-accessibility-beforehand.njk
+++ b/app/views/accessibility/partials/run-technical-tests-for-accessibility-beforehand.njk
@@ -1,5 +1,4 @@
 <h2 id="run-technical-tests-for-accessibility-beforehand">Run technical tests for accessibility beforehand</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>Check that the thing you're testing is technically accessible - for example, that it works for people who use screen readers or voice input.</p>
 <p>This applies to your survey software too. If you're using Qualtrics, as many user researchers do, be aware that it's not fully accessible.</p>
 

--- a/app/views/accessibility/partials/set-language.njk
+++ b/app/views/accessibility/partials/set-language.njk
@@ -1,5 +1,4 @@
 <h2 id="set-language">Set language</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>You need a small bit of markup on every page for screenreaders (and search engines) to know what language the content (or a part of the content) is in.</p>
 
 <details class="nhsuk-details">

--- a/app/views/accessibility/partials/set-page-titles.njk
+++ b/app/views/accessibility/partials/set-page-titles.njk
@@ -1,5 +1,4 @@
 <h2 id="set-page-titles">Set page titles</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>A good page title helps users find what they want and recognise they're in the right place. It's the link that shows in search results and the first thing a screenreader will read out when the user lands on a page.</p>
 <p>Each page title must be unique and descriptive. Keep it concise and consider putting important keywords near the beginning.</p>
 

--- a/app/views/accessibility/partials/share-your-research.njk
+++ b/app/views/accessibility/partials/share-your-research.njk
@@ -1,5 +1,4 @@
 <h2 id="share-your-research">Share your research</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>Share your research findings with colleagues, taking out any personal information.</p>
 <p>Feedback about <a href="/design-system/components">NHS components</a> and help us improve this guidance.</p>
 

--- a/app/views/accessibility/partials/test-that-text-sizes-and-zooms-correctly.njk
+++ b/app/views/accessibility/partials/test-that-text-sizes-and-zooms-correctly.njk
@@ -1,5 +1,4 @@
 <h2 id="test-that-text-sizes-and-zooms-correctly">Test that text sizes and zooms correctly</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>People use their browser to change the size of content, and people with low vision may use that to a more extreme level. The guidelines specify a level of 320 (CSS) px wide. That is equivalent to 400% for a 1280px wide browser.</p>
 <p>Users can also override the font-family and spacing for text, which can break a fragile layout. We use this <a href="https://www.html5accessibility.com/tests/tsbookmarklet.html">text spacing bookmarklet</a> to test with.</p>
 

--- a/app/views/accessibility/partials/understand-participants-needs-before-you-test.njk
+++ b/app/views/accessibility/partials/understand-participants-needs-before-you-test.njk
@@ -1,5 +1,4 @@
 <h2 id="understand-participants-needs-before-you-test">Understand participants' needs before you test</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/user-research">User research</a></p>
 <p>Make it easy for people with access needs to take part in the research by planning the venue, the tech and the "paperwork" around their needs.</p>
 
 <details class="nhsuk-details">

--- a/app/views/accessibility/partials/understand-types-of-testing.njk
+++ b/app/views/accessibility/partials/understand-types-of-testing.njk
@@ -1,5 +1,4 @@
 <h2 id="understand-types-of-testing">Understand types of testing</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/testing">Testing</a></p>
 <p>There are 3 types of accessibility testing:</p>
 <ul>
   <li>testing with people - see the guidance on <a href="/accessibility/user-research">user research</a></li>

--- a/app/views/accessibility/partials/use-alternative-text-for-functional-images.njk
+++ b/app/views/accessibility/partials/use-alternative-text-for-functional-images.njk
@@ -1,5 +1,4 @@
 <h2 id="use-alternative-text-for-functional-images">Use alternative text for functional images</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/design">Design</a>, <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Some images are "functional". That means that they trigger an action. If people can't see the image, they need an alternative.</p>
 <p>Use "alt‑text" for images like PNG or JPEG. W3C has information about <a href="https://www.w3.org/WAI/tutorials/images/functional/">how to deal with different kinds of functional image</a>, including logos.</p>
 <p>The NHS website (nhs.uk) prefers inline SVG files for functional images. SVGs don't have an alt attribute. Instead we use aria-hidden="true" and, if there is no link text, "visually-hidden" in span tags.</p>

--- a/app/views/accessibility/partials/use-alternative-text-for-images-in-content.njk
+++ b/app/views/accessibility/partials/use-alternative-text-for-images-in-content.njk
@@ -1,7 +1,7 @@
 <h2 id="use-alternative-text-for-images-in-content">Use alternative text for images in content</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>People who cannot see a meaningful image need an alternative to understand the content. You need to add "alt-text" to explain what's in the image. Alt-text is not usually visible but is read out by screen readers or displayed if an image does not load or if images have been switched off.</p>
 <p>You can see what alt-text an image has by viewing it with <a href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">Chrome's Web Developer toolbar</a>.</p>
+
 <details class="nhsuk-details">
   <summary class="nhsuk-details__summary">
     <span class="nhsuk-details__summary-text">

--- a/app/views/accessibility/partials/use-aria-patterns.njk
+++ b/app/views/accessibility/partials/use-aria-patterns.njk
@@ -1,5 +1,4 @@
 <h2 id="use-aria-patterns">Use ARIA patterns</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/development">Development</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>ARIA (Accessibility Rich Internet Applications) adds extra information that lets people who use assistive technologies know what's going on. If a component needs more description than HTML provides, you need to mark it up with an ARIA pattern.</p>
 <p>We use simple examples of ARIA in some of the service manual components, such as <a href="/design-system/components/details">details</a>, <a href="/design-system/components/breadcrumbs">breadcrumbs</a> and <a href="/design-system/components/error-message">error messages</a>.</p>
 

--- a/app/views/accessibility/partials/use-headings-correctly.njk
+++ b/app/views/accessibility/partials/use-headings-correctly.njk
@@ -1,5 +1,4 @@
 <h2 id="use-headings-correctly">Use headings correctly</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Everyone relies on meaningful headings to navigate the page but they are especially important for some people with access needs. Make sure your headings reflect the page structure.</p>
 
 <details class="nhsuk-details">

--- a/app/views/accessibility/partials/use-html-rather-than-pdfs.njk
+++ b/app/views/accessibility/partials/use-html-rather-than-pdfs.njk
@@ -1,5 +1,4 @@
 <h2 id="pdfs">Use HTML rather than PDFs</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Avoid using PDFs as they are not accessible. If you must use a PDF, make sure the content is also available in HTML form.</p>
 <p>Read more about <a href="/content/pdfs-and-other-non-html-documents">PDFs and other non-HTML documents in the content guide</a>.</p>
 

--- a/app/views/accessibility/partials/use-tables-to-show-relationships-between-data.njk
+++ b/app/views/accessibility/partials/use-tables-to-show-relationships-between-data.njk
@@ -1,5 +1,4 @@
 <h2 id="use-tables-to-show-relationships-between-data">Use tables to show relationships between data</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a></p>
 <p>Tables make it easier for users to understand logical relationships between bits of data or information.</p>
 <p>Only use tables when there is a relationship between the "header" cells and the "data" cells in the grid. Assistive technologies announce the header with the data it refers to.</p>
 

--- a/app/views/accessibility/partials/write-content-thats-easy-to-understand.njk
+++ b/app/views/accessibility/partials/write-content-thats-easy-to-understand.njk
@@ -1,4 +1,3 @@
 <h2 id="write-content-thats-easy-to-understand">Write content that's easy to understand</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a></p>
 <p>Clear content helps everyone and it's the most important thing you can do to make things accessible. It will help more people than any other accessibility requirement.</p>
 <p>NHS services should follow the <a href="/content">content guide</a>, including the guidance on <a href="/content/health-literacy">health literacy</a> and <a href="/content/inclusive-content">inclusive content</a>.</p>

--- a/app/views/accessibility/partials/write-good-link-and-form-control-names.njk
+++ b/app/views/accessibility/partials/write-good-link-and-form-control-names.njk
@@ -1,15 +1,14 @@
 <h2 id="write-good-link-and-form-control-names">Write good link and form control names</h2>
-<p class="nhsuk-body-s">For: <a href="/accessibility/content">Content</a>, <a href="/accessibility/design">Design</a>, <a href="/accessibility/testing">Testing</a></p>
 <p>Links or buttons need to make sense out of context as some people experience them that way.</p>
-    <ul>
-      <li>Each link should clearly describe where it will take you. For example: "Find your nearest A&amp;E".</li>
-      <li>Ideally link text should match the heading of the target page. If the target page has the heading "Sleep and tiredness", that's good link text.</li>
-      <li>If the target page heading is too long, shorten it but use words from it so that users can predict where the link will take them.</li>
-      <li>Avoid ambiguous phrases such as "click here" or "read more". Be specific, for example: "Learn more about <u>how to deal with stress</u>."</li>
-      <li>Avoid "see" or "read". Instead we use "find out about" or "learn about".</li>
-      <li>Avoid having links or buttons open new tabs or windows. Find out more on our <a href="/content/links">Links page</a>.</li>
-      <li>If the link goes to a document, include the file type and size in the link phrase. For example: "Link name (PDF, 200KB)".</li>
-    </ul>
+<ul>
+  <li>Each link should clearly describe where it will take you. For example: "Find your nearest A&amp;E".</li>
+  <li>Ideally link text should match the heading of the target page. If the target page has the heading "Sleep and tiredness", that's good link text.</li>
+  <li>If the target page heading is too long, shorten it but use words from it so that users can predict where the link will take them.</li>
+  <li>Avoid ambiguous phrases such as "click here" or "read more". Be specific, for example: "Learn more about <u>how to deal with stress</u>."</li>
+  <li>Avoid "see" or "read". Instead we use "find out about" or "learn about".</li>
+  <li>Avoid having links or buttons open new tabs or windows. Find out more on our <a href="/content/links">Links page</a>.</li>
+  <li>If the link goes to a document, include the file type and size in the link phrase. For example: "Link name (PDF, 200KB)".</li>
+</ul>
 
 <details class="nhsuk-details">
   <summary class="nhsuk-details__summary">

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,6 +9,25 @@
 
   <h2>Latest updates</h2>
 
+  <h3>January 2025</h3>
+  <table class="nhsuk-table">
+    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in January 2025</caption>
+    <thead class="nhsuk-table__head">
+      <tr class="nhsuk-table__row">
+        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+        <th class="nhsuk-table__header" scope="col">Update</th>
+      </tr>
+    </thead>
+    <tbody class="nhsuk-table__body">
+    <tr>
+      <td class="nhsuk-table__cell">Accessibility</td>
+      <td class="nhsuk-table__cell">
+      <p>Removed same-page profession links as they have caused confusion in testing</p>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+
   <h3>December 2024</h3>
   <table class="nhsuk-table">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in December 2024</caption>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,50 +10,69 @@
 
 {% block bodyContent %}
 
+<h2>January 2025</h2>
+<table class="nhsuk-table">
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in January 2025</caption>
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+      <th class="nhsuk-table__header" scope="col">Update</th>
+    </tr>
+  </thead>
+  <tbody class="nhsuk-table__body">
+  <tr>
+    <td class="nhsuk-table__cell">Accessibility</td>
+    <td class="nhsuk-table__cell">
+    <p>Removed same-page profession links as they have caused confusion in testing</p>
+    </td>
+  </tr>
+  </tbody>
+</table>
+
 <h2>December 2024</h2>
   <table class="nhsuk-table">
-    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in December 2024</caption>
-    <thead class="nhsuk-table__head">
-      <tr class="nhsuk-table__row">
-        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
-        <th class="nhsuk-table__header" scope="col">Update</th>
-      </tr>
-    </thead>
-    <tbody class="nhsuk-table__body">
-    <tr>
-      <td class="nhsuk-table__cell">Design system</td>
-      <td class="nhsuk-table__cell">
-      <p>Replaced image in <a href="https://service-manual.nhs.uk/design-system/components/images">image component</a></p>
-      </td>
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in December 2024</caption>
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+      <th class="nhsuk-table__header" scope="col">Update</th>
     </tr>
-    </tbody>
-  </table>
+  </thead>
+  <tbody class="nhsuk-table__body">
+  <tr>
+    <td class="nhsuk-table__cell">Design system</td>
+    <td class="nhsuk-table__cell">
+    <p>Replaced image in <a href="https://service-manual.nhs.uk/design-system/components/images">image component</a></p>
+    </td>
+  </tr>
+  </tbody>
+</table>
 
 <h2>November 2024</h2>
-  <table class="nhsuk-table">
-    <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in November 2024</caption>
-    <thead class="nhsuk-table__head">
-      <tr class="nhsuk-table__row">
-        <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
-        <th class="nhsuk-table__header" scope="col">Update</th>
-      </tr>
-    </thead>
-    <tbody class="nhsuk-table__body">
-    <tr>
-      <td class="nhsuk-table__cell">Community and contribution</td>
-      <td class="nhsuk-table__cell">
-      <p>Added <a href="/community-and-contribution/community-resources">Community resources</a> page to list resources based on the NHS design system.</p>
-      </td>
+<table class="nhsuk-table">
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in November 2024</caption>
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+      <th class="nhsuk-table__header" scope="col">Update</th>
     </tr>
-    <tr>
-      <td class="nhsuk-table__cell">Design system</td>
-      <td class="nhsuk-table__cell">
-      <p>Added a <a href="/design-system/components/task-list">task list component</a> and a pattern to <a href="/design-system/patterns/complete-multiple-tasks">help users complete multiple tasks</a></p>
-      <p>Changed side navigation in <a href="/design-system/patterns">patterns</a><p>
-      </td>
-    </tr>
-    </tbody>
-  </table>
+  </thead>
+  <tbody class="nhsuk-table__body">
+  <tr>
+    <td class="nhsuk-table__cell">Community and contribution</td>
+    <td class="nhsuk-table__cell">
+    <p>Added <a href="/community-and-contribution/community-resources">Community resources</a> page to list resources based on the NHS design system.</p>
+    </td>
+  </tr>
+  <tr>
+    <td class="nhsuk-table__cell">Design system</td>
+    <td class="nhsuk-table__cell">
+    <p>Added a <a href="/design-system/components/task-list">task list component</a> and a pattern to <a href="/design-system/patterns/complete-multiple-tasks">help users complete multiple tasks</a></p>
+    <p>Changed side navigation in <a href="/design-system/patterns">patterns</a><p>
+    </td>
+  </tr>
+  </tbody>
+</table>
 
 <h2>October 2024</h2>
 <table class="nhsuk-table">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removes the same page profession links in the accessibility section. 

![image](https://github.com/user-attachments/assets/35d4fb1c-8111-4869-9807-ca9c18fd0016)

We have not observed them being useful when user testing and they have cause some confusion when users click the one that points to their current page. Removing them also simplifies the page. 

### Related issue
<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->
https://github.com/nhsuk/nhsuk-service-manual/issues/2081

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
