### PR TITLE
responsive tables margin update

### DIFF
--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -26,7 +26,7 @@
   <p>See the full list of <a href="/design-system">design system changes to meet WCAG 2.2</a>.</p>
 </div>
 
-  <table class="nhsuk-table nhsuk-table--full-width nhsuk-table-responsive nhsuk-u-margin-bottom-6">
+  <table class="nhsuk-table nhsuk-table--full-width nhsuk-table-responsive">
     <caption class="nhsuk-table__caption">Icon you can use</caption>
     <thead>
       <tr>

--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -189,7 +189,7 @@
 
   <h3 id="options">Options</h3>
 
-  <table class="nhsuk-table nhsuk-table--full-width nhsuk-table-responsive nhsuk-u-margin-bottom-6">
+  <table class="nhsuk-table nhsuk-table--full-width nhsuk-table-responsive">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Options that you can use with the page template</caption>
     <thead class="nhsuk-table__head" role="rowgroup">
       <tr class="nhsuk-table__row" role="row">


### PR DESCRIPTION
remove margin helper classes from responsive tables, they now have their own margin (https://github.com/nhsuk/nhsuk-frontend/pull/1005)

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
