### PR TITLE
Update hint guidance to avoid unnecessary set usage

### DIFF
--- a/app/views/design-system/components/hint-text/input/index.njk
+++ b/app/views/design-system/components/hint-text/input/index.njk
@@ -4,7 +4,7 @@
   label: {
     text: "What is your NHS number?"
   },
-    hint: {
+  hint: {
     text: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you, for example, 485 777 3456"
   },
   id: "example-with-hint-text",

--- a/app/views/design-system/components/hint-text/radios/index.njk
+++ b/app/views/design-system/components/hint-text/radios/index.njk
@@ -2,10 +2,6 @@
 {% from 'fieldset/macro.njk' import fieldset %}
 {% from 'hint/macro.njk' import hint %}
 
-{% set hintHtml -%}
-  <p class="nhsuk-u-margin-bottom-2">This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App</p>
-{%- endset %}
-
 {{ radios({
   idPrefix: "example-hints",
   name: "example-hints",
@@ -17,20 +13,20 @@
     }
   },
   hint: {
-    html: hintHtml
+    text: "This is a 10 digit number, like 485 777 3456, that you can find on an NHS letter, prescription or in the NHS App"
   },
   items: [
-  {
-    value: "yes",
-    text: "Yes, I know my NHS number"
-  },
-  {
-    value: "no",
-    text: "No, I do not know my NHS number"
-  },
-  {
-    value: "not sure",
-    text: "I'm not sure"
-  }
-]
+    {
+      value: "yes",
+      text: "Yes, I know my NHS number"
+    },
+    {
+      value: "no",
+      text: "No, I do not know my NHS number"
+    },
+    {
+      value: "not sure",
+      text: "I'm not sure"
+    }
+  ]
 }) }}


### PR DESCRIPTION
## Description

This came up in the kit training yesterday - the hint guidance for radios uses the older example we replaced a few weeks ago.