### PR TITLE
Add description of Checkbox/Radio 'value(s)' param

### DIFF
--- a/app/views/design-system/components/checkboxes/macro-options.json
+++ b/app/views/design-system/components/checkboxes/macro-options.json
@@ -31,6 +31,12 @@
       "description": "Name attribute for all checkbox items."
     },
     {
+      "name": "values",
+      "type": "array",
+      "required": false,
+      "description": "Array of values for checkboxes which should be checked when the page loads. Use this as an alternative to setting the checked option on each individual item."
+    },
+    {
       "name": "items",
       "type": "array",
       "required": true,

--- a/app/views/design-system/components/radios/macro-options.json
+++ b/app/views/design-system/components/radios/macro-options.json
@@ -34,6 +34,12 @@
       "description": "Name attribute for each radio item."
     },
     {
+      "name": "value",
+      "type": "string",
+      "required": false,
+      "description": "The value for the radio which should be checked when the page loads. Use this as an alternative to setting the checked option on each individual item."
+    },
+    {
       "name": "items",
       "type": "array",
       "required": true,


### PR DESCRIPTION
This feature was releases as part of NHS Frontend 9.2.0 - see https://github.com/nhsuk/nhsuk-frontend/pull/1105 and I forgot to add it to the documentation in the Service Manual.

Thanks to @edwardhorsford for spotting this.