### PR TITLE
Confirmation page example tweaks

### DIFF
--- a/app/views/design-system/patterns/confirmation-page/default/index.njk
+++ b/app/views/design-system/patterns/confirmation-page/default/index.njk
@@ -8,41 +8,48 @@ previewLayout: design-example-wrapper-full
 {% from "summary-list/macro.njk" import summaryList %}
 
 {% block content %}
-    <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-two-thirds">
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
 
-            {{ panel({
-                titleText: "Booking complete",
-                html: "We have sent you a confirmation email"
-            }) }}
+      {{ panel({
+        titleText: "Booking complete",
+        html: "We have sent you a confirmation email"
+      }) }}
 
-            <h2 class="nhsuk-heading-m">Your appointment details</h2>
+      <h2 class="nhsuk-heading-m">Your appointment details</h2>
 
-                {{ summaryList({
-                classes: 'nhsuk-summary-list--no-border',
-                rows: [
-                    {
-                        key: {
-                            text: "Site location"
-                        },
-                        value: {
-                            html: "St Georges Pharmacy<br>46 St George's Rd,<br>Elephant and Castle,<br>London<br>SE1 6ET<br>
-                            <a href='#'>Map and directions (opens in a new tab)</a>"
-                        }
-                    },
-                    {
-                        key: {
-                            text: "Date and time"
-                        },
-                        value: {
-                            text: "Thursday 15 June at 9:10am"
-                        }
-                    }
-                ]
-                }) }}
+      {% set siteLocationHtml %}
+        St Georges Pharmacy<br>
+        46 St George's Rd,<br>
+        Elephant and Castle,<br>
+        London<br>
+        SE1 6ET<br>
+        <a href="#" target="_blank" class="nhsuk-link">Map and directions (opens in a new tab)</a>
+      {% endset %}
 
-            <p><a href="#" class="nhsuk-link">Tell us about your experience using this service (opens in a new tab)</a></p>
+      {{ summaryList({
+        classes: "nhsuk-summary-list--no-border",
+        rows: [
+          {
+            key: {
+              text: "Site location"
+            },
+            value: {
+              html: siteLocationHtml
+            }
+          },
+          {
+            key: {
+              text: "Date and time"
+            },
+            value: {
+              text: "Thursday 15 June at 9:10am"
+            }
+          }
+        ]
+      }) }}
 
-        </div>
+      <p><a href="#" class="nhsuk-link">Tell us about your experience using this service (opens in a new tab)</a></p>
     </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
Updates to the example:

* 2 spaces for indenting instead of 4
* using `"` for html attributes
* a `set` block for html embedded in a Nunjucks macro (avoids escaping `"` characters)
* adding `nhsuk-link` class to 1 of the links
* adding `target="_blank"` to a link which opens in a new tab