### PR TITLE
Remove duplicate 'nhsuk-button' class

### DIFF
--- a/app/views/design-system/components/buttons/button-group-link/index.njk
+++ b/app/views/design-system/components/buttons/button-group-link/index.njk
@@ -2,8 +2,7 @@
 
 <div class="nhsuk-button-group">
   {{ button({
-    text: "Continue",
-    classes: "nhsuk-button"
+    text: "Continue"
   }) }}
 
   <a href="#" class="nhsuk-link">Cancel</a>


### PR DESCRIPTION
Another duplicate `nhsuk-button` class used on button-group-link