### PR TITLE
Remove close, plus and minus icons

### DIFF
--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -125,30 +125,6 @@
         <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-arrow-left.svg">icon-arrow-left.svg</a></td>
         <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><span>Previous page (<a href="/design-system/components/pagination">pagination</a>)</span></td>
       </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__plus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" aria-hidden="true" height="34" width="34">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M12 8v8M8 12h8"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Plus</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-plus.svg">icon-plus.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/expander">Expander</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__minus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" aria-hidden="true" height="34" width="34">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M8 12h8"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Minus</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-minus.svg">icon-minus.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/expander">Expander</a></td>
-      </tr>
     </tbody>
   </table>
 
@@ -175,7 +151,6 @@
   <ul>
     <li>search</li>
     <li>chevron right</li>
-    <li>plus and minus (for reveals)</li>
   </ul>
   <p>Other icons needs an explanation. They include:</p>
   <ul>


### PR DESCRIPTION
## Description

* The close icon is no longer used by the header mobile menu. It was removed in https://github.com/nhsuk/nhsuk-frontend/pull/1512
* The plus and minus icon have been implemented using a `clip-path()` and no longer use SVG icons. These 2 icons were removed in https://github.com/nhsuk/nhsuk-frontend/pull/1514

Links to these 3 icons are now broken, as the Icons page points to resources on the `main` branch.

I’ve removed mentions of these icons in the remainder of the guidance.

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
