### PR TITLE
Improve id and namePrefix for date of birth examples

### DIFF
--- a/app/views/design-system/components/date-input/default/index.njk
+++ b/app/views/design-system/components/date-input/default/index.njk
@@ -1,8 +1,8 @@
 {% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
-  id: "example",
-  namePrefix: "example",
+  id: "date-of-birth",
+  namePrefix: "dateOfBirth",
   fieldset: {
     legend: {
       text: "What is your date of birth?",

--- a/app/views/design-system/components/date-input/with-errors/index.njk
+++ b/app/views/design-system/components/date-input/with-errors/index.njk
@@ -1,7 +1,8 @@
 {% from 'date-input/macro.njk' import dateInput %}
 
 {{ dateInput({
-  id: "dob-errors",
+  id: "date-of-birth",
+  namePrefix: "dateOfBirth",
   fieldset: {
     legend: {
       text: "What is your date of birth?",


### PR DESCRIPTION
Generally we recommend using kebab-case for `id`s and camelCase for `name` fields.

Also fixes #2051