### PR TITLE
add check answers and confirmation pages to site map and search

### DIFF
--- a/app/views/site-map.njk
+++ b/app/views/site-map.njk
@@ -119,14 +119,14 @@
         <li><a href="/design-system/patterns">Patterns</a>
           <ul class="nhsuk-u-nested-list">
             <li><a href="/design-system/patterns/ask-for-nhs-numbers">Ask users for their NHS number</a></li>
-            <li><a href="/design-system/patterns/a-to-z-page">A to Z</a></li>
+            <li><a href="/design-system/patterns/check-answers">Check answers</a></li>
             <li><a href="/design-system/patterns/complete-multiple-tasks">Complete multiple tasks</a></li>
+            <li><a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">Decide when and where to get care (care cards)</a></li>
+            <li><a href="/design-system/patterns/reassure-users-that-a-page-is-up-to-date">Know that a page is up to date</a></li>
+            <li><a href="/design-system/patterns/a-to-z-page">A to Z</a></li>
             <li><a href="/design-system/patterns/confirmation-page">Confirmation page</a></li>
-            <li><a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">Help users decide when and where to get care (care cards)</a></li>
             <li><a href="/design-system/patterns/mini-hub">Mini-hub</a></li>
             <li><a href="/design-system/patterns/question-pages">Question pages</a></li>
-            <li><a href="/design-system/patterns/start-page">Start page</a></li>
-            <li><a href="/design-system/patterns/reassure-users-that-a-page-is-up-to-date">Reassure users that information is up-to-date</a></li>
             <li><a href="/design-system/patterns/start-page">Start page</a></li>
           </ul>
         </li>

--- a/app/views/sitemap.xml
+++ b/app/views/sitemap.xml
@@ -305,6 +305,12 @@
     <loc>https://service-manual.nhs.uk/design-system/patterns/know-that-a-page-is-up-to-date</loc>
   </url>
   <url>
+    <loc>https://service-manual.nhs.uk/design-system/patterns/check-answers</loc>
+  </url>
+  <url>
+    <loc>https://service-manual.nhs.uk/design-system/patterns/confirmation-page</loc>
+  </url>
+  <url>
     <loc>https://service-manual.nhs.uk/design-system/styles/focus-state</loc>
   </url>
   <url>

--- a/lib/page-index-additions.js
+++ b/lib/page-index-additions.js
@@ -51,9 +51,8 @@ const additionalIndices = {
   '/design-system/components/warning-callout': [
     'yellow callout, warning box, important'
   ],
-  '/design-system/patterns/know-that-a-page-is-up-to-date': [
-    'review date, date updated'
-  ],
+  '/design-system/patterns/know-that-a-page-is-up-to-date': ['review date, date updated'],
+  '/design-system/patterns/check-answers': ['summary, confirm, review'],
   '/design-system/styles/colour': ['palette'],
   '/design-system/styles/layout': ['grid'],
   '/design-system/styles/spacing': ['margin, padding'],


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixes issue that right now, check answers cannot be found in search

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
