### PR TITLE
Use medium legend for smaller checkboxes and radios

### DIFF
--- a/app/views/design-system/components/checkboxes/smaller/index.njk
+++ b/app/views/design-system/components/checkboxes/smaller/index.njk
@@ -6,7 +6,7 @@
   fieldset: {
     legend: {
       text: "Care setting",
-      classes: "nhsuk-fieldset__legend--s",
+      classes: "nhsuk-fieldset__legend--m",
       isPageHeading: true
     }
   },

--- a/app/views/design-system/components/radios/smaller/index.njk
+++ b/app/views/design-system/components/radios/smaller/index.njk
@@ -6,7 +6,7 @@
   fieldset: {
     legend: {
       text: "Filter",
-      classes: "nhsuk-fieldset__legend--s",
+      classes: "nhsuk-fieldset__legend--m",
       isPageHeading: true
     }
   },


### PR DESCRIPTION
Previously the example for smaller radios used a small legend, but the example for smaller checkboxes used a large legend.

This changes them both to medium size.