### PR TITLE
Update hint text in radio examples and on NHS number pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS digital service manual Changelog
 
+## 7.13.0 - TBC
+
+:wrench: **Maintenance**
+
+- Update hint text in radio examples 
+- Update examples in NHS number pattern
+
 ## 7.12.0 - 7 July 2025
 
 :new: **New features**

--- a/app/views/design-system/components/hint-text/radios/index.njk
+++ b/app/views/design-system/components/hint-text/radios/index.njk
@@ -3,8 +3,7 @@
 {% from 'hint/macro.njk' import hint %}
 
 {% set hintHtml -%}
-  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
-  <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App</p>
 {%- endset %}
 
 {{ radios({

--- a/app/views/design-system/components/radios/with-hints/index.njk
+++ b/app/views/design-system/components/radios/with-hints/index.njk
@@ -3,8 +3,7 @@
 {% from 'hint/macro.njk' import hint %}
 
 {% set hintHtml -%}
-  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
-  <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App</p>
 {%- endset %}
 
 {{ radios({

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/filter-third/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/filter-third/index.njk
@@ -14,8 +14,7 @@ previewLayout: design-example-wrapper-full
     <div class="nhsuk-grid-column-two-thirds">
 
       {% set hintHtml -%}
-        <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
-        <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+        <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App</p>
       {%- endset %}
 
       {{ radios({

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/filter/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/filter/index.njk
@@ -14,8 +14,7 @@ previewLayout: design-example-wrapper-full
     <div class="nhsuk-grid-column-two-thirds">
 
       {% set hintHtml -%}
-        <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456.</p>
-        <p>You can find it on any letter the NHS has sent you, on a prescription or by logging in to a GP practice online service.</p>
+        <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App</p>
       {%- endset %}
 
       {{ radios({
@@ -39,10 +38,6 @@ previewLayout: design-example-wrapper-full
         {
           value: "no",
           text: "No, I do not know my NHS number"
-        },
-        {
-          value: "not sure",
-          text: "I'm not sure"
         }
       ]
       }) }}

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/index.njk
@@ -3,7 +3,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Patterns" %}
 {% set theme = "Ask users for" %}
-{% set dateUpdated = "January 2022" %}
+{% set dateUpdated = "July 2025" %}
 {% set backlog_issue_id = "109" %}
 
 {% extends "layouts/app-layout.njk" %}
@@ -54,7 +54,7 @@
 
   <h3 id="filter-question-before-single-text">Filter question before single text input</h3>
   <p>Use a <a href='/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users'>filter question</a> before a single text input if there is another way for users to continue without an NHS number.</p>
-  <p>Use a 2-option radio button that asks the user if they know their NHS number.</p>
+  <p>Use a 2-option radio button that asks the user if they know their NHS number (or try giving users <a href="#filter-question-before-input-with-3rd-option">a 3rd option</a>).</p>
 
   {{ designExample({
     group: "patterns",


### PR DESCRIPTION
## Description

Bringing hint text in radio examples that mention NHS number into line with recent guidance we published re hint text. In other words, short sentences with no full stop.

This is an interim content fix, pending a full review of the NHS number pattern and NHS number-related content in coded examples. 

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - not needed for this
