### PR TITLE
Add guidance for secondary text colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## 7.13.0 - TBC
+
+:new: **New features**
+
+- Add guidance on using `nhsuk-u-secondary-text-color` modifier class
+
 ## 7.12.0 - 7 July 2025
 
 :new: **New features**

--- a/app/stylesheets/app/_colour-swatch.scss
+++ b/app/stylesheets/app/_colour-swatch.scss
@@ -21,22 +21,24 @@
   border-radius: 50%;
   display: inline-block;
   height: nhsuk-spacing(6);
-  margin-right: nhsuk-spacing(2);
+  margin-right: 0;
   vertical-align: middle;
   width: nhsuk-spacing(6);
 
+  position: absolute;
+  left: 0;
+  top: 0;
+
   @include nhsuk-media-query($until: tablet) {
     height: nhsuk-spacing(4);
-    left: 0;
-    position: absolute;
     width: nhsuk-spacing(4);
   }
 }
 
 .app-colour-list__column {
   padding-left: 0;
-  padding-top: 0;
-  vertical-align: middle;
+  padding-top: nhsuk-spacing(2);
+  vertical-align: top;
 
   @include nhsuk-media-query($until: tablet) {
     display: block;
@@ -47,15 +49,19 @@
 
 .app-colour-list__column--name {
   font-weight: normal;
+  position: relative;
+  padding-left: nhsuk-spacing(8);
 
   @include nhsuk-media-query($until: tablet) {
+    padding-left: nhsuk-spacing(5);
     padding-bottom: nhsuk-spacing(1);
-    padding-top: nhsuk-spacing(2);
+    padding-top: nhsuk-spacing(1);
   }
 }
 
 .app-colour-list__column--colour {
   @include nhsuk-media-query($until: tablet) {
+    padding-top: 0;
     padding-bottom: nhsuk-spacing(1);
   }
 }

--- a/app/stylesheets/app/_colour-swatch.scss
+++ b/app/stylesheets/app/_colour-swatch.scss
@@ -27,11 +27,12 @@
 
   position: absolute;
   left: 0;
-  top: 0;
+  top: nhsuk-spacing(1) / 2;
 
   @include nhsuk-media-query($until: tablet) {
     height: nhsuk-spacing(4);
     width: nhsuk-spacing(4);
+    top: nhsuk-spacing(1);
   }
 }
 

--- a/app/views/design-system/styles/colour/index.njk
+++ b/app/views/design-system/styles/colour/index.njk
@@ -49,7 +49,7 @@
         <th class="app-colour-list__column app-colour-list__column--name" scope="row">
           <span class="app-colour-list__swatch" style="background-color:#4c6272"></span>
           <code>$nhsuk-secondary-text-color</code>
-          <p>Modifier class: <code>nhsuk-u-secondary-text-color</code></p>
+          <p class="nhsuk-u-margin-bottom-0">Modifier class: <code>nhsuk-u-secondary-text-color</code></p>
         </th>
         <td class="app-colour-list__column app-colour-list__column--colour">
           #4c6272

--- a/app/views/design-system/styles/colour/index.njk
+++ b/app/views/design-system/styles/colour/index.njk
@@ -49,6 +49,7 @@
         <th class="app-colour-list__column app-colour-list__column--name" scope="row">
           <span class="app-colour-list__swatch" style="background-color:#4c6272"></span>
           <code>$nhsuk-secondary-text-color</code>
+          <p>Modifier class: <code>nhsuk-u-secondary-text-color</code></p>
         </th>
         <td class="app-colour-list__column app-colour-list__column--colour">
           #4c6272

--- a/app/views/design-system/styles/colour/index.njk
+++ b/app/views/design-system/styles/colour/index.njk
@@ -206,6 +206,13 @@
   </ul>
   <p class="rich-text"><code>$color_nhsuk-white</code> is used to make important information stand out and for alternating backgrounds, for example on <a href="https://www.nhs.uk/">the NHS website home page</a>.</p>
 
+  <h3>Secondary text colour</h3>
+
+  <p>You can use the <code>nhsuk-u-secondary-text-color</code> class for text that should appear in the secondary text colour of dark grey.</p>
+
+  <p>For example, this could be used for text to describe missing data in a table or summary list.</p>
+
+
   <h2 id="colour-palette">Colour palette</h2>
   <p class="rich-text">Avoid using the palette colours if there is a Sass variable that is designed for your context. For example, if you are styling the error state of a component you should use the <code>$nhsuk-error-color</code> Sass variable rather than <code>$color_nhsuk-red</code>.</p>
 

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -9,7 +9,7 @@
 
   <h2>Latest updates</h2>
 
-  <h3>July 2025</h3>
+  <h3>Month 2025</h3>
   <table class="nhsuk-table">
     <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in July 2025</caption>
     <thead class="nhsuk-table__head">
@@ -20,18 +20,9 @@
     </thead>
     <tbody class="nhsuk-table__body">
       <tr>
-        <td class="nhsuk-table__cell">Community and contribution</td>
-        <td class="nhsuk-table__cell">
-          <p>Added link to NHS App design system to <a href="/community-and-contribution/community-resources">Community resources</a> page</p>
-        </td>
-      </tr>
-      <tr>
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
-          <p>Added new <a href="/design-system/patterns/question-pages">question pages pattern</a></p>
-          <p>Added guidance on <a href="/design-system/components/hint-text#how-to-use-hint-text">how to use hint text</a> and updated examples in design system</p>
-          <p>Updated WCAG 2.2 alerts in the design system and moved full list of <a href="/design-system/changes-to-design-system-wcag-2-2">changes to the design system to meet WCAG 2.2</a></p>
-          <p>Changed "Go back" to "Back" on <a href="/design-system/components/back-link">back link</a> and in back link examples on other pages</p>
+          <p>Added guidance on <a href="/design-system/styles/colour#main-colours">using the grey text colour modifer class</a></p>
         </td>
       </tr>
     </tbody>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -10,7 +10,7 @@
 
 {% block bodyContent %}
 
-<h2>July 2025</h2>
+<h2>Month 2025</h2>
 <table class="nhsuk-table">
   <caption class="nhsuk-table__caption nhsuk-u-visually-hidden">Updates to the service manual in July 2025</caption>
   <thead class="nhsuk-table__head">
@@ -21,19 +21,9 @@
   </thead>
   <tbody class="nhsuk-table__body">
     <tr>
-      <td class="nhsuk-table__cell">Community and contribution</td>
-      <td class="nhsuk-table__cell">
-        <p>Added link to NHS App design system to <a href="/community-and-contribution/community-resources">Community resources</a> page</p>
-      </td>
-    </tr>
-    <tr>
-    <tr>
       <td class="nhsuk-table__cell">Design system</td>
       <td class="nhsuk-table__cell">
-        <p>Added new <a href="/design-system/patterns/question-pages">question pages pattern</a></p>
-        <p>Added guidance on <a href="/design-system/components/hint-text#how-to-use-hint-text">how to use hint text</a> and updated examples in design system</p>
-        <p>Updated WCAG 2.2 alerts in the design system and moved full list of <a href="/design-system/changes-to-design-system-wcag-2-2">changes to the design system to meet WCAG 2.2</a></p>
-        <p>Changed "Go back" to "Back" on <a href="/design-system/components/back-link">back link</a> and in back link examples on other pages</p>
+        <p>Added guidance on <a href="/design-system/styles/colour#main-colours">using the grey text colour modifer class</a></p>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
We currently have a `nhsuk-u-secondary-text-color` modifier class which isn’t documented in the Service Manual.

This adds some basic guidance. Wasn't sure whether it should be in Typography or Colours, but it felt more natural in the latter.

## Screenshot

![Screenshot 2025-07-07 at 16 44 02](https://github.com/user-attachments/assets/517e0bab-d2d8-4ca1-9eb9-83dc434f8359)

## Checklist

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
