### PR TITLE
Add `nhsuk-summary-list__row--no-border` to summary list component guidance

### DIFF
--- a/app/views/design-system/components/summary-list/index.njk
+++ b/app/views/design-system/components/summary-list/index.njk
@@ -102,4 +102,6 @@
     type: "without-border"
   }) }}
 
+  <p>To remove borders on a single row, use the <code>nhsuk-summary-list__row--no-border</code> class.</p>
+
 {% endblock %}


### PR DESCRIPTION
## Description

The new `nhsuk-summary-list__row--no-border` allows authors to remove borders from individual summary list rows (rather than for all rows, which is what `nhsuk-summary-list--no-border` does).

This PR adds a note about this feature, using the same wording as that used for the equivalent feature in the GOV.UK Design System.

### Related issue

https://github.com/nhsuk/nhsuk-frontend/pull/1325

## Checklist

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
