### PR TITLE
Update radios hint example

### DIFF
--- a/app/views/design-system/components/radios/with-hints/index.njk
+++ b/app/views/design-system/components/radios/with-hints/index.njk
@@ -2,10 +2,6 @@
 {% from 'fieldset/macro.njk' import fieldset %}
 {% from 'hint/macro.njk' import hint %}
 
-{% set hintHtml -%}
-  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App</p>
-{%- endset %}
-
 {{ radios({
   idPrefix: "example-hints",
   name: "example-hints",
@@ -17,7 +13,7 @@
     }
   },
   hint: {
-    html: hintHtml
+    text: "This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App"
   },
   items: [
   {


### PR DESCRIPTION
Now that this is a single sentence, it no longer needs to use a `set` block or a margin overrride class, and can instead use the `text` param.