### PR TITLE
Use Nunjucks macro for buttons

### DIFF
--- a/app/views/design-system/patterns/start-page/example/index.njk
+++ b/app/views/design-system/patterns/start-page/example/index.njk
@@ -43,7 +43,10 @@ previewLayout: design-example-wrapper-full
 
       <p>We'll ask you for: ...</p>
 
-      <a class="nhsuk-button" href="#" role="button" draggable="false">Start now</a>
+      {{ button({
+        text: "Start now",
+        href: "#"
+      }) }}
 
       <p>By using this service you are agreeing to our <a href="#">terms of use</a> and <a href="#">privacy policy</a>.</p>
 

--- a/app/views/design-system/styles/use-frutiger-font/index.njk
+++ b/app/views/design-system/styles/use-frutiger-font/index.njk
@@ -103,9 +103,14 @@
 </ul>
 
 <h2>Next step</h2>
+
 <div>
-  <a class="nhsuk-button" style="display: inline-block;" href="/design-system/styles/use-frutiger-font/terms-of-licence" role="button" draggable="false">Read the licence terms</a>
+  {{ button({
+    text: "Read the licence terms",
+    href: "/design-system/styles/use-frutiger-font/terms-of-licence"
+  }) }}
 </div>
+
 <p>At the end of the terms, there's a link to the registration form.</p>
 
 <h2>More information</h2>


### PR DESCRIPTION
Switch to using the Nunjucks macro for the button on the Start page example.

This adds a missing `data-module="button"` attribute, and also helps us keep the example up to date with any HTML changes in future.