### PR TITLE
Add reverse link guidance

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,6 +81,8 @@ env.addFilter('highlight', (code, language) => {
 app.get('/design-example/:group/:item/:type', (req, res) => {
   const displayFullPage = req.query.fullpage === 'true';
   const blankPage = req.query.blankpage === 'true';
+  const backgroundColours = ['blue'];
+  const background = backgroundColours.includes(req.query.background) ? req.query.background : null;
   const { group } = req.params;
   const { item } = req.params;
   const { type } = req.params;
@@ -101,6 +103,7 @@ app.get('/design-example/:group/:item/:type', (req, res) => {
   res.render(baseTemplate, {
     body: exampleHtml,
     item,
+    background,
   });
 });
 

--- a/app/styles/design-example-overrides.scss
+++ b/app/styles/design-example-overrides.scss
@@ -22,6 +22,11 @@ body {
   padding: 0;
 }
 
+/* Component examples on a blue background */
+.app-example-background-blue {
+  background-color: #005eb8;
+}
+
 /*
   In order to show how the grid works, we need to have an element inside the
   grid that is visible and fills the available space with a background color.

--- a/app/styles/design-example-overrides.scss
+++ b/app/styles/design-example-overrides.scss
@@ -24,7 +24,7 @@ body {
 
 /* Component examples on a blue background */
 .app-example-background-blue {
-  background-color: #005eb8;
+  background-color: #005eb8; // sass-lint:disable-line no-color-hex no-color-literals
 }
 
 /*

--- a/app/views/design-system/components/buttons/index.njk
+++ b/app/views/design-system/components/buttons/index.njk
@@ -64,7 +64,8 @@
   {{ designExample({
     group: "components",
     item: "buttons",
-    type: "reverse"
+    type: "reverse",
+    background: "blue"
   }) }}
 
   <h3>When to use a white button on solid background colour</h3>

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -224,6 +224,18 @@
     htmlOnly: true
   }) }}
 
+  <p>If the link is on a dark background, for example in custom components, use the  <code>nhsuk-link--reverse</code> modifier class to make the text white.</p>
+
+  <p>The white links and background colour must have a contrast ratio of at least 4.5:1 to meet <a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html">WCAG 2.2 success criterion 1.4.3 Contrast (minimum), level AA</a>.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "typography",
+    type: "links-reverse",
+    background: "blue",
+    htmlOnly: true
+  }) }}
+
   <h2 id="lists">Lists</h2>
   <p>Use lists to make blocks of text easier to read, and to break information into manageable chunks.</p>
 

--- a/app/views/design-system/styles/typography/links-reverse/index.njk
+++ b/app/views/design-system/styles/typography/links-reverse/index.njk
@@ -1,0 +1,1 @@
+<a href="#" class="nhsuk-link nhsuk-link--reverse">Example link</a>

--- a/app/views/includes/design-example-wrapper.njk
+++ b/app/views/includes/design-example-wrapper.njk
@@ -25,7 +25,7 @@
     <script src="/js/main.min.js" defer></script>
   </head>
 
-  <body class="app-example-{{item}}-page">
+  <body class="app-example-{{item}}-page{% if background %} app-example-background-{{ background }}{% endif %}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     {{ body | safe }}

--- a/app/views/includes/design-example.njk
+++ b/app/views/includes/design-example.njk
@@ -2,6 +2,9 @@
   {% set examplePath = "app/views/design-system/" + params.group + "/" + params.item + "/" + params.type + "/index.njk" %}
   {% set exampleArguments = "app/views/design-system/" + params.group + "/" + params.item + "/" + "macro-options.json" %}
   {% set standaloneURL = "/design-example/" + params.group + "/" + params.item + "/" + params.type + "?fullpage=" + params.fullpage + "&blankpage=" + params.blankpage %}
+  {% if params.background %}
+    {% set standaloneURL = standaloneURL + "&background=" + params.background %}
+  {% endif %}
 
   {# `showExample` and `showCode` is true, unless explicitly turned off with params #}
   {% set showExample = params.showExample !== false %}


### PR DESCRIPTION
This adds a small amount of guidance for the reverse link style included in the next release of NHS frontend (see [pull request #1269](https://github.com/nhsuk/nhsuk-frontend/pull/1269)).

The guidance is based on the GOV.UK guidance: [Links on dark backgrounds](https://design-system.service.gov.uk/styles/links/#links-on-dark-backgrounds).

To make the example clearer, support is also added for displaying component examples on blue backgrounds.

## Screenshot

<img width="875" alt="Screenshot 2025-05-06 at 21 39 59" src="https://github.com/user-attachments/assets/cf2971d7-e7dd-4a64-8e28-d6de2a8af508" />

## Checklist

- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
