### PR TITLE
Update icon guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Update footer component and examples
 - Update guidance for using Nunjucks in production code on NHS.UK frontend v10.x
+- Update guidance for icons as we now provide inline SVG icons via nhsukIcon macro
 - Update links to blog post about question protocol
 
 ## 7.13.0 - 28 July 2025

--- a/app/javascripts/design-example.mjs
+++ b/app/javascripts/design-example.mjs
@@ -14,7 +14,9 @@ export class DesignExample extends Component {
     this.hiddenClass = 'js-hidden'
 
     this.tabs = this.$root.querySelectorAll(`.${this.tabClass}`)
-    this.examples = this.$root.querySelectorAll('.code-snippet__preformatted')
+    this.examples = this.$root.querySelectorAll(
+      '.app-code-snippet__preformatted'
+    )
     this.closeButtons = this.$root.querySelectorAll('.app-button--close')
     this.copyButtons = this.$root.querySelectorAll('.app-button--copy')
     this.iframe = this.$root.querySelector('iframe')

--- a/app/stylesheets/app/_code-highlight.scss
+++ b/app/stylesheets/app/_code-highlight.scss
@@ -34,15 +34,6 @@ td code {
   }
 }
 
-// Design example code snippet overrides
-.code-snippet__preformatted {
-  align-items: flex-end;
-  border-bottom: 1px solid nhsuk-colour("grey-4");
-  display: flex;
-  flex-direction: column;
-  padding: 16px;
-}
-
 .hljs {
   background-color: nhsuk-colour("white");
   color: nhsuk-colour("black");
@@ -68,8 +59,4 @@ td code {
 .app-tabs__container pre,
 .app-tabs__container code {
   font-family: $app-code-font;
-}
-
-.code-snippet__macro {
-  width: 100%;
 }

--- a/app/stylesheets/design-example/_code-embed.scss
+++ b/app/stylesheets/design-example/_code-embed.scss
@@ -1,6 +1,6 @@
 @use "../vendor/nhsuk-frontend" as *;
 
-.code-embed {
+.app-code-embed {
   background-color: nhsuk-colour("grey-5");
   border: 1px solid nhsuk-colour("grey-3");
 
@@ -13,7 +13,7 @@
     width: 99%;
   }
 
-  + .code-snippet {
+  + .app-code-snippet {
     margin-top: -1px;
   }
 }

--- a/app/stylesheets/design-example/_code-snippet.scss
+++ b/app/stylesheets/design-example/_code-snippet.scss
@@ -1,7 +1,7 @@
 // stylelint-disable color-no-hex, max-nesting-depth
 @use "../vendor/nhsuk-frontend" as *;
 
-.code-snippet {
+.app-code-snippet {
   background-color: nhsuk-colour("grey-5");
 
   .js-hidden {
@@ -84,11 +84,8 @@
     border-bottom: 1px solid nhsuk-colour("grey-3");
     display: flex;
     flex-direction: column;
-    padding: 16px;
 
-    @include nhsuk-media-query($from: tablet) {
-      padding: 24px;
-    }
+    @include nhsuk-responsive-padding(4);
   }
 }
 

--- a/app/views/design-system/styles/icons/arrow-right-circle/index.njk
+++ b/app/views/design-system/styles/icons/arrow-right-circle/index.njk
@@ -1,0 +1,3 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("arrow-right-circle") }}

--- a/app/views/design-system/styles/icons/arrows/index.njk
+++ b/app/views/design-system/styles/icons/arrows/index.njk
@@ -1,0 +1,5 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("arrow-left") }}
+
+{{ nhsukIcon("arrow-right") }}

--- a/app/views/design-system/styles/icons/chevron-right-circle/index.njk
+++ b/app/views/design-system/styles/icons/chevron-right-circle/index.njk
@@ -1,0 +1,3 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("chevron-right-circle") }}

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -82,7 +82,10 @@
   <p>We use scalable vector graphics (SVG) for icons, rather than images such as PNG. SVG are code snippets that you can drop directly into the HTML.</p>
   <p>SVG icons are sharp, flexible, and load quickly. You can control how they appear, for example their colour, with style sheets (CSS).</p>
   <p>If you're using Nunjucks templating language, you can use the <code>nhsukIcon</code> macro.</p>
-  <p>SVG icons have the class <code>.nhsuk-icon</code>, which sets a default size for the icon. Each icon also has a specific class, such as <code>.nhsuk-icon--search</code>. The specific class allows you to modify the icon with styles, such as fill. This means you can change the colour of the SVG for states such as hover, focus and active.</p>
+  <p>SVG icons have the class <code>.nhsuk-icon</code>, which sets a default size for the icon. Each icon also has a specific class, such as <code>.nhsuk-icon--search</code>. The specific class allows you to modify the icon with styles, such as colour via <code>fill</code>.</p>
+
+  <h3>Using colour with icons</h3>
+  <p>Icons often need to change colour based on their context and state, such as hover, focus and active. Make sure that when choosing icon colours, they have sufficient colour contrast to pass <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html">WCAG 2.2 success criterion 1.4.11 Non-text Contrast (W3C)</a>.</p>
 
   <h3>Changing the size of an icon</h3>
   <p>If you want to make an icon bigger, you can use the size override classes to make an icon 25%, 50%, 75% or 100% larger.</p>

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -84,6 +84,9 @@
     type: "user"
   }) }}
 
+  <h3 id="plus-and-minus">Plus and minus</h3>
+  <p>We use plus (+) and minus (-) in the <a href="/design-system/components/expander">expander</a> component. However, these are provided by the CSS. We do not have SVG icons for them.</p>
+
   <h2 id="how-to-use-these-icons">How to use these icons</h2>
   <p>Use icons sparingly, and not for decoration.</p>
 

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -19,9 +19,10 @@
 
   <h2 id="icons">Icons you can use</h2>
   <p>Use these icons to mark important parts of the page and highlight things you want users to do.</p>
-
+  <p>Check the relevant component and pattern pages in the design system for guidance on how to use the icons, including use of colour.</p>
+  
   <h3 id="arrows">Left and right arrows</h3>
-    <p>The left and right arrow icons are used in the <a href="/design-system/components/pagination">pagination</a> component. These icons should be used alongside text labels, for example 'Previous page' and 'Next page'.</p>
+  <p>The left and right arrow icons are used in the <a href="/design-system/components/pagination">pagination</a> component. These icons should be used alongside text labels, for example "Previous page" and "Next page".</p>
 
   {{ designExample({
     group: "styles",
@@ -39,7 +40,7 @@
   }) }}
 
   <h3 id="chevron-right-circle">Right chevron (inside a circle)</h3>
-  <p>The right chevron inside a circle icon is used in the primary <a href="/design-system/components/card">card</a> component. This icon should be used to signpost links to frequently visited or important topics.</p>
+  <p>The right chevron inside a circle icon is used in the <a href="/design-system/components/card#primary-card-with-chevron">primary card</a> component. This icon should be used on hub page cards to signpost important groups of information.</p>
 
   {{ designExample({
     group: "styles",
@@ -48,7 +49,7 @@
   }) }}
 
   <h3 id="tick-and-cross">Tick and cross</h3>
-  <p>The tick (do) and cross (don't) icons are used for <a href="/design-system/components/do-and-dont-lists">do and don't lists</a>. These icons should be shown below 'Do' and 'Don't' headings.</p>
+  <p>The tick (do) and cross (don't) icons are used for <a href="/design-system/components/do-and-dont-lists">do and don't lists</a>. These icons should be shown below "Do" and "Don't" headings.</p>
 
   {{ designExample({
     group: "styles",
@@ -57,7 +58,7 @@
   }) }}
 
   <h3 id="search">Search</h3>
-  <p>The search icon is used in the <a href="/design-system/components/header">header</a> component. When used without a visible text label, make sure the icon has an accessible name, for example 'Search'.</p>
+  <p>The search icon is used in the <a href="/design-system/components/header">header</a> component. When used without a visible text label, make sure the icon has an accessible name, for example "Search".</p>
 
   {{ designExample({
     group: "styles",
@@ -66,7 +67,7 @@
   }) }}
 
   <h3 id="user">User profile</h3>
-  <p>The user profile icon is used in the <a href="/design-system/components/header">header</a> component. This icon should be shown alongside information about the currently logged in user.</p>
+  <p>The user profile icon is used in the <a href="/design-system/components/header">header</a> component. This icon should be shown alongside information about the currently logged-in user.</p>
 
   {{ designExample({
     group: "styles",
@@ -94,7 +95,7 @@
   <p>SVG icons have the class <code>.nhsuk-icon</code>, which sets a default size for the icon. Each icon also has a specific class, such as <code>.nhsuk-icon--search</code>. The specific class allows you to modify the icon with styles, such as colour via <code>fill</code>.</p>
 
   <h3>Using colour with icons</h3>
-  <p>Icons often need to change colour based on their context and state, such as hover, focus and active. Make sure that when choosing icon colours, they have sufficient colour contrast to pass <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html">WCAG 2.2 success criterion 1.4.11 Non-text Contrast (W3C)</a>.</p>
+  <p>Icons often need to change colour based on their context and state, such as hover, focus and active. When choosing colours, make sure they have sufficient colour contrast to pass <a href="https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html">WCAG 2.2 success criterion 1.4.11 Non-text Contrast (W3C)</a>.</p>
 
   <h3>Changing the size of an icon</h3>
   <p>If you want to make an icon bigger, you can use the size override classes to make an icon 25%, 50%, 75% or 100% larger.</p>

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -7,6 +7,8 @@
 
 {% extends "layouts/app-layout.njk" %}
 
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
 {% block beforeContent %}
   {% include "design-system/styles/_breadcrumb.njk" %}
 {% endblock %}
@@ -15,160 +17,53 @@
 
   <p>WCAG 2.2: Make sure that users can successfully <a href="#wcag-icon-focus">interact with icons used as buttons</a>.</p>
 
-  <table class="nhsuk-table nhsuk-table--full-width nhsuk-table-responsive app-icon-table">
-    <caption class="nhsuk-table__caption">Icon you can use</caption>
-    <thead>
-      <tr>
-        <th>Icon</th>
-        <th>Label</th>
-        <th>Code in GitHub</th>
-        <th>Used in</th>
-      </tr>
-    </thead>
-    <tbody class="nhsuk-table__body">
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" height="34" width="34">
-            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Search</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-search.svg">icon-search.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/header">Header</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-            <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Chevron left</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-chevron-left.svg">icon-chevron-left.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><span><a href="/design-system/components/breadcrumbs">Breadcrumbs</a> (on mobile screens)</span></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Chevron right</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-chevron-right.svg">icon-chevron-right.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><span>Mobile menu, and primary <a href="/design-system/components/card">card</a> and <a href="/design-system/components/breadcrumbs">breadcrumb</a> on desktop</span></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="27" height="27">
-            <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Close</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-close.svg">icon-close.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span>Mobile menu</td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__cross" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-            <path d="M17 18.5c-.4 0-.8-.1-1.1-.4l-10-10c-.6-.6-.6-1.6 0-2.1.6-.6 1.5-.6 2.1 0l10 10c.6.6.6 1.5 0 2.1-.3.3-.6.4-1 .4z"></path>
-            <path d="M7 18.5c-.4 0-.8-.1-1.1-.4-.6-.6-.6-1.5 0-2.1l10-10c.6-.6 1.5-.6 2.1 0 .6.6.6 1.5 0 2.1l-10 10c-.3.3-.6.4-1 .4z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Cross (don't)</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-cross.svg">icon-cross.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/do-and-dont-lists">Do and Don't lists</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="none">
-            <path stroke-width="4" stroke-linecap="round" stroke="#007f3b" d="M18.4 7.8l-8.5 8.4L5.6 12"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Tick (do)</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-tick.svg">icon-tick.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/do-and-dont-lists">Do and Don't lists</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__arrow-right-circle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="34" width="34">
-            <path d="M0 0h24v24H0z" fill="none"></path>
-            <path d="M12 2a10 10 0 0 0-9.95 9h11.64L9.74 7.05a1 1 0 0 1 1.41-1.41l5.66 5.65a1 1 0 0 1 0 1.42l-5.66 5.65a1 1 0 0 1-1.41 0 1 1 0 0 1 0-1.41L13.69 13H2.05A10 10 0 1 0 12 2z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Arrow right circle</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-arrow-right-circle.svg">icon-arrow-right-circle.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/action-link">Action link</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" width="34" height="34">
-            <path d="M19.6 11.66l-2.73-3A.51.51 0 0 0 16 9v2H5a1 1 0 0 0 0 2h11v2a.5.5 0 0 0 .32.46.39.39 0 0 0 .18 0 .52.52 0 0 0 .37-.16l2.73-3a.5.5 0 0 0 0-.64z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Arrow right</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-arrow-right.svg">icon-arrow-right.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><span>Next page (<a href="/design-system/components/pagination">pagination</a>)</span></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M4.1 12.3l2.7 3c.2.2.5.2.7 0 .1-.1.1-.2.1-.3v-2h11c.6 0 1-.4 1-1s-.4-1-1-1h-11V9c0-.2-.1-.4-.3-.5h-.2c-.1 0-.3.1-.4.2l-2.7 3c0 .2 0 .4.1.6z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Arrow left</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-arrow-left.svg">icon-arrow-left.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><span>Previous page (<a href="/design-system/components/pagination">pagination</a>)</span></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__plus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" aria-hidden="true" height="34" width="34">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M12 8v8M8 12h8"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Plus</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-plus.svg">icon-plus.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/expander">Expander</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__minus" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" aria-hidden="true" height="34" width="34">
-            <circle cx="12" cy="12" r="10"></circle>
-            <path fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" d="M8 12h8"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Minus</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-minus.svg">icon-minus.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/expander">Expander</a></td>
-      </tr>
-      <tr class="nhsuk-table__row">
-        <td>
-          <span class="nhsuk-table-responsive__heading" aria-hidden="true">Icon </span>
-          <svg class="nhsuk-icon nhsuk-icon__user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M12 1a11 11 0 1 1 0 22 11 11 0 0 1 0-22Zm0 2a9 9 0 0 0-5 16.5V18a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4v1.5A9 9 0 0 0 12 3Zm0 3a3.5 3.5 0 1 1-3.5 3.5A3.4 3.4 0 0 1 12 6Z"></path>
-          </svg>
-        </td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Label </span>Profile</td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Code in GitHub </span><a target="_blank" rel="noopener noreferrer" href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons/icon-user.svg">icon-user.svg</a></td>
-        <td><span class="nhsuk-table-responsive__heading" aria-hidden="true">Used in </span><a href="/design-system/components/header">Header</a></td>
-      </tr>
-    </tbody>
-  </table>
-
-  <p>You can find all the SVG icons code in the <a href="https://github.com/nhsuk/nhsuk-frontend/tree/main/packages/nhsuk-frontend/src/nhsuk/assets/icons">NHS.UK frontend library on GitHub</a>.</p>
-
-  <h2 id="when-to-use-these-icons">When to use these icons</h2>
+  <h2 id="icons">Icons you can use</h2>
   <p>Use these icons to mark important parts of the page and highlight things you want users to do.</p>
+
+  <h3 id="arrows">Left and right arrows</h3>
+  <p>The left and right arrow icons are used in the <a href="/design-system/components/pagination">pagination</a> component. These icons should be used alongside text labels, for example ‘Previous page’ and ‘Next page’.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "arrows"
+  }) }}
+
+  <h3 id="arrow-right-circle">Right arrow (inside a circle)</h3>
+  <p>The right arrow inside a circle icon is used in the <a href="/design-system/components/action-link">action link</a> and primary <a href="/design-system/components/card">card</a> components. This icon should be used to add visual weight and signpost key links on a page.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "arrow-right-circle"
+  }) }}
+
+  <h3 id="tick-and-cross">Tick and cross</h3>
+  <p>The tick (do) and cross (don't) icons are used for <a href="/design-system/components/do-and-dont-lists">do and don't lists</a>. These icons should be shown below 'Do' and 'Don't' headings.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "tick-and-cross"
+  }) }}
+
+  <h3 id="search">Search</h3>
+  <p>The search icon is used in the <a href="/design-system/components/header">header</a> component. When used without a visible text label, make sure the icon has an accessible name, for example 'Search'.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "search"
+  }) }}
+
+  <h3 id="user">User profile</h3>
+  <p>The user profile icon is used in the <a href="/design-system/components/header">header</a> component. This icon should be shown alongside information about the currently logged in user.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "user"
+  }) }}
 
   <h2 id="how-to-use-these-icons">How to use these icons</h2>
   <p>Use icons sparingly, and not for decoration.</p>
@@ -179,30 +74,24 @@
       WCAG 2.2
     </strong>
 
-    <p>Make sure any icons used as buttons are at least 24px by 24px in target size, or that there is another way to perform the action. For example: an "X" icon to close, supported by a labelled "Close" button.</p>
+    <p>Make sure any icons used as buttons are at least 24px by 24px in target size, or that there is another way to perform the action. For example: a search icon to submit a query supported by a labelled "Search" button.</p>
     <p>This is to make sure users can easily interact with them. This is to comply with <a href="https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html">WCAG 2.2 success criterion 2.5.8 Target Size (W3C)</a>.</p>
   </div>
-
-  <h3>Using text with icons</h3>
-  <p>Some of our icons can be used on their own. Users recognise them easily. They include:</p>
-  <ul>
-    <li>search</li>
-    <li>chevron right</li>
-    <li>plus and minus (for reveals)</li>
-    <li>close</li>
-  </ul>
-  <p>Other icons needs an explanation. They include:</p>
-  <ul>
-    <li><a href="/design-system/components/action-link">action links</a> – tell the user what the link will help them do, for example: "Find a pharmacy"</li>
-    <li>right and left arrows for <a href="/design-system/components/pagination">pagination</a> – add "Previous" or "Next"</li>
-    <li>cross and tick – use the words Do and Don't at the top of <a href="/design-system/components/do-and-dont-lists">Do and Don't lists</a></li>
-  </ul>
 
   <h3>Using SVG classes for icons</h3>
   <p>We use scalable vector graphics (SVG) for icons, rather than images such as PNG. SVG are code snippets that you can drop directly into the HTML.</p>
   <p>SVG icons are sharp, flexible, and load quickly. You can control how they appear, for example their colour, with style sheets (CSS).</p>
-  <p class="rich-text">If you're using a server side or templating language, you can include the icons with <code>include 'partials/icons/icon-search.svg'</code>.</p>
-  <p class="rich-text">SVG icons have the class <code>.nhsuk-icon</code>, which sets a default size for the icon. Each icon also has a specific class, such as <code>.nhsuk-icon__search</code>. The specific class allows you to modify the icon with styles, such as fill. This means you can change the colour of the SVG for states such as hover, focus and active.</p>
+  <p>If you're using Nunjucks templating language, you can use the <code>nhsukIcon</code> macro.</p>
+  <p>SVG icons have the class <code>.nhsuk-icon</code>, which sets a default size for the icon. Each icon also has a specific class, such as <code>.nhsuk-icon--search</code>. The specific class allows you to modify the icon with styles, such as fill. This means you can change the colour of the SVG for states such as hover, focus and active.</p>
+
+  <h3>Changing the size of an icon</h3>
+  <p>If you want to make an icon bigger, you can use the size override classes to make an icon 25%, 50%, 75% or 100% larger.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "sizes"
+  }) }}
 
   <h3>Accessibility</h3>
   <p>SVG icons must be accessible. For example, they need to meet accessible colour contrast standards. Our recommended tool to test colour combinations is the <a href="https://webaim.org/resources/contrastchecker/">WebAIM contrast checker</a>. Read more about <a href="https://css-tricks.com/accessible-svgs/">accessible SVGs on CSS Tricks website</a>.</p>

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -15,12 +15,21 @@
 
 {% block bodyContent %}
 
+  <div class="nhsuk-inset-text nhsuk-u-margin-top-0">
+    <strong class="nhsuk-tag nhsuk-tag--blue nhsuk-u-margin-bottom-2">
+      Version 10
+    </strong>
+
+    <h3 id="v10-affects-this-component" class="nhsuk-u-margin-bottom-2">Icons updated in August 2025</h3>
+    <p>See <a href="/design-system/guides/updating-to-v10#components">updates to components (including icons) in version 10</a></p>
+  </div>
+
   <p>WCAG 2.2: Make sure that users can successfully <a href="#wcag-icon-focus">interact with icons used as buttons</a>.</p>
 
   <h2 id="icons">Icons you can use</h2>
   <p>Use these icons to mark important parts of the page and highlight things you want users to do.</p>
   <p>Check the relevant component and pattern pages in the design system for guidance on how to use the icons, including use of colour.</p>
-  
+
   <h3 id="arrows">Left and right arrows</h3>
   <p>The left and right arrow icons are used in the <a href="/design-system/components/pagination">pagination</a> component. These icons should be used alongside text labels, for example "Previous page" and "Next page".</p>
 

--- a/app/views/design-system/styles/icons/index.njk
+++ b/app/views/design-system/styles/icons/index.njk
@@ -21,7 +21,7 @@
   <p>Use these icons to mark important parts of the page and highlight things you want users to do.</p>
 
   <h3 id="arrows">Left and right arrows</h3>
-  <p>The left and right arrow icons are used in the <a href="/design-system/components/pagination">pagination</a> component. These icons should be used alongside text labels, for example ‘Previous page’ and ‘Next page’.</p>
+    <p>The left and right arrow icons are used in the <a href="/design-system/components/pagination">pagination</a> component. These icons should be used alongside text labels, for example 'Previous page' and 'Next page'.</p>
 
   {{ designExample({
     group: "styles",
@@ -30,12 +30,21 @@
   }) }}
 
   <h3 id="arrow-right-circle">Right arrow (inside a circle)</h3>
-  <p>The right arrow inside a circle icon is used in the <a href="/design-system/components/action-link">action link</a> and primary <a href="/design-system/components/card">card</a> components. This icon should be used to add visual weight and signpost key links on a page.</p>
+  <p>The right arrow inside a circle icon is used in the <a href="/design-system/components/action-link">action link</a> component. This icon should be used to signpost links that start a digital service.</p>
 
   {{ designExample({
     group: "styles",
     item: "icons",
     type: "arrow-right-circle"
+  }) }}
+
+  <h3 id="chevron-right-circle">Right chevron (inside a circle)</h3>
+  <p>The right chevron inside a circle icon is used in the primary <a href="/design-system/components/card">card</a> component. This icon should be used to signpost links to frequently visited or important topics.</p>
+
+  {{ designExample({
+    group: "styles",
+    item: "icons",
+    type: "chevron-right-circle"
   }) }}
 
   <h3 id="tick-and-cross">Tick and cross</h3>

--- a/app/views/design-system/styles/icons/search/index.njk
+++ b/app/views/design-system/styles/icons/search/index.njk
@@ -1,0 +1,5 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("search", {
+  title: "Search"
+}) }}

--- a/app/views/design-system/styles/icons/sizes/index.njk
+++ b/app/views/design-system/styles/icons/sizes/index.njk
@@ -1,0 +1,17 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("user", {
+  classes: "nhsuk-icon--size-25"
+}) }}
+
+{{ nhsukIcon("user", {
+  classes: "nhsuk-icon--size-50"
+}) }}
+
+{{ nhsukIcon("user", {
+  classes: "nhsuk-icon--size-75"
+}) }}
+
+{{ nhsukIcon("user", {
+  classes: "nhsuk-icon--size-100"
+}) }}

--- a/app/views/design-system/styles/icons/tick-and-cross/index.njk
+++ b/app/views/design-system/styles/icons/tick-and-cross/index.njk
@@ -1,0 +1,5 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("tick") }}
+
+{{ nhsukIcon("cross") }}

--- a/app/views/design-system/styles/icons/user/index.njk
+++ b/app/views/design-system/styles/icons/user/index.njk
@@ -1,0 +1,3 @@
+{% from "nhsuk/macros/icon.njk" import nhsukIcon %}
+
+{{ nhsukIcon("user") }}

--- a/app/views/macros/design-example/macro.njk
+++ b/app/views/macros/design-example/macro.njk
@@ -48,13 +48,13 @@
       <a href="{{ standaloneURL }}" class="app-design-example__pop-out" target="_blank" rel="noopener noreferrer">
         Open this<span class="nhsuk-u-visually-hidden"> {{ exampleTitle }}</span> example in a new tab
       </a>
-      <div class="code-embed">
+      <div class="app-code-embed">
         <iframe title="{{ params.type }}" src="{{ standaloneURL }}" class="app-design-example__frame"></iframe>
       </div>
     {% endif %}
 
     {% if showCode %}
-      <div class="code-snippet">
+      <div class="app-code-snippet">
         {% if snippets | length > 1 %}
           <ul class="app-tabs" role="tablist">
             {% for snippet in snippets %}
@@ -76,11 +76,11 @@
                 </a>
               </div>
             {% endif %}
-            <div class="code-snippet__preformatted {% if snippets|length > 1 %}js-hidden{% endif %}" data-index="ex-{{ loop.index }}">
+            <div class="app-code-snippet__preformatted {% if snippets|length > 1 %}js-hidden{% endif %}" data-index="ex-{{ loop.index }}">
               {% set nunjucksParams = getNunjucksParams(params.item) if params.group == "components" and snippet.name == "Nunjucks" else [] %}
 
               {% if nunjucksParams | length %}
-                <div class="code-snippet__macro">
+                <div class="app-code-snippet__macro">
                   <details class="nhsuk-details">
                     <summary class="nhsuk-details__summary">
                       <span class="nhsuk-details__summary-text">


### PR DESCRIPTION
## Description

For the next breaking v10 release of NHS.UK frontend, inline SVG icons are provided to components via an `nhsukIcon` macro. This means there is now a single source of truth for our icon set, and no longer a separate store of SVG files which may fall out of sync.

This change however means we need to update our guidance page for icons. Some of the icons are no longer provided by this macro (they are provided by CSS) while links to SVG files for the remaining icons now return a 404 page. Some of the guidance is also out of date.

However, we can use the new macro in the service manual and output the same SVG code for users to copy and paste, as well as show them how they can use the macro to output icons if they are using Nunjucks.

▶️ [View updated icons guidance](https://nhsuk-service-manual-pr-2245.herokuapp.com/design-system/styles/icons)

<img width="400" alt="Screenshot of updated icons guidance page." src="https://github.com/user-attachments/assets/184a8847-6116-4638-a3b4-d70b46d22e1f" />

### Updates

- Replaces the table with separate code examples for each icon. I have combined the information in this table with later guidance about how these icons should be used
- Adds guidance about the sizing class modifier
- Updates guidance about how to include icons with the Nunjucks macro 
- Fixes some inconsistent and duplicate styles used for code examples

### Right chevron in a circle

This PR currently excludes the chevron in a circle icon. Upon reviewing this guidance, it seemed odd that we have 2 very similar icons, used for very similar purposes. I am proposing consolidating these 2 icons in https://github.com/nhsuk/nhsuk-frontend/pull/1541

### Related issues

- https://github.com/nhsuk/nhsuk-frontend/pull/1028
- https://github.com/nhsuk/nhsuk-frontend/pull/1521

## Checklist

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
