### PR TITLE
Fix path to new nhsuk-frontend.min.js

### DIFF
--- a/app/views/design-system/guides/updating-to-v10.njk
+++ b/app/views/design-system/guides/updating-to-v10.njk
@@ -128,7 +128,7 @@
 
   <p>For precompiled JavaScript, note the following path changes:</p>
 
-  <p>If you are using the precompiled file in the npm package at <code>node_modules/nhsuk-frontend/dist/nhsuk/nhsuk-frontend.min.js</code>, update this path to <code>node_modules/nhsuk-frontend/dist/nhsuk.min.js</code></p>
+  <p>If you are using the precompiled file in the npm package at <code>node_modules/nhsuk-frontend/dist/nhsuk.min.js</code>, update this path to <code>node_modules/nhsuk-frontend/dist/nhsuk/nhsuk-frontend.min.js</code></p>
 
   <p>If you are using the precompiled file from the GitHub release zip file at <code>css/nhsuk-&lt;VERSION-NUMBER&gt;.min.js</code>, update this path to <code>nhsuk-frontend-&lt;VERSION-NUMBER&gt;.min.js</code>.</p>
 


### PR DESCRIPTION
Discovered a typo in the Upgrade guide for the new path of the precompiled JavaScript.

It is correct in the `CHANGELOG`.