### PR TITLE
Add interruption guidance

### DIFF
--- a/app/views/design-system/components/panel/index.njk
+++ b/app/views/design-system/components/panel/index.njk
@@ -44,4 +44,14 @@
   <p>Use short words and phrases to make sure highlighted information is easy to read at different screen sizes. Shorter text is less likely to wrap around the panel, which can happen when using the zoom function on mobiles.</p>
   <p>If you need to give detailed information, or more context, use the description text under the heading text.</p>
 
+  <h3 id="interruption">Interruption panels</h3>
+
+  <p>Use an interruption panel if you need to draw a user’s attention to something important. See <a href="/design-system/patterns/interruption">interruption pattern</a> for further guidance.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "panel",
+    type: "interruption"
+  }) }}
+
 {% endblock %}

--- a/app/views/design-system/components/panel/index.njk
+++ b/app/views/design-system/components/panel/index.njk
@@ -40,9 +40,14 @@
   </ul>
 
   <h3 id="how-to-write-panel-text">How to write panel text</h3>
-  <p>Keep your panel text brief. It only needs to summarise what has happened. For example, "Application complete".</p>
+
+  <p>Keep your panel heading text brief. It only needs to summarise what has happened. For example, "Application complete".</p>
+
   <p>Use short words and phrases to make sure highlighted information is easy to read at different screen sizes. Shorter text is less likely to wrap around the panel, which can happen when using the zoom function on mobiles.</p>
-  <p>If you need to give detailed information, or more context, use the description text under the heading text.</p>
+
+  <p>If the panel heading needs to be longer, you can reduce the text size by adding the <code>nhsuk-panel__title--l</code> class.</p>
+
+  <p>You can add more context or details by using additional text under the heading.</p>
 
   <h3 id="interruption">Interruption panels</h3>
 

--- a/app/views/design-system/components/panel/interruption/index.njk
+++ b/app/views/design-system/components/panel/interruption/index.njk
@@ -1,0 +1,22 @@
+{% from 'panel/macro.njk' import panel %}
+{% from 'button/macro.njk' import button %}
+
+{% set panelHtml %}
+  <p>They had a COVID-19 vaccine on 25 September 2025.</p>
+  <p>For most people, the minimum recommended gap between COVID-19 vaccine doses is 3 months.</p>
+  <div class="nhsuk-button-group">
+    {{ button({
+      text: "Continue anyway",
+      classes: "nhsuk-button--reverse",
+      href: "#"
+    }) }}
+    <a href="#">Cancel</a>
+  </div>
+{% endset %}
+
+{{ panel({
+  titleText: "Jodie Brown had a COVID-19 vaccine less than 3 months ago",
+  titleClasses: "nhsuk-panel__title--l",
+  classes: "nhsuk-panel--interruption",
+  html: panelHtml
+}) }}

--- a/app/views/design-system/patterns/interruption/confirmation/index.njk
+++ b/app/views/design-system/patterns/interruption/confirmation/index.njk
@@ -1,0 +1,44 @@
+---
+previewLayout: design-example-wrapper-full
+---
+
+{% extends "layouts/design-example-wrapper-full-layout.njk" %}
+
+{% from 'button/macro.njk' import button %}
+{% from 'panel/macro.njk' import panel %}
+{% from 'back-link/macro.njk' import backLink %}
+
+{% block beforeContent %}
+  {{ backLink({
+    href: "#",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% set panelHtml %}
+        <p>You will be able to reschedule your appointment for another time, but this may delay your treatment.</p>
+
+        <p>Cancelling your appointment cannot be undone.</p>
+        <div class="nhsuk-button-group">
+          {{ button({
+            text: "Yes, I want to cancel",
+            classes: "nhsuk-button--reverse",
+            href: "#"
+          }) }}
+        </div>
+      {% endset %}
+
+      {{ panel({
+        titleText: "Are you sure you want to cancel your hospital appointment?",
+        titleClasses: "nhsuk-panel__title--l",
+        classes: "nhsuk-panel--interruption",
+        html: panelHtml
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/design-system/patterns/interruption/default/index.njk
+++ b/app/views/design-system/patterns/interruption/default/index.njk
@@ -1,0 +1,44 @@
+---
+previewLayout: design-example-wrapper-full
+---
+
+{% extends "layouts/design-example-wrapper-full-layout.njk" %}
+
+{% from 'button/macro.njk' import button %}
+{% from 'panel/macro.njk' import panel %}
+{% from 'back-link/macro.njk' import backLink %}
+
+{% block beforeContent %}
+  {{ backLink({
+    href: "#",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% set panelHtml %}
+        <p>They had a COVID-19 vaccine on 25 September 2025.</p>
+        <p>For most people, the minimum recommended gap between COVID-19 vaccine doses is 3 months.</p>
+        <div class="nhsuk-button-group">
+          {{ button({
+            text: "Continue anyway",
+            classes: "nhsuk-button--reverse",
+            href: "#"
+          }) }}
+          <a href="#">Cancel</a>
+        </div>
+      {% endset %}
+
+      {{ panel({
+        titleText: "Jodie Brown had a COVID-19 vaccine less than 3 months ago",
+        titleClasses: "nhsuk-panel__title--l",
+        classes: "nhsuk-panel--interruption",
+        html: panelHtml
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/design-system/patterns/interruption/index.njk
+++ b/app/views/design-system/patterns/interruption/index.njk
@@ -1,0 +1,100 @@
+{% set pageTitle = "Interruption pages" %}
+{% set pageDescription = "Use an interruption page if you need to pause a user’s journey with important information." %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Pages" %}
+{% set dateUpdated = "October 2025" %}
+{% set backlog_issue_id = "241" %}
+
+{% extends "layouts/app-layout.njk" %}
+
+{% block beforeContent %}
+  {% include "design-system/patterns/_breadcrumb.njk" %}
+{% endblock %}
+
+{% block bodyContent %}
+
+  {{ designExample({
+    group: "patterns",
+    item: "interruption",
+    type: "default"
+  }) }}
+
+  <h2 id="when-to-use">When to use an interruption page</h2>
+
+  <p>You should only use an interruption page when you need to make sure that the user is not about to make a mistake.</p>
+
+  <p>It should be used sparingly as the more often a user sees it, the more likely they are to skip over the content.</p>
+
+  <p>You should try using a regular page first, and only use the interruption page if you find in research that users are often missing the content.</p>
+
+  <p>Example use cases are:</p>
+
+  <ul>
+    <li>asking users to check whether somethin they have entered is correct if it is quite likely to be a mistake</li>
+    <li>asking users to confirm something which cannot be undone, such as cancelling an appointment</li>
+    <li>an exceptional clinical warning in a staff-facing service</li>
+  </ul>
+
+  <h3>Possible mistakes</h3>
+
+  <p>If the user has entered some information which is highly likely to be mistake, but is not completely impossible, you can use an interruption card to check it with them.</p>
+
+  <p>Unlike a <a href="/design-system/components/error-summary">validation error</a>, they can continue without changing their answer.</p>
+
+  {{ designExample({
+    group: "patterns",
+    item: "interruption",
+    type: "possible-mistake"
+  }) }}
+
+  <h3>Confirming something which cannot be undone</h3>
+
+  <p>If the user is about to do something unusual which cannot be undone and could have a serious consequences, such as cancelling a hospital appointment, you can use an interruption page to check with them first.</p>
+
+  <p>Do not use this pattern if the outcome is less serious, such as unsubscribing from notifications.</p>
+
+  <p>Do not use this pattern to ask a user to check all their answers as part of a regular journey, use the <a href="/design-system/patterns/check-answers">check answers pattern instead</a>.</p>
+
+  {{ designExample({
+    group: "patterns",
+    item: "interruption",
+    type: "confirmation"
+  }) }}
+
+  <h3>Clinical warnings</h3>
+
+  <p>In a staff facing service you can use an interruption page to warn clinicians that they are about to do something unusual, but which they can go ahead with based upon their clinical judgement.</p>
+
+  <p>If the action should never be taken in any circumstances, you should prevent it from happening instead.</p>
+
+  <p>Use this warning sparingly.</p>
+
+  {{ designExample({
+    group: "patterns",
+    item: "interruption",
+    type: "default"
+  }) }}
+
+  <h2 id="when-not-to-use">When not to use an interruption page</h2>
+
+  <p>Do not use an interruption card to:</p>
+
+  <ul>
+    <li>emphasise large amounts of content on a page (as the impact will be lost)</li>
+    <li>ask users to agree to terms of use or other legal terms</li>
+    <li>display content that the user will repeatedly see, such as a warning that a service is provided by another organisation</li>
+  </ul>
+
+
+  <h2 id="how-to-use">How to use an interruption page</h2>
+
+  <p>The interruption page uses the <a href="/design-system/components/panel">panel component</a> with the addition of a <code>nhsuk-panel--interruption</code> class to make it blue.</p>
+
+  <p>You should include a <a href="/design-system/components/back-link">back link</a> at the top of the page, as well as allowing users to use their browser back button.</p>
+
+  <p>Within the panel, the button should have a <code>nhsuk-button--reverse</code> class to make it appear white.</p>
+
+  <p>You can also include a cancel or change link beside the button if needed. If you do this, you should add a <code>&lt;div class="nhsuk-button-group"&gt;</code> container to <a href="/design-system/components/buttons#grouping-buttons">group the button</a> and the link together.</p>
+
+{% endblock %}

--- a/app/views/design-system/patterns/interruption/possible-mistake/index.njk
+++ b/app/views/design-system/patterns/interruption/possible-mistake/index.njk
@@ -1,0 +1,43 @@
+---
+previewLayout: design-example-wrapper-full
+---
+
+{% extends "layouts/design-example-wrapper-full-layout.njk" %}
+
+{% from 'button/macro.njk' import button %}
+{% from 'panel/macro.njk' import panel %}
+{% from 'back-link/macro.njk' import backLink %}
+
+{% block beforeContent %}
+  {{ backLink({
+    href: "#",
+    text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      {% set panelHtml %}
+        <p>You entered your weight as <b>21.4 kilograms</b>. This is lower than expected.</p>
+        <div class="nhsuk-button-group">
+          {{ button({
+            text: "Yes, this is correct",
+            classes: "nhsuk-button--reverse",
+            href: "#"
+          }) }}
+          <a href="#">Change my weight</a>
+        </div>
+      {% endset %}
+
+      {{ panel({
+        titleText: "Is your weight correct?",
+        titleClasses: "nhsuk-panel__title--l",
+        classes: "nhsuk-panel--interruption",
+        html: panelHtml
+      }) }}
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -152,6 +152,7 @@
 {% set pages = [
   { title: "A to Z page", url: "/design-system/patterns/a-to-z-page" },
   { title: "Confirmation page", url: "/design-system/patterns/confirmation-page" },
+  { title: "Interruption page", url: "/design-system/patterns/interruption" },
   { title: "Mini-hub", url: "/design-system/patterns/mini-hub" },
   { title: "Question pages", url: "/design-system/patterns/question-pages" },
   { title: "Start page", url: "/design-system/patterns/start-page" }


### PR DESCRIPTION
This adds guidance for the Interruption panel added in https://github.com/nhsuk/nhsuk-frontend/pull/1196

It adds:

* a section about interruption panels to the existing Panel component page
* a new Interruption page which has more detailed guidance

The guidance is partly based on the [MOJ Interruption card guidance](https://design-patterns.service.justice.gov.uk/components/interruption-card/) as well as from the [NHS GitHub discussion](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/241).

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
