### PR TITLE
Add button text guidance

### DIFF
--- a/app/views/design-system/components/buttons/index.njk
+++ b/app/views/design-system/components/buttons/index.njk
@@ -103,7 +103,20 @@
 
   <h2 id="how-to-use-buttons">How to use buttons</h2>
   <p>The <a href="https://design-system.service.gov.uk/components/button/">GOV.UK design system</a> suggests using a button to help users carry out an action on a page like starting an application or saving their progress.</p>
-  <p>Write button text in sentence case and describe the action the button performs. For example "Save and continue" or "Start now".</p>
+  <p>Write button text in sentence case, describing the action it performs. For example:</p>
+  <ul>
+    <li>'Start now' at the <a href="/design-system/patterns/start-page/">start of your service</a></li>
+    <li>'Log in' to an account a user has already created</li>
+    <li>'Continue' when the service does not save a user's information</li>
+    <li>'Save and continue' when the service does save a user's information</li>
+    <li>'Save and come back later' when a user can save their information and come back later</li>
+    <li>'Add another' to add another item to a list or group</li>
+    <li>'Pay' to make a payment</li>
+    {# <li>'Confirm and send' on a <a href="/patterns/check-answers/">Check answers page</a> that does not have any legal content a user must agree to</li> #}
+    {# <li>'Accept and send' on a <a href="/patterns/check-answers/">Check answers page</a> that has legal content a user must agree to</li> #}
+    <li>'Log out' when a user is logged in to an account</li>
+  </ul>
+  <p>You may need to include more or different words to better describe the action. For example, 'Add another address' and 'Accept and claim a tax refund'.</p>
   <p>Align the primary action button to the left edge of your form.</p>
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add some guidance, [tweaked from govuk](https://design-system.service.gov.uk/components/button#how-it-works), for what wording should be used on buttons. References to 'Sign in' have been changed to our preferred 'Log in'. References to 'Check answers' page buttons have been commented out, so that we can add them once we have that page, which is in progress: https://github.com/nhsuk/nhsuk-service-manual/pull/2141.

<img width="754" alt="image" src="https://github.com/user-attachments/assets/579d85f7-7f88-4a6c-b005-1f58021f28ee" />

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
