### PR TITLE
SPIKE: Selectable table

### DIFF
--- a/app/views/design-system/components/table/with-checkboxes/index.njk
+++ b/app/views/design-system/components/table/with-checkboxes/index.njk
@@ -1,0 +1,65 @@
+{% from "tables/macro.njk" import table %}
+{% from "checkboxes/macro.njk" import checkboxes %}
+
+{% set organisations = [{name: "NHS England", code: "X26"}, {name: "NHS Business Services Authority", code: "T1450"}, {name: "NHS Blood and Tranplant", code: "T1460"}, {name: "UK Health Security Agency", code: "X36"}] %}
+
+{% set rows = [] %}
+
+{% set headerCheckboxHtml %}
+  {{ checkboxes({
+    idPrefix: "organisations",
+    name: "organisations",
+    classes: "nhsuk-checkboxes--small",
+    formGroup: {
+      classes: "nhsuk-u-margin-bottom-0"
+    },
+    items: [
+      {
+        value: "",
+        text: "Name",
+        id: "organisation-select-all",
+        inclusive: true,
+        label: {
+          classes: "nhsuk-label--s"
+        }
+      }
+    ]
+  }) }}
+{% endset %}
+
+{% for organisation in organisations %}
+  {% set nameCheckboxHtml %}
+    {{ checkboxes({
+      idPrefix: "organisations",
+      name: "organisations",
+      classes: "nhsuk-checkboxes--small",
+      formGroup: {
+        classes: "nhsuk-u-margin-bottom-0"
+      },
+      items: [
+        {
+          value: organisation.code,
+          text: organisation.name,
+          id: "organisation-" + loop.index0
+        }
+      ]
+    }) }}
+  {% endset %}
+
+  {% set rows = (rows.push([{ html: nameCheckboxHtml}, {text: organisation.code}]), rows) %}
+{% endfor %}
+
+{{ table({
+  panel: false,
+  caption: "Organisations",
+  firstCellIsHeader: false,
+  head: [
+    {
+      html: headerCheckboxHtml
+    },
+    {
+      text: "ODS code"
+    }
+  ],
+  rows: rows
+}) }}

--- a/app/views/design-system/patterns/selectable-table/default/index.njk
+++ b/app/views/design-system/patterns/selectable-table/default/index.njk
@@ -1,0 +1,96 @@
+---
+previewLayout: design-example-wrapper-full
+---
+
+{% extends "layouts/design-example-wrapper-full-layout.njk" %}
+
+{% from "tables/macro.njk" import table %}
+{% from "checkboxes/macro.njk" import checkboxes %}
+{% from "button/macro.njk" import button %}
+
+
+{% set organisations = [{name: "NHS England", code: "X26"}, {name: "NHS Business Services Authority", code: "T1450"}, {name: "NHS Blood and Tranplant", code: "T1460"}, {name: "UK Health Security Agency", code: "X36"}] %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+
+      {% set headerCheckboxHtml %}
+        {{ checkboxes({
+          idPrefix: "organisations",
+          name: "organisations",
+          classes: "nhsuk-checkboxes--small",
+          formGroup: {
+            classes: "nhsuk-u-margin-bottom-0"
+          },
+          items: [
+            {
+              value: "",
+              text: "Name",
+              id: "organisation-select-all",
+              inclusive: true,
+              label: {
+                classes: "nhsuk-label--s"
+              }
+            }
+          ]
+        }) }}
+      {% endset %}
+
+      {% set rows = [] %}
+
+      {% for organisation in organisations %}
+        {% set nameCheckboxHtml %}
+          {{ checkboxes({
+            idPrefix: "organisations",
+            name: "organisations",
+            classes: "nhsuk-checkboxes--small",
+            formGroup: {
+              classes: "nhsuk-u-margin-bottom-0"
+            },
+            items: [
+              {
+                value: organisation.code,
+                text: organisation.name,
+                id: "organisation-" + loop.index0
+              }
+            ]
+          }) }}
+        {% endset %}
+
+        {% set editLinkHtml %}
+          <a href="#" class="nhsuk-link">Edit<span class="nhsuk-u-visually-hidden"> {{ organisation.name }}</a>
+        {% endset %}
+
+        {% set rows = (rows.push([{ html: nameCheckboxHtml}, {text: organisation.code}, {html: editLinkHtml}]), rows) %}
+      {% endfor %}
+
+      {{ table({
+        panel: false,
+        caption: "Organisations",
+        captionSize: "l",
+        firstCellIsHeader: false,
+        head: [
+          {
+            html: headerCheckboxHtml
+          },
+          {
+            text: "ODS code"
+          },
+          {
+            text: "Actions"
+          }
+        ],
+        rows: rows
+      }) }}
+
+      <div class="nhsuk-button-group nhsuk-button-group--small">
+        {{ button({
+          text: "Edit selected",
+          classes: "nhsuk-button--secondary nhsuk-button--small"
+        }) }}
+      </div>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/design-system/patterns/selectable-table/index.njk
+++ b/app/views/design-system/patterns/selectable-table/index.njk
@@ -1,0 +1,24 @@
+{% extends "layouts/app-layout.njk" %}
+
+{% set pageTitle = "Selectable table" %}
+{% set pageDescription = "TODO" %}
+{% set pageSection = "Design system" %}
+{% set subSection = "Patterns" %}
+{% set theme = "Pages" %}
+{% set dateUpdated = "October 2025" %}
+{% set backlog_issue_id = "86" %}
+
+{% block beforeContent %}
+  {% include "design-system/patterns/_breadcrumb.njk" %}
+{% endblock %}
+
+{% block bodyContent %}
+
+  {{ designExample({
+    group: "patterns",
+    item: "selectable-table",
+    type: "default"
+  }) }}
+
+
+{% endblock %}

--- a/app/views/includes/_side-nav.njk
+++ b/app/views/includes/_side-nav.njk
@@ -155,7 +155,8 @@
   { title: "Confirmation page", url: "/design-system/patterns/confirmation-page" },
   { title: "Mini-hub", url: "/design-system/patterns/mini-hub" },
   { title: "Question pages", url: "/design-system/patterns/question-pages" },
-  { title: "Start page", url: "/design-system/patterns/start-page" }
+  { title: "Start page", url: "/design-system/patterns/start-page" },
+  { title: "Selectable table", url: "/design-system/patterns/selectable-table" }
 ] %}
 
 {% set community = [


### PR DESCRIPTION
This seems to be a common-ish pattern in staff-facing services, where there's a table containing rows that have individual actions, but also a checkbox per row you can use to do something to multiple rows at once (edit / delete / activate / etc).

<img width="807" height="650" alt="Screenshot 2025-12-09 at 12 30 00" src="https://github.com/user-attachments/assets/81095a76-2bc3-43f0-b325-d226314daf25" />

Having a 'Select all' checkbox can also be handy, both for actually selecting all, or for selecting all and then deselecting some, if you need to select most of them. That feature is being explored separately in https://github.com/nhsuk/nhsuk-frontend/pull/1707.


Open questions:

* Should the checkbox and label be in single `<td>` or in separate ones?
* Should the 'Name' header row be the label for the 'Select all' checkbox, or should that have a visually-hidden label and the 'Name' header be separate?
* Should button at the bottom change state if there is nothing selected, or should it remain the same but show some kind of error if nothing selected?
* Is the "Actions" header helpful, or should this be empty or visually-hidden?
* If the table is the main content of the page, should the table caption be the `<h1>`? Or is it better to have a separate `<h1>` and make the table caption smaller (or even absent or visually-hidden)?
* Should the spacing be tighter on the rows?