### PR TITLE
Add guidance on missing data in tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 :new: **New features**
 
-- Add new guidance on displaying missing data in tables
+- Add guidance on displaying missing data in tables
 
 ## 7.12.0 - 7 July 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - Add new guidance on displaying missing data in tables
 
-
 ## 7.12.0 - 7 July 2025
 
 :new: **New features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS digital service manual Changelog
 
+## 7.13.0 - TBC
+
+:new: **New features**
+
+- Add new guidance on displaying missing data in tables
+
+
 ## 7.12.0 - 7 July 2025
 
 :new: **New features**

--- a/app/views/design-system/components/table/index.njk
+++ b/app/views/design-system/components/table/index.njk
@@ -75,7 +75,7 @@
     <li>"Not known"</li>
   </ul>
 
-  <p>To distinguish the text from other table content, use the <code>nhsuk-u-secondary-text-color</code> modifier to make it dark grey.</p>
+  <p>To distinguish the text from other table content, use the <code>nhsuk-u-secondary-text-color</code> modifier class to make it dark grey.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/table/index.njk
+++ b/app/views/design-system/components/table/index.njk
@@ -65,6 +65,18 @@
   }) }}
   <p>Find out more about word-breaks, with or without a hyphen, in <a href="/design-system/styles/typography#breaking-up-long-words">breaking up long words in the typography section</a>.</p>
 
+  <h2 id="missing-data-table">Displaying missing data</h2>
+
+  <p>You should not have empty cells in your table, except for the top left cell. If you have data which is missing, instead use some short text to explain why it is missing, if known, or use 'No data' or 'Not applicable'.</p>
+
+  <p>You can use the <code>nhsuk-u-secondary-text-color</code> modifier to make the text for missing data dark grey if this is helpful to distinguish it from other text.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "table",
+    type: "missing-data"
+  }) }}
+
   <h2 id="how-it-works">How tables work</h2>
   <h3>Accessibility</h3>
   <p>Follow <a href="https://webaim.org/techniques/tables/data">WebAIM's guidance for tables</a> and:</p>

--- a/app/views/design-system/components/table/index.njk
+++ b/app/views/design-system/components/table/index.njk
@@ -67,9 +67,15 @@
 
   <h2 id="missing-data-table">Displaying missing data</h2>
 
-  <p>You should not have empty cells in your table, except for the top left cell. If you have data which is missing, instead use some short text to explain why it is missing, if known, or use 'No data' or 'Not applicable'.</p>
+  <p>You should not have empty cells in your table, except for the top left cell. If you have missing data, include some short text to explain why it’s missing, or use:</p>
 
-  <p>You can use the <code>nhsuk-u-secondary-text-color</code> modifier to make the text for missing data dark grey if this is helpful to distinguish it from other text.</p>
+  <ul>
+    <li>No data</li>
+    <li>Not applicable</li>
+    <li>Not known</li>
+  </ul>
+
+  <p>To distinguish the text from other table content, use the <code>nhsuk-u-secondary-text-color</code> modifier to make it dark grey.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/table/index.njk
+++ b/app/views/design-system/components/table/index.njk
@@ -3,7 +3,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use a table to make it easier for users to compare and scan information." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "April 2025" %}
+{% set dateUpdated = "July 2025" %}
 {% set backlog_issue_id = "26" %}
 
 {% extends "layouts/app-layout.njk" %}
@@ -67,12 +67,12 @@
 
   <h2 id="missing-data-table">Displaying missing data</h2>
 
-  <p>You should not have empty cells in your table, except for the top left cell. If you have missing data, include some short text to explain why it’s missing, or use:</p>
+  <p>Do not leave empty cells in your table. The only exception can be the top left cell. If you have missing data, include some short text to explain why it's missing, such as:</p>
 
   <ul>
-    <li>No data</li>
-    <li>Not applicable</li>
-    <li>Not known</li>
+    <li>"No data"</li>
+    <li>"Not applicable"</li>
+    <li>"Not known"</li>
   </ul>
 
   <p>To distinguish the text from other table content, use the <code>nhsuk-u-secondary-text-color</code> modifier to make it dark grey.</p>

--- a/app/views/design-system/components/table/missing-data/index.njk
+++ b/app/views/design-system/components/table/missing-data/index.njk
@@ -1,0 +1,41 @@
+{% from 'tables/macro.njk' import table %}
+
+{{ table({
+  caption: "Vaccinations given",
+  head: [
+    {
+      text: 'Date'
+    },
+    {
+      text: 'Vaccine'
+    },
+    {
+      text: 'Product'
+    }
+  ],
+  rows: [
+    [
+      {
+        text: '10 July 2024'
+      },
+      {
+        text: 'COVID-19'
+      },
+      {
+        text: 'Spikevax JN.1'
+      }
+    ],
+    [
+      {
+        text: '6 September 2023'
+      },
+      {
+        text: 'RSV'
+      },
+      {
+        text: 'No data',
+        classes: 'nhsuk-u-secondary-text-color'
+      }
+    ]
+  ]
+}) }}

--- a/app/views/design-system/components/table/missing-data/index.njk
+++ b/app/views/design-system/components/table/missing-data/index.njk
@@ -19,10 +19,10 @@
         text: '10 July 2024'
       },
       {
-        text: 'COVID-19'
+        text: 'RSV'
       },
       {
-        text: 'Spikevax JN.1'
+        text: 'Abrysvo'
       }
     ],
     [
@@ -30,7 +30,7 @@
         text: '6 September 2023'
       },
       {
-        text: 'RSV'
+        text: 'Flu'
       },
       {
         text: 'No data',

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -20,6 +20,12 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr>
+        <td class="nhsuk-table__cell">Table</td>
+        <td class="nhsuk-table__cell">
+          <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
+        </td>
+      </tr>
+      <tr>
         <td class="nhsuk-table__cell">Community and contribution</td>
         <td class="nhsuk-table__cell">
           <p>Added link to NHS App design system to <a href="/community-and-contribution/community-resources">Community resources</a> page</p>

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,7 +9,7 @@
 
   <h2>Latest updates</h2>
 
-  <h3>July 2025</h3>
+  <h3>Month 2025</h3>
   <table class="nhsuk-table">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in July 2025</caption>
     <thead class="nhsuk-table__head">
@@ -20,24 +20,9 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr>
-        <td class="nhsuk-table__cell">Table</td>
-        <td class="nhsuk-table__cell">
-          <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
-        </td>
-      </tr>
-      <tr>
-        <td class="nhsuk-table__cell">Community and contribution</td>
-        <td class="nhsuk-table__cell">
-          <p>Added link to NHS App design system to <a href="/community-and-contribution/community-resources">Community resources</a> page</p>
-        </td>
-      </tr>
-      <tr>
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
-          <p>Added new <a href="/design-system/patterns/question-pages">question pages pattern</a></p>
-          <p>Added guidance on <a href="/design-system/components/hint-text#how-to-use-hint-text">how to use hint text</a> and updated examples in design system</p>
-          <p>Updated WCAG 2.2 alerts in the design system and moved full list of <a href="/design-system/changes-to-design-system-wcag-2-2">changes to the design system to meet WCAG 2.2</a></p>
-          <p>Changed "Go back" to "Back" on <a href="/design-system/components/back-link">back link</a> and in back link examples on other pages</p>
+          <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -21,6 +21,12 @@
   </thead>
   <tbody class="nhsuk-table__body">
     <tr>
+      <td class="nhsuk-table__cell">Table</td>
+      <td class="nhsuk-table__cell">
+        <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
+      </td>
+    </tr>
+    <tr>
       <td class="nhsuk-table__cell">Community and contribution</td>
       <td class="nhsuk-table__cell">
         <p>Added link to NHS App design system to <a href="/community-and-contribution/community-resources">Community resources</a> page</p>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,6 +10,25 @@
 
 {% block bodyContent %}
 
+<h2>Month 2025</h2>
+<table class="nhsuk-table">
+  <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in July 2025</caption>
+  <thead class="nhsuk-table__head">
+    <tr class="nhsuk-table__row">
+      <th class="nhsuk-table__header" scope="col" style="width: 25%;">Section</th>
+      <th class="nhsuk-table__header" scope="col">Update</th>
+    </tr>
+  </thead>
+  <tbody class="nhsuk-table__body">
+    <tr>
+      <td class="nhsuk-table__cell">Design system</td>
+      <td class="nhsuk-table__cell">
+        <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <h2>July 2025</h2>
 <table class="nhsuk-table">
   <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in July 2025</caption>


### PR DESCRIPTION
## Description

The GOV.UK Content design guide says that table cells (apart from the top left one) should not be empty for accessibility reasons. Instead, some text should be added.

To make this more distinguishable from regular text, this could use the dark grey colour if necessary (depending on context - might not be needed if other cells contain numbers?). 

We already have an (undocumented) `nhsuk-u-secondary-text-color` modifier, so could use that.

## Screenshot

<img width="876" height="703" alt="Screenshot 2025-07-15 at 18 21 39" src="https://github.com/user-attachments/assets/14934b81-07a8-49cd-913f-75e561133003" />


## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
