### PR TITLE
Notifications were added in v10, not updated

### DIFF
--- a/app/views/design-system/components/notification-banners/index.njk
+++ b/app/views/design-system/components/notification-banners/index.njk
@@ -19,8 +19,8 @@
       Version 10
     </strong>
 
-    <h3 id="v10-affects-this-component" class="nhsuk-u-margin-bottom-2">Notification banners updated in August 2025</h3>
-    <p>See <a href="/design-system/guides/updating-to-v10#notification-banners">updates to notification banners in version 10</a></p>
+    <h3 id="v10-affects-this-component" class="nhsuk-u-margin-bottom-2">Notification banners added in August 2025</h3>
+    <p>See <a href="/design-system/guides/updating-to-v10#notification-banners">notification banners in version 10</a></p>
   </div>
 
 {{ designExample({


### PR DESCRIPTION
Make it clear that Notification banners were added in version 10, and weren't updated then (as there was nothing to update).

Alternatively we could remove this bit from the page entirely, as there’s not a lot of extra detail in the upgrade guide, except for:

> If you have created your own custom notification banner component, you can replace this with the newly added one.

?