### PR TITLE
Fix 2 typos 

### DIFF
--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -36,7 +36,7 @@
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
           <p>Added new <a href="/design-system/patterns/question-pages">question pages pattern</a></p>
-          <p>Added guidance on <a href="/design-system/styles/colour#secondary-text-colour">using the grey secondary text colour modifer class</a></p>
+          <p>Added guidance on <a href="/design-system/styles/colour#secondary-text-colour">using the grey secondary text colour modifier class</a></p>
           <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
           <p>Added guidance on <a href="/design-system/components/hint-text#how-to-use-hint-text">how to use hint text</a> and updated examples in design system</p>
           <p>Updated WCAG 2.2 alerts in the design system and moved full list of <a href="/design-system/changes-to-design-system-wcag-2-2">changes to the design system to meet WCAG 2.2</a></p>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -37,7 +37,7 @@
         <td class="nhsuk-table__cell">Design system</td>
         <td class="nhsuk-table__cell">
           <p>Added new <a href="/design-system/patterns/question-pages">question pages pattern</a></p>
-          <p>Added guidance on <a href="/design-system/styles/colour#secondary-text-colour">using the grey secondary text colour modifer class</a></p>
+          <p>Added guidance on <a href="/design-system/styles/colour#secondary-text-colour">using the grey secondary text colour modifier class</a></p>
           <p>Added new guidance on <a href="/design-system/components/table#missing-data-table">displaying missing data in tables</a></p>
           <p>Added guidance on <a href="/design-system/components/hint-text#how-to-use-hint-text">how to use hint text</a> and updated examples in design system</p>
           <p>Updated WCAG 2.2 alerts in the design system and moved full list of <a href="/design-system/changes-to-design-system-wcag-2-2">changes to the design system to meet WCAG 2.2</a></p>


### PR DESCRIPTION
## Description

Fix misspellings of "modifier" on What's new index and updates pages.

For next service manual release. 

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
