### PR TITLE
Add form tag to question page examples

### DIFF
--- a/app.js
+++ b/app.js
@@ -238,7 +238,7 @@ app.get('/robots.txt', (_, res) => {
 })
 
 // Render 404 page
-app.get('*', (_, res) => {
+app.all('*', (_, res) => {
   res.statusCode = 404
   res.render('page-not-found')
 })

--- a/app/javascripts/main.mjs
+++ b/app/javascripts/main.mjs
@@ -48,6 +48,6 @@ document.querySelectorAll(DesignExample.selector()).forEach((el) => {
 
 document.querySelectorAll('form[action="/form-handler"]').forEach((form) => {
   form.addEventListener('submit', (event) => {
-    event.preventDefault();
+    event.preventDefault()
   })
 })

--- a/app/javascripts/main.mjs
+++ b/app/javascripts/main.mjs
@@ -45,3 +45,9 @@ AccessibleAutocomplete({
 document.querySelectorAll(DesignExample.selector()).forEach((el) => {
   new DesignExample(el)
 })
+
+document.querySelectorAll('form[action="/form-handler"]').forEach((form) => {
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+  })
+})

--- a/app/views/design-system/patterns/question-pages/complex-question/index.njk
+++ b/app/views/design-system/patterns/question-pages/complex-question/index.njk
@@ -26,30 +26,33 @@ previewLayout: design-example-wrapper-full
       </h1>
       <p>Let us know if you have any communication needs you'd like us to be aware of. For example, a hearing or visual impairment.</p>
 
-      {{ radios({
-        name: "contactNeeds",
-        fieldset: {
-          legend: {
-            text: "Do you have any communication needs?",
-            classes: "nhsuk-fieldset__legend--m"
-          }
-        },
-        items: [
-          {
-            value: "yes",
-            text: "Yes"
+      <form action="/form-handler" method="post" novalidate>
+
+        {{ radios({
+          name: "contactNeeds",
+          fieldset: {
+            legend: {
+              text: "Do you have any communication needs?",
+              classes: "nhsuk-fieldset__legend--m"
+            }
           },
-          {
-            value: "no",
-            text: "No"
-          }
-        ]
-      }) }}
+          items: [
+            {
+              value: "yes",
+              text: "Yes"
+            },
+            {
+              value: "no",
+              text: "No"
+            }
+          ]
+        }) }}
 
-      {{ button({
-        text: "Continue"
-      }) }}
+        {{ button({
+          text: "Continue"
+        }) }}
 
+      </form>
     </div>
   </div>
 

--- a/app/views/design-system/patterns/question-pages/default/index.njk
+++ b/app/views/design-system/patterns/question-pages/default/index.njk
@@ -20,40 +20,42 @@ previewLayout: design-example-wrapper-full
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
+      <form action="/form-handler" method="post" novalidate>
 
-      {{ radios({
-        name: "whereDoYouLive",
-        fieldset: {
-          legend: {
-            text: "Where do you live?",
-            isPageHeading: true,
-            classes: "nhsuk-fieldset__legend--l"
-          }
-        },
-        items: [
-          {
-            value: "england",
-            text: "England"
+        {{ radios({
+          name: "whereDoYouLive",
+          fieldset: {
+            legend: {
+              text: "Where do you live?",
+              isPageHeading: true,
+              classes: "nhsuk-fieldset__legend--l"
+            }
           },
-          {
-            value: "scotland",
-            text: "Scotland"
-          },
-          {
-            value: "wales",
-            text: "Wales"
-          },
-          {
-            value: "northern-ireland",
-            text: "Northern Ireland"
-          }
-        ]
-      }) }}
+          items: [
+            {
+              value: "england",
+              text: "England"
+            },
+            {
+              value: "scotland",
+              text: "Scotland"
+            },
+            {
+              value: "wales",
+              text: "Wales"
+            },
+            {
+              value: "northern-ireland",
+              text: "Northern Ireland"
+            }
+          ]
+        }) }}
 
-      {{ button({
-        text: "Continue"
-      }) }}
+        {{ button({
+          text: "Continue"
+        }) }}
 
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/app/views/design-system/patterns/question-pages/label-page-heading/index.njk
+++ b/app/views/design-system/patterns/question-pages/label-page-heading/index.njk
@@ -20,23 +20,25 @@ previewLayout: design-example-wrapper-full
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
+      <form action="/form-handler" method="post" novalidate>
 
-      {{ input({
-        label: {
-          text: "What is your home postcode?",
-          isPageHeading: true,
-          classes: "nhsuk-label--l"
-        },
-        classes: "nhsuk-input--width-10",
-        id: "postcode",
-        name: "postcode",
-        autocomplete: "postal-code"
-      }) }}
+        {{ input({
+          label: {
+            text: "What is your home postcode?",
+            isPageHeading: true,
+            classes: "nhsuk-label--l"
+          },
+          classes: "nhsuk-input--width-10",
+          id: "postcode",
+          name: "postcode",
+          autocomplete: "postal-code"
+        }) }}
 
-      {{ button({
-        text: "Continue"
-      }) }}
+        {{ button({
+          text: "Continue"
+        }) }}
 
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/app/views/design-system/patterns/question-pages/legend-page-heading/index.njk
+++ b/app/views/design-system/patterns/question-pages/legend-page-heading/index.njk
@@ -20,40 +20,42 @@ previewLayout: design-example-wrapper-full
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
+      <form action="/form-handler" method="post" novalidate>
 
-      {{ dateInput({
-        id: "example",
-        namePrefix: "example",
-        fieldset: {
-          legend: {
-            text: "What is your date of birth?",
-            classes: "nhsuk-label--l",
-            isPageHeading: true
-          }
-        },
-        hint: {
-          text: "For example, 15 3 1984"
-        },
-        items: [
-          {
-            name: "day",
-            classes: "nhsuk-input--width-2"
+        {{ dateInput({
+          id: "example",
+          namePrefix: "example",
+          fieldset: {
+            legend: {
+              text: "What is your date of birth?",
+              classes: "nhsuk-label--l",
+              isPageHeading: true
+            }
           },
-          {
-            name: "month",
-            classes: "nhsuk-input--width-2"
+          hint: {
+            text: "For example, 15 3 1984"
           },
-          {
-            name: "year",
-            classes: "nhsuk-input--width-4"
-          }
-        ]
-      }) }}
+          items: [
+            {
+              name: "day",
+              classes: "nhsuk-input--width-2"
+            },
+            {
+              name: "month",
+              classes: "nhsuk-input--width-2"
+            },
+            {
+              name: "year",
+              classes: "nhsuk-input--width-4"
+            }
+          ]
+        }) }}
 
-      {{ button({
-        text: "Continue"
-      }) }}
+        {{ button({
+          text: "Continue"
+        }) }}
 
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/app/views/design-system/patterns/question-pages/multiple-questions/index.njk
+++ b/app/views/design-system/patterns/question-pages/multiple-questions/index.njk
@@ -20,58 +20,60 @@ previewLayout: design-example-wrapper-full
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-
       <h1 class="nhsuk-heading-l">
         Your details
       </h1>
       <p>You've told us you are the carer. We need your details.</p>
 
-      {{ input({
-        label: {
-          text: "First name",
-          classes: "nhsuk-label--s"
-        },
-        id: "example",
-        name: "example"
-      }) }}
+      <form action="/form-handler" method="post" novalidate>
 
-      {{ input({
-        label: {
-          text: "Last name",
-          classes: "nhsuk-label--s"
-        },
-        id: "example1",
-        name: "example1"
-      }) }}
+        {{ input({
+          label: {
+            text: "First name",
+            classes: "nhsuk-label--s"
+          },
+          id: "example",
+          name: "example"
+        }) }}
 
-      {{ input({
-        label: {
-          text: "Relationship to the person being registered",
-          classes: "nhsuk-label--s"
-        },
-        hint: {
-          text: "For example, a family member or friend"
-        },
-        id: "example2",
-        name: "example2"
-      }) }}
+        {{ input({
+          label: {
+            text: "Last name",
+            classes: "nhsuk-label--s"
+          },
+          id: "example1",
+          name: "example1"
+        }) }}
 
-      {{ input({
-        label: {
-          text: "Contact phone number",
-          classes: "nhsuk-label--s"
-        },
-        id: "example3",
-        name: "example3",
-        type: "tel",
-        autocomplete: "tel",
-        classes: "nhsuk-input--width-20"
-      }) }}
+        {{ input({
+          label: {
+            text: "Relationship to the person being registered",
+            classes: "nhsuk-label--s"
+          },
+          hint: {
+            text: "For example, a family member or friend"
+          },
+          id: "example2",
+          name: "example2"
+        }) }}
 
-      {{ button({
-        text: "Continue"
-      }) }}
+        {{ input({
+          label: {
+            text: "Contact phone number",
+            classes: "nhsuk-label--s"
+          },
+          id: "example3",
+          name: "example3",
+          type: "tel",
+          autocomplete: "tel",
+          classes: "nhsuk-input--width-20"
+        }) }}
 
+        {{ button({
+          text: "Continue"
+        }) }}
+
+      </form>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
When reviewing the NHS Prototype kit tutorial, @edwardhorsford and I noticed that the tutorial asks you to [copy the code from the question page examples](https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/create-pages) and then [change the action attribute in the `<form>` tag](https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/link-pages-together) to link the pages together.

However the examples don’t currently include a `<form>` tag. Whilst we could update the tutorial to mention adding this, it does feel like a helpful thing to have in the examples, especially as it also reminds you to add the `novalidate` attribute to disable any client-side validation.

This is also consistent with the [GOV.UK Design System question page examples](https://design-system.service.gov.uk/patterns/question-pages/).

Not sure this change is significant enough to warrant a mention in the CHANGELOG, but happy to add it if we think it’d helpful.