### PR TITLE
Use camelCase for all input names

### DIFF
--- a/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
+++ b/app/views/content/how-to-write-good-questions-for-forms/use-filter-questions-to-route-users.njk
@@ -34,7 +34,7 @@
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {{ radios({
       idPrefix: "example-research",
-      name: "example-research",
+      name: "exampleResearch",
       fieldset: {
         legend: {
           text: "Can we email you about research?",
@@ -75,7 +75,7 @@
 
     {{ radios({
       idPrefix: "example-hints",
-      name: "example-hints",
+      name: "exampleHints",
       fieldset: {
         legend: {
           text: "Do you know your NHS number?",
@@ -114,7 +114,7 @@
     <strong class="nhsuk-tag app-example__heading">Example</strong>
     {{ radios({
       idPrefix: "example-registration-details",
-      name: "example-registration-details",
+      name: "exampleRegistrationDetails",
       fieldset: {
         legend: {
           text: "Do you have your registration details?",

--- a/app/views/design-system/components/character-count/default/index.njk
+++ b/app/views/design-system/components/character-count/default/index.njk
@@ -1,7 +1,7 @@
 {% from 'character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
-  name: "more-detail",
+  name: "moreDetail",
   id: "more-detail",
   maxlength: 200,
   label: {

--- a/app/views/design-system/components/character-count/without-heading/index.njk
+++ b/app/views/design-system/components/character-count/without-heading/index.njk
@@ -1,7 +1,7 @@
 {% from 'character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
-  name: "more-detail",
+  name: "moreDetail",
   id: "more-detail",
   maxlength: 150,
   label: {

--- a/app/views/design-system/components/character-count/word-count/index.njk
+++ b/app/views/design-system/components/character-count/word-count/index.njk
@@ -1,7 +1,7 @@
 {% from 'character-count/macro.njk' import characterCount %}
 
 {{ characterCount({
-  name: "more-detail",
+  name: "moreDetail",
   id: "more-detail",
   maxwords: 150,
   label: {

--- a/app/views/design-system/components/error-message/error-summary-placement-multiple/index.njk
+++ b/app/views/design-system/components/error-message/error-summary-placement-multiple/index.njk
@@ -42,7 +42,7 @@ previewLayout: design-example-wrapper-full
             text: "First name"
           },
           id: "first-name",
-          name: "first-name",
+          name: "firstName",
           errorMessage: {
             text: "Enter your first name"
           }
@@ -53,7 +53,7 @@ previewLayout: design-example-wrapper-full
             text: "Last name"
           },
           id: "last-name",
-          name: "last-name",
+          name: "lastName",
           errorMessage: {
             text: "Enter your last name"
           }

--- a/app/views/design-system/components/error-message/radios/index.njk
+++ b/app/views/design-system/components/error-message/radios/index.njk
@@ -2,7 +2,7 @@
 
 {{ radios({
   idPrefix: "example-error",
-  name: "example-error",
+  name: "exampleError",
   errorMessage: {
     text: "Select yes if you have changed your name"
   },

--- a/app/views/design-system/components/fieldset/default/index.njk
+++ b/app/views/design-system/components/fieldset/default/index.njk
@@ -14,7 +14,7 @@
       html: 'Building and street <span class="nhsuk-u-visually-hidden">line 1 of 2</span>'
     },
     id: "address-line-1",
-    name: "address-line-1"
+    name: "addressLine1"
   }) }}
 
   {{ input({
@@ -22,7 +22,7 @@
       html: '<span class="nhsuk-u-visually-hidden">Building and street line 2 of 2</span>'
     },
     id: "address-line-2",
-    name: "address-line-2"
+    name: "addressLine2"
   }) }}
 
   {{ input({
@@ -31,7 +31,7 @@
     },
     classes: "nhsuk-u-width-two-thirds",
     id: "address-town",
-    name: "address-town"
+    name: "addressTown"
   }) }}
 
   {{ input({
@@ -40,7 +40,7 @@
     },
     classes: "nhsuk-u-width-two-thirds",
     id: "address-county",
-    name: "address-county"
+    name: "addressCounty"
   }) }}
 
   {{ input({
@@ -49,7 +49,7 @@
     },
     classes: "nhsuk-input--width-10",
     id: "address-postcode",
-    name: "address-postcode"
+    name: "addressPostcode"
   }) }}
 
 {% endcall %}

--- a/app/views/design-system/components/hint-text/input/index.njk
+++ b/app/views/design-system/components/hint-text/input/index.njk
@@ -8,7 +8,7 @@
     text: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you, for example, 485 777 3456"
   },
   id: "example-with-hint-text",
-  name: "example-with-hint-text",
+  name: "exampleWithHintText",
   classes: "nhsuk-input--width-10",
   inputmode: "numeric"
 }) }}

--- a/app/views/design-system/components/hint-text/radio-item-with-hints/index.njk
+++ b/app/views/design-system/components/hint-text/radio-item-with-hints/index.njk
@@ -2,7 +2,7 @@
 
 {{ radios({
   idPrefix: "example-hints",
-  name: "example-hints",
+  name: "exampleHints",
   fieldset: {
     legend: {
       text: "How do you want to sign in?",

--- a/app/views/design-system/components/hint-text/radios/index.njk
+++ b/app/views/design-system/components/hint-text/radios/index.njk
@@ -4,7 +4,7 @@
 
 {{ radios({
   idPrefix: "example-hints",
-  name: "example-hints",
+  name: "exampleHints",
   fieldset: {
     legend: {
       text: "Do you know your NHS number?",

--- a/app/views/design-system/components/radios/error-message/index.njk
+++ b/app/views/design-system/components/radios/error-message/index.njk
@@ -2,7 +2,7 @@
 
 {{ radios({
   idPrefix: "example-error",
-  name: "example-error",
+  name: "exampleError",
   errorMessage: {
     text: "Select yes if you have changed your name"
   },

--- a/app/views/design-system/components/radios/inline/index.njk
+++ b/app/views/design-system/components/radios/inline/index.njk
@@ -2,7 +2,7 @@
 
 {{ radios({
   idPrefix: "example-inline",
-  name: "example-inline",
+  name: "exampleInline",
   classes: "nhsuk-radios--inline",
   fieldset: {
     legend: {

--- a/app/views/design-system/components/radios/items-with-a-text-divider/index.njk
+++ b/app/views/design-system/components/radios/items-with-a-text-divider/index.njk
@@ -2,7 +2,7 @@
 
 {{ radios({
   idPrefix: "example-divider",
-  name: "example-divider",
+  name: "exampleDivider",
   fieldset: {
     legend: {
       text: "How do you want to sign in?",

--- a/app/views/design-system/components/radios/with-hints-options/index.njk
+++ b/app/views/design-system/components/radios/with-hints-options/index.njk
@@ -2,7 +2,7 @@
 
 {{ radios({
   idPrefix: "example-hints",
-  name: "example-hints",
+  name: "exampleHints",
   fieldset: {
     legend: {
       text: "Do you have a mobile phone with signal?",

--- a/app/views/design-system/components/radios/with-hints/index.njk
+++ b/app/views/design-system/components/radios/with-hints/index.njk
@@ -4,7 +4,7 @@
 
 {{ radios({
   idPrefix: "example-hints",
-  name: "example-hints",
+  name: "exampleHints",
   fieldset: {
     legend: {
       text: "Do you know your NHS number?",

--- a/app/views/design-system/components/select/default/index.njk
+++ b/app/views/design-system/components/select/default/index.njk
@@ -2,7 +2,7 @@
 
 {{ select({
   id: "select-1",
-  name: "select-1",
+  name: "select1",
   label: {
     text: "Label text goes here"
   },

--- a/app/views/design-system/components/text-input/fixed-width/index.njk
+++ b/app/views/design-system/components/text-input/fixed-width/index.njk
@@ -5,7 +5,7 @@
   text: "20 character width"
   },
   id: "input-width-20",
-  name: "test-width-20",
+  name: "testWidth20",
   classes: "nhsuk-input--width-20"
 }) }}
 {{ input({
@@ -13,7 +13,7 @@
   text: "10 character width"
   },
   id: "input-width-10",
-  name: "test-width-10",
+  name: "testWidth10",
   classes: "nhsuk-input--width-10"
 }) }}
 {{ input({
@@ -21,7 +21,7 @@
   text: "5 character width"
   },
   id: "input-width-5",
-  name: "test-width-5",
+  name: "testWidth5",
   classes: "nhsuk-input--width-5"
 }) }}
 {{ input({
@@ -29,7 +29,7 @@
   text: "4 character width"
   },
   id: "input-width-4",
-  name: "test-width-4",
+  name: "testWidth4",
   classes: "nhsuk-input--width-4"
 }) }}
 {{ input({
@@ -37,7 +37,7 @@
   text: "3 character width"
   },
   id: "input-width-3",
-  name: "test-width-3",
+  name: "testWidth3",
   classes: "nhsuk-input--width-3"
 }) }}
 {{ input({
@@ -45,6 +45,6 @@
   text: "2 character width"
   },
   id: "input-width-2",
-  name: "test-width-2",
+  name: "testWidth2",
   classes: "nhsuk-input--width-2"
 }) }}

--- a/app/views/design-system/components/text-input/fluid-width/index.njk
+++ b/app/views/design-system/components/text-input/fluid-width/index.njk
@@ -15,7 +15,7 @@
   },
   classes: "nhsuk-u-width-three-quarters",
   id: "three-quarters",
-  name: "three-quarters"
+  name: "threeQuarters"
 }) }}
 
 {{ input({
@@ -24,7 +24,7 @@
   },
   classes: "nhsuk-u-width-two-thirds",
   id: "two-thirds",
-  name: "two-thirds"
+  name: "twoThirds"
 }) }}
 
 {{ input({
@@ -33,7 +33,7 @@
   },
   classes: "nhsuk-u-width-one-half",
   id: "one-half",
-  name: "one-half"
+  name: "oneHalf"
 }) }}
 
 {{ input({
@@ -42,7 +42,7 @@
   },
   classes: "nhsuk-u-width-one-third",
   id: "one-third",
-  name: "one-third"
+  name: "oneThird"
 }) }}
 
 {{ input({
@@ -51,5 +51,5 @@
   },
   classes: "nhsuk-u-width-one-quarter",
   id: "one-quarter",
-  name: "one-quarter"
+  name: "oneQuarter"
 }) }}

--- a/app/views/design-system/components/text-input/hint-text/index.njk
+++ b/app/views/design-system/components/text-input/hint-text/index.njk
@@ -8,6 +8,6 @@
     text: "For example, LS1 1AB"
   },
   id: "example-with-hint-text",
-  name: "example-with-hint-text",
+  name: "exampleWithHintText",
   classes: "nhsuk-input--width-10"
 }) }}

--- a/app/views/design-system/components/text-input/number/index.njk
+++ b/app/views/design-system/components/text-input/number/index.njk
@@ -8,7 +8,7 @@
     text: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you, for example, 485 777 3456"
   },
   id: "example-with-hint-text",
-  name: "example-with-hint-text",
+  name: "exampleWithHintText",
   classes: "nhsuk-input--width-10",
   inputmode: "numeric"
 }) }}

--- a/app/views/design-system/components/textarea/error/index.njk
+++ b/app/views/design-system/components/textarea/error/index.njk
@@ -1,7 +1,7 @@
 {% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
-  name: "example-error",
+  name: "exampleError",
   id: "example-error",
   label: {
     text: "Why can't you provide a National Insurance number?"

--- a/app/views/design-system/components/textarea/longer/index.njk
+++ b/app/views/design-system/components/textarea/longer/index.njk
@@ -1,7 +1,7 @@
 {% from 'textarea/macro.njk' import textarea %}
 
 {{ textarea({
-  name: "example-longer",
+  name: "exampleLonger",
   id: "example-longer",
   rows: "10",
   label: {

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/default/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/default/index.njk
@@ -21,7 +21,7 @@ previewLayout: design-example-wrapper-full
           html: "Your NHS number is a 10 digit number that you find on any letter the NHS has sent you, for example, <span class=\"nhsuk-u-nowrap\">485 777 3456</span>"
         },
         id: "nhs-number",
-        name: "nhs-number",
+        name: "nhsNumber",
         classes: "nhsuk-input--width-10",
         inputmode: "numeric"
       }) }}

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/error/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/error/index.njk
@@ -35,7 +35,7 @@ previewLayout: design-example-wrapper-full
           text: "Your NHS number is too long"
         },
         id: "nhs-number",
-        name: "nhs-number",
+        name: "nhsNumber",
         classes: "nhsuk-input--width-10",
         inputmode: "numeric"
       }) }}

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/filter-single/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/filter-single/index.njk
@@ -21,7 +21,7 @@ previewLayout: design-example-wrapper-full
           html: "Your NHS number is a 10 digit number, for example <span class=\"nhsuk-u-nowrap\">485 777 3456</span>"
         },
         id: "nhs-number",
-        name: "nhs-number",
+        name: "nhsNumber",
         classes: "nhsuk-input--width-10",
         inputmode: "numeric"
       }) }}

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/filter-third/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/filter-third/index.njk
@@ -19,7 +19,7 @@ previewLayout: design-example-wrapper-full
 
       {{ radios({
         idPrefix: "example-hints",
-        name: "example-hints",
+        name: "exampleHints",
         fieldset: {
           legend: {
             text: "Do you know your NHS number?",

--- a/app/views/design-system/patterns/ask-for-nhs-numbers/filter/index.njk
+++ b/app/views/design-system/patterns/ask-for-nhs-numbers/filter/index.njk
@@ -19,7 +19,7 @@ previewLayout: design-example-wrapper-full
 
       {{ radios({
         idPrefix: "example-hints",
-        name: "example-hints",
+        name: "exampleHints",
         fieldset: {
           legend: {
             text: "Do you know your NHS number?",


### PR DESCRIPTION
Generally we use camelCase for input names rather than hyphens, as it helps to distinguish the 2, and when used in the NHS Prototype kit or other javascript based frameworks, the camelCased properties can be accessed using the dot notation instead of square brackets (`data.fullName` instead of `data['full-name']`).

We didn't do this consistently though, so this switches all the remaining input examples to use camelCase.