### PR TITLE
Fix unnecessarily escaped HTML attributes

### DIFF
--- a/app/views/community-and-contribution/community-resources.njk
+++ b/app/views/community-and-contribution/community-resources.njk
@@ -55,7 +55,7 @@
   {% call details({
     summaryText: "Get support with these resources via Slack"
   }) %}
-    <p><a href=\"https://service-manual.nhs.uk/slack\">Join our free Slack workspace</a> to access dedicated channels where you can ask questions and discuss issues and ideas. The channels are:</p>
+    <p><a href="https://service-manual.nhs.uk/slack">Join our free Slack workspace</a> to access dedicated channels where you can ask questions and discuss issues and ideas. The channels are:</p>
     <ul>
       <li>#mural-flow-diagrams</li>
       <li>#paper-sketching-templates</li>

--- a/app/views/design-system/components/expander/default/index.njk
+++ b/app/views/design-system/components/expander/default/index.njk
@@ -7,6 +7,6 @@
   <p>You can see your GP records by:</p>
   <ul>
     <li>asking for them at your GP surgery </li>
-    <li>going online to see them (if you have signed up for <a href=\"/using-the-nhs/nhs-services/gps/gp-online-services/\">GP online services</a>) </li>
+    <li>going online to see them (if you have signed up for <a href="/using-the-nhs/nhs-services/gps/gp-online-services/">GP online services</a>) </li>
   </ul>
 {% endcall %}


### PR DESCRIPTION
## Description

Found a couple of stray `href=\""` attributes affecting the Slack sign up link etc

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
