### PR TITLE
Add default cache headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,8 +40,42 @@ app.use(
   })
 )
 
-// Middleware to serve static assets
-app.use(express.static(config.publicPath))
+/**
+ * Send different cache-control headers depending on the file path
+ *
+ * Asset filenames with fingerprint hashes (stylesheets, javascripts) are
+ * given an 'infinite' max-age since the content never changes.
+ *
+ * Historically, an 'infinite' max-age is the 32-bit maximum 2,147,483,648.
+ * https://datatracker.ietf.org/doc/html/rfc9111#section-1.2.2
+ */
+
+app.use(
+  '/assets',
+  express.static(join(config.publicPath, 'assets'), {
+    setHeaders(res) {
+      res.set('Cache-Control', 'public,max-age=0,must-revalidate')
+    }
+  })
+)
+
+app.use(
+  '/javascripts',
+  express.static(join(config.publicPath, 'javascripts'), {
+    setHeaders(res) {
+      res.set('Cache-Control', 'public,max-age=2147483648,immutable')
+    }
+  })
+)
+
+app.use(
+  '/stylesheets',
+  express.static(join(config.publicPath, 'stylesheets'), {
+    setHeaders(res) {
+      res.set('Cache-Control', 'public,max-age=2147483648,immutable')
+    }
+  })
+)
 
 // View engine (nunjucks)
 app.set('view engine', 'njk')

--- a/middleware/routing.js
+++ b/middleware/routing.js
@@ -18,7 +18,10 @@ function renderPath(path, res, next) {
   res.render(path, (error, html) => {
     // [1] //
     if (!error) {
-      res.set({ 'Content-type': 'text/html; charset=utf-8' }) // [2] //
+      res.set({
+        'Cache-Control': 'public,max-age=0,must-revalidate',
+        'Content-Type': 'text/html; charset=utf-8'
+      }) // [2] //
       res.end(html)
       return
     }


### PR DESCRIPTION
## Description

This PR adds changes to automatically revalidate CDN-cached responses

We now use two types of default `Cache-Control` header:

1. Adds `public,max-age=0,must-revalidate` to `/assets/*` and HTML pages
2. Adds `public,max-age=2147483648,immutable` to `/javascripts/*` and `/stylesheets/*`

Where 1) is the sensible default for [Netlify's **Better Living Through Caching** approach](https://www.netlify.com/blog/2017/02/23/better-living-through-caching/)

>**“max-age=0, must-revalidate, public”** = “please cache this content, and then do not trust your cache”. This seems a bit counterintuitive, but there’s a good reason. This favors you as a content creator — you can change any of your content in an instant. Let a broken page out in a deploy? Roll back instantly. Want to make sure that your new marketing site all goes out — text, code, and assets — at the same instant so your visitors don’t experience the dreaded new/old mixture that old, file-at-a-time deploy methods left you with? We’re ready!

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
