### PR TITLE
Enable search autocomplete again

### DIFF
--- a/app/javascripts/accessible-autocomplete.mjs
+++ b/app/javascripts/accessible-autocomplete.mjs
@@ -7,56 +7,42 @@ import AccessibleAutoComplete from 'accessible-autocomplete'
  * @param {Config<ResultType>} config
  */
 export default (config) => {
-  const { formId, inputId, containerId } = config
+  const { input, button } = config
 
-  const form = document.getElementById(formId)
-  const input = document.getElementById(inputId)
-  const container = document.getElementById(containerId)
-
-  /**
-   * Adds event to catch enter presses when the main input is focused and submits the form
-   */
-  const addFormEvents = () => {
-    // Attach event to form as the original input element is cloned by autoComplete plugin
-    form.addEventListener('keyup', ({ key }) => {
-      // Submit search using current input value if input is focused and enter is pressed
-      if (key === 'Enter' && document.activeElement.id === inputId)
-        form.submit()
-    })
+  if (
+    !config.source ||
+    !(input instanceof HTMLInputElement) ||
+    !(button instanceof HTMLButtonElement)
+  ) {
+    return
   }
 
-  const initAutoComplete = () => {
-    const defaultConfig = {
-      confirmOnBlur: false,
-      element: container,
-      id: inputId,
-      minLength: 2,
-      name: input.name,
-      placeholder: input.placeholder
-    }
+  const $container = document.createElement('div')
+  $container.classList.add('autocomplete')
 
-    // Remove original search input as it will be replaced by accessibleAutocomplete
-    input.parentNode.removeChild(input)
-
-    // Initialise accessibleAutocomplete
-    AccessibleAutoComplete(Object.assign({}, defaultConfig, config))
+  const defaultConfig = {
+    confirmOnBlur: false,
+    element: $container,
+    id: input.id,
+    inputClasses: 'nhsuk-header__search-input nhsuk-input',
+    menuClasses: 'nhsuk-width-container',
+    minLength: 2,
+    name: input.name,
+    placeholder: input.placeholder
   }
 
-  // Add autocomplete functionality if required config options exist
-  if (input && container && config.source) {
-    initAutoComplete()
-    // If form element exists then add events to add standard form functionality
-    if (form) addFormEvents()
-  }
+  // Remove original search input as it will be replaced by accessibleAutocomplete
+  input.replaceWith($container)
+
+  // Initialise accessibleAutocomplete
+  AccessibleAutoComplete(Object.assign({}, defaultConfig, config))
 }
 
 /**
  * @template {unknown} ResultType
  * @typedef {object} Config
- * @property {string} [formId] - ID of form element containing autocomplete
- *   (Optional param for NHS.UK functionality)
- * @property {string} inputId - ID of the input field
- * @property {string} containerId - ID of element in which the autocomplete will be rendered in
+ * @property {Element | null} input - Search input
+ * @property {Element | null} button - Search button
  * @property {OnSourceCallback<ResultType>} source - Search query callback function
  * @property {OnConfirmCallback<ResultType>} [onConfirm] - Result selection confirmed callback function
  * @property {object} [templates] - Template functions

--- a/app/javascripts/main.mjs
+++ b/app/javascripts/main.mjs
@@ -20,9 +20,8 @@ initAll({
 
 // Initialise NHS digital service manual components
 initAccessibleAutocomplete({
-  containerId: 'autocomplete-container',
-  formId: 'search',
-  inputId: 'search-field',
+  input: document.querySelector('.nhsuk-header__search-input'),
+  button: document.querySelector('.nhsuk-header__search-submit'),
   onConfirm,
   source,
   templates: {

--- a/app/stylesheets/app/_autocomplete.scss
+++ b/app/stylesheets/app/_autocomplete.scss
@@ -3,123 +3,94 @@
 ////
 /// Autocomplete component
 ///
-/// 1. IE 10 prefix for flexbox
-/// 2. Proprietary extension so form field looks the same in Safari
-/// 3. Custom height and width of form items
-/// 4. Custom height and width of svg icons
-/// 5. Custom spacing to position the search icon
-/// 6. Drop shadow on search suggestions dropdown box, custom spread and blur
-/// 7. Z-index to bring the dropdown to the front
-/// 8. No current spacing at 12px so using this value
-/// 9. Z-index to bring search box to the front for focus state style
-/// 10. Custom padding to stop text jumping on focus
+/// 1. Custom height and width of form items
+/// 2. Custom height and width of svg icons
+/// 3. Custom spacing to position the search icon
+/// 4. Drop shadow on search suggestions dropdown box, custom spread and blur
 ////
 
-.autocomplete-container {
-  display: inline-block;
-  z-index: 1; // [9]
+.autocomplete {
+  width: 100%;
+  pointer-events: none;
+  position: relative;
+  z-index: 9;
+
+  // Stack button above autocomplete
+  + .nhsuk-header__search-submit {
+    position: relative;
+    z-index: 10;
+  }
+
+  // Stack button below autocomplete when focused
+  &:focus-within + .nhsuk-header__search-submit {
+    z-index: 8;
+  }
 
   @include nhsuk-media-query($until: tablet) {
-    display: inline;
-    width: 100%;
-  }
-}
-
-@include nhsuk-media-query($until: tablet) {
-  // duplicate of .nhsuk-search__input in _header.scss, for non javascript version
-  .autocomplete__input {
-    -ms-flex-positive: 2; // [1]
-    -webkit-appearance: listbox; // [2]
-    border-bottom: 1px solid nhsuk-colour("grey-3");
-    border-bottom-left-radius: $nhsuk-border-radius;
-    border-bottom-right-radius: 0;
-    border-left: 1px solid nhsuk-colour("grey-3");
-    border-right: 0;
-    border-top: 1px solid nhsuk-colour("grey-3");
-    border-top-left-radius: $nhsuk-border-radius;
-    border-top-right-radius: 0;
-    flex-grow: 2;
-    font-size: inherit;
-    height: 52px; // [3]
-    margin: 0;
-    outline: none;
-    padding: 0 nhsuk-spacing(3);
-    width: 100%; // [3]
-
-    &:focus {
-      border: $nhsuk-focus-width solid $nhsuk-focus-text-colour;
-      box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-colour;
-      outline: $nhsuk-focus-width solid transparent;
-      outline-offset: $nhsuk-focus-width;
-      padding: 0 13px; // [10]
+    + .nhsuk-header__search-submit {
+      position: absolute;
+      right: 0;
+      top: 0;
     }
   }
 }
 
-@include nhsuk-media-query($from: tablet) {
-  // duplicate of .nhsuk-search__input in _header.scss, for non javascript version
-  .autocomplete__input {
-    -webkit-appearance: listbox; // [2]
-    border: 1px solid nhsuk-colour("white");
-    border-bottom-left-radius: $nhsuk-border-radius;
-    border-bottom-right-radius: 0;
-    border-right: 0;
-    border-top-left-radius: $nhsuk-border-radius;
-    border-top-right-radius: 0;
-    font-size: $nhsuk-base-font-size;
-    height: 40px; // [3]
-    padding: 0 12px; // [9]
-    width: 200px; // [3]
+.autocomplete__input.nhsuk-header__search-input {
+  pointer-events: all;
+  width: calc(100% - 44px); // [1]
 
-    &:focus {
-      border: 2px solid $nhsuk-focus-text-colour;
-      box-shadow: 0 0 0 $nhsuk-focus-width $nhsuk-focus-colour;
-      outline: $nhsuk-focus-width solid transparent;
-      outline-offset: $nhsuk-focus-width;
-      padding: 0 11px; // [10]
-    }
-
-    &::placeholder {
-      color: nhsuk-colour("grey-1");
-      font-size: $nhsuk-base-font-size;
-    }
-  }
-}
-
-@include nhsuk-media-query($from: desktop) {
-  .autocomplete__input {
-    width: 235px;
+  @include nhsuk-media-query($from: tablet) {
+    width: 100%; // [1]
   }
 }
 
 .autocomplete__menu {
-  -moz-box-shadow: 0 3px 5px rgba(nhsuk-colour("grey-1"), 0.5); // [6]
-  -webkit-box-shadow: 0 3px 5px rgba(nhsuk-colour("grey-1"), 0.5); // [6]
   background-color: nhsuk-colour("white");
-  border-bottom: 1px solid nhsuk-colour("grey-4");
-  border-bottom-left-radius: $nhsuk-border-radius;
-  border-bottom-right-radius: $nhsuk-border-radius;
-  border-left: 1px solid nhsuk-colour("grey-4");
-  border-right: 1px solid nhsuk-colour("grey-4");
-  box-shadow: 0 0 3px 0 rgba(nhsuk-colour("grey-1"), 0.5); // [6]
   list-style: none;
-  margin-top: 2px;
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding: nhsuk-spacing(3);
-  position: absolute;
-  top: 100%;
-  width: 100%;
-  z-index: 1; // [7]
+  margin: 10px 0 0;
+  padding: 0;
+  pointer-events: all;
+  position: relative;
+  @include nhsuk-print-hide;
 
-  @include nhsuk-media-query($until: tablet) {
-    border: 0;
-    box-shadow: none;
-    margin: 0;
-    padding-left: 0;
-    padding-right: 0;
-    position: relative;
+  &::after {
+    position: absolute;
+    top: 0;
+    right: -$nhsuk-gutter;
+    bottom: 0;
+    left: -$nhsuk-gutter;
+
+    display: block;
+    background-color: nhsuk-colour("white");
+    content: "";
   }
+
+  @include nhsuk-media-query($from: tablet) {
+    border: solid nhsuk-colour("grey-4");
+    border-width: 0 1px 1px;
+    border-radius: $nhsuk-border-radius;
+    box-shadow: 0 0 3px 0 rgba(nhsuk-colour("grey-1"), 0.5); // [4]
+    margin: 2px -44px 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: nhsuk-spacing(2) nhsuk-spacing(3);
+    position: absolute;
+    right: 0;
+    top: 100%;
+    width: 360px;
+    z-index: -1;
+
+    &::after {
+      display: none;
+    }
+  }
+}
+
+.autocomplete__option-category {
+  color: $nhsuk-secondary-text-colour;
+  display: block;
+  @include nhsuk-font(16);
+  margin-top: nhsuk-spacing(1);
 }
 
 .autocomplete__menu--visible {
@@ -131,54 +102,45 @@
 }
 
 .autocomplete__option {
+  display: block;
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  padding: nhsuk-spacing(3) 2px;
+  white-space: nowrap;
   border-bottom: 1px solid nhsuk-colour("grey-5");
-  color: nhsuk-colour("blue");
+  color: $nhsuk-header-item-colour;
   cursor: pointer;
-  font-size: $nhsuk-base-font-size;
-  padding-bottom: 12px; // [8]
-  text-align: left;
-  text-decoration: underline;
+  @include nhsuk-font(16);
 
-  .nhsuk-icon__search {
-    fill: nhsuk-colour("grey-3");
-    float: left;
-    height: 22px; // [4]
-    margin: 2px 4px 0 0; // [5]
-    width: 22px; // [4]
+  @include nhsuk-link-style-visited($nhsuk-header-item-colour);
+  @include nhsuk-link-style-hover($nhsuk-header-item-hover-colour);
+  @include nhsuk-link-style-active($nhsuk-header-item-active-colour);
+  @include nhsuk-link-style-focus;
+
+  &:last-child {
+    border-color: transparent;
   }
 
   &:hover,
-  &:active {
-    text-decoration: none;
-  }
-
   &:focus {
-    outline: 1px solid transparent;
-    text-decoration: none;
-
-    a {
-      @include nhsuk-focused-text;
+    .autocomplete__option-title {
+      text-decoration: none;
     }
   }
 
-  @include nhsuk-media-query($from: tablet) {
-    &:last-child {
-      border-bottom: 0;
-    }
+  &:focus,
+  &:focus:visited {
+    color: $nhsuk-focus-text-colour;
+    box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-focus-text-colour;
+    border-color: nhsuk-colour("white");
+  }
+
+  @include nhsuk-media-query($until: tablet) {
+    font-size: inherit;
   }
 }
 
-.autocomplete__option--no-results {
-  border-bottom: 0;
-  color: nhsuk-colour("black");
-  font-size: $nhsuk-base-font-size;
-  line-height: $nhsuk-base-line-height;
-  margin: 0;
-  padding: 0;
-  text-align: left;
-  text-decoration: none;
-
-  @include nhsuk-media-query($until: tablet) {
-    padding: nhsuk-spacing(3) 0;
-  }
+.autocomplete__option-title {
+  text-decoration: underline;
 }

--- a/app/stylesheets/app/_search.scss
+++ b/app/stylesheets/app/_search.scss
@@ -31,14 +31,6 @@
 
   @include nhsuk-responsive-margin(7, "bottom");
 
-  .autocomplete-container {
-    width: 100%;
-  }
-
-  .autocomplete__menu--hidden {
-    display: none;
-  }
-
   .autocomplete__input,
   .nhsuk-search__input {
     -ms-flex-positive: 2; // [14]
@@ -127,53 +119,4 @@
   color: $nhsuk-secondary-text-colour;
   display: block;
   font-size: 14px;
-}
-
-.autocomplete__option {
-  line-height: 1.35;
-  text-decoration: none;
-
-  &:focus {
-    .autocomplete__option-title {
-      @include nhsuk-focused-text;
-    }
-  }
-
-  &:hover,
-  &:focus {
-    .autocomplete__option-title {
-      text-decoration: none;
-    }
-  }
-
-  &-title {
-    text-decoration: underline;
-  }
-}
-
-// Autocomplete list hotfixes
-
-.autocomplete__option .nhsuk-icon__search {
-  margin: 2px 4px 2px 0;
-}
-
-@include nhsuk-media-query($from: tablet) {
-  .autocomplete__option:last-child {
-    padding-bottom: 0;
-  }
-
-  .autocomplete__menu {
-    padding: 16px 8px;
-  }
-
-  .autocomplete__option-title {
-    text-decoration: underline;
-  }
-}
-
-.autocomplete__option-category {
-  color: $nhsuk-secondary-text-colour;
-  display: block;
-  font-size: 14px;
-  margin-top: nhsuk-spacing(1);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "accessible-autocomplete": "^2.0.4",
+        "accessible-autocomplete": "^3.0.1",
         "axios": "^1.12.2",
         "basic-auth": "^2.0.1",
         "browser-sync": "^3.0.4",
@@ -4070,12 +4070,17 @@
       }
     },
     "node_modules/accessible-autocomplete": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz",
-      "integrity": "sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz",
+      "integrity": "sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==",
       "license": "MIT",
-      "dependencies": {
-        "preact": "^8.3.1"
+      "peerDependencies": {
+        "preact": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {
@@ -12110,7 +12115,9 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
       "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
       "hasInstallScript": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "accessible-autocomplete": "^2.0.4",
+    "accessible-autocomplete": "^3.0.1",
     "axios": "^1.12.2",
     "basic-auth": "^2.0.1",
     "browser-sync": "^3.0.4",


### PR DESCRIPTION
## Description

This PR updates to [`accessible-autocomplete@3`](https://github.com/alphagov/accessible-autocomplete/releases/tag/v3.0.0) and enables it in the header

I'm not quite sure when it stopped working, but it looks like this now:

<img width="549" height="196" alt="Screenshot 2025-09-30 at 14 35 51" src="https://github.com/user-attachments/assets/8c1eb319-faef-4dee-a06c-ef2f354fedc7" />

<br>
<br>

<img width="426" height="280" alt="Screenshot 2025-09-30 at 14 36 14" src="https://github.com/user-attachments/assets/6d1c482b-c322-4237-a2d2-d12236e7d110" />

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
