### PR TITLE
Fix to previous javascripts path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:wrench: **Maintenance**
+
+- Update javascript path examples in version 10 upgrade guide
+
 ## 8.0.2 - 12 September 2025
 
 :wrench: **Maintenance**

--- a/app/views/design-system/guides/updating-to-v10.njk
+++ b/app/views/design-system/guides/updating-to-v10.njk
@@ -204,16 +204,16 @@
   <p>Before:</p>
 
   <code class="language-js nhsuk-u-margin-bottom-4"><pre>
-    <del>&lt;script src="/<JAVASCRIPTS-PATH>/nhsuk.min.js" defer&gt;&lt;/script&gt;</del>
+    <del>&lt;script src="/&lt;JAVASCRIPTS-PATH&gt;/nhsuk.min.js" defer&gt;&lt;/script&gt;</del>
   <del>&lt;/head&gt;</del>
 </pre></code>
 
   <p>After:</p>
 
   <code class="language-js nhsuk-u-margin-bottom-4"><pre>
-    <ins>&lt;script type="module" src="/<JAVASCRIPTS-PATH>/nhsuk-frontend.min.js"&gt;&lt;/script&gt;</ins>
+    <ins>&lt;script type="module" src="/&lt;JAVASCRIPTS-PATH&gt;/nhsuk-frontend.min.js"&gt;&lt;/script&gt;</ins>
     <ins>&lt;script type="module"&gt;</ins>
-      <ins>import { initAll } from '/<JAVASCRIPTS-PATH>/nhsuk-frontend.min.js'</ins>
+      <ins>import { initAll } from '/&lt;JAVASCRIPTS-PATH&gt;/nhsuk-frontend.min.js'</ins>
       <ins>initAll()</ins>
     <ins>&lt;/script&gt;</ins>
   <ins>&lt;/body&gt;</ins>

--- a/app/views/design-system/guides/updating-to-v10.njk
+++ b/app/views/design-system/guides/updating-to-v10.njk
@@ -204,16 +204,16 @@
   <p>Before:</p>
 
   <code class="language-js nhsuk-u-margin-bottom-4"><pre>
-    <del>&lt;script src="/javascripts/nhsuk-frontend.min.js" defer&gt;&lt;/script&gt;</del>
+    <del>&lt;script src="/<JAVASCRIPTS-PATH>/nhsuk.min.js" defer&gt;&lt;/script&gt;</del>
   <del>&lt;/head&gt;</del>
 </pre></code>
 
   <p>After:</p>
 
   <code class="language-js nhsuk-u-margin-bottom-4"><pre>
-    <ins>&lt;script type="module" src="/javascripts/nhsuk-frontend.min.js"&gt;&lt;/script&gt;</ins>
+    <ins>&lt;script type="module" src="/<JAVASCRIPTS-PATH>/nhsuk-frontend.min.js"&gt;&lt;/script&gt;</ins>
     <ins>&lt;script type="module"&gt;</ins>
-      <ins>import { initAll } from '/javascripts/nhsuk-frontend.min.js'</ins>
+      <ins>import { initAll } from '/<JAVASCRIPTS-PATH>/nhsuk-frontend.min.js'</ins>
       <ins>initAll()</ins>
     <ins>&lt;/script&gt;</ins>
   <ins>&lt;/body&gt;</ins>


### PR DESCRIPTION
We made a small mistake in the v10 upgrade guide by saying that the javascripts path in the templates used to be `nhsuk-frontend.min.js` but it actually used to be `nhsuk.min.js`.

We've also realised that the path prefix is not necessarily `/javascripts/` but can vary depending on your setup (eg the NHS prototype kit uses `/nhsuk-frontend/`). So this makes that clearer by using `<JAVASCRIPTS-PATH>` to hopefully make it clear that that bit isn't part of the upgrade guidance.
