### PR TITLE
Contain full title in code example

### DIFF
--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -71,7 +71,7 @@
   <h2 id="page-title">Page title</h2>
 
   <p>The page title (<code>&lt;title&gt;</code>) is in the HTML metadata, in the <code>&lt;head&gt;</code> section. It is displayed in the browser tab.</p>
-  <p>A basic page title is made up of the main page heading (the <code>&lt;h1&gt;</code>) and the website name, separated by a dash. For example: <code>&lt;title&gt;</code>Flu – NHS<code>&lt;/title&gt;</code>, which is the title for the <a href="https://www.nhs.uk/conditions/flu/">flu page on the NHS website</a>. Use a unique and informative title on every page.</p>
+  <p>A basic page title is made up of the main page heading (the <code>&lt;h1&gt;</code>) and the website name, separated by a dash. For example: <code>&lt;title&gt;Flu – NHS&lt;/title&gt;</code>, which is the title for the <a href="https://www.nhs.uk/conditions/flu/">flu page on the NHS website</a>. Use a unique and informative title on every page.</p>
 
     <details class="nhsuk-details">
   <summary class="nhsuk-details__summary">


### PR DESCRIPTION
I found following the example title a bit tricky as the start and end are in code blocks, but not the title itself.

Before:
<img width="1562" height="286" alt="Screenshot of title guidance where full title is not in code block" src="https://github.com/user-attachments/assets/9471dedd-ba18-4591-8dd3-cbbee395eb0e" />

After:
<img width="1536" height="286" alt="Screenshot of title guidance where full title is in code block" src="https://github.com/user-attachments/assets/528ff91e-36d7-4d3e-8e73-b7f987e1f89c" />
