### PR TITLE
Add words of caution for using narrow cards or columns

### DIFF
--- a/app/views/design-system/components/card/index.njk
+++ b/app/views/design-system/components/card/index.njk
@@ -163,8 +163,9 @@
     type: "group-third"
   }) }}
 
-  <p>For quarters, use <code>nhsuk-grid-column-one-quarter</code>:</p>
+  <p>When using thirds or quarters, check your content on smaller screens as the cards become narrow. Avoid adding paragraphs of text that will become hard to read.</p>
 
+  <p>For quarters, use <code>nhsuk-grid-column-one-quarter</code>:</p>
   {{ designExample({
     group: "components",
     item: "card",

--- a/app/views/design-system/styles/layout/index.njk
+++ b/app/views/design-system/styles/layout/index.njk
@@ -68,7 +68,7 @@
   <p>You can choose from a fixed-width container (960px) or a fluid-width container (which spans the entire width of the viewport).</p>
 
   <h3>Container</h3>
-  <p class="rich-text">Use <code>nhsuk-width-container</code> for a container with a maximum width of 960px.</p>
+  <p>Use <code>nhsuk-width-container</code> for a container with a maximum width of 960px.</p>
 
   {{ designExample({
     group: "styles",
@@ -79,7 +79,7 @@
   }) }}
 
   <h3>Fluid container</h3>
-  <p class="rich-text">Use <code>nhsuk-width-container-fluid</code> for a full width container, spanning the entire width of the viewport.</p>
+  <p>Use <code>nhsuk-width-container-fluid</code> for a full width container, spanning the entire width of the viewport.</p>
 
   {{ designExample({
     group: "styles",
@@ -90,8 +90,8 @@
   }) }}
 
   <h2 id="main-content">Main content</h2>
-  <p class="rich-text">The second wrapper is a <code>main</code> element with the <code>nhsuk-main-wrapper</code> class, which gives responsive padding to the top and bottom of the page and will be the wrapper for the main content of the page.</p>
-  <p class="rich-text">There should be only one <code>main</code> element and it should have a unique id of <code>maincontent</code>, which allows keyboard-only users to skip to the main content on a page with the <a href="/design-system/components/skip-link">skip link component</a>.</p>
+  <p>The second wrapper is a <code>main</code> element with the <code>nhsuk-main-wrapper</code> class, which gives responsive padding to the top and bottom of the page and will be the wrapper for the main content of the page.</p>
+  <p>There should be only one <code>main</code> element and it should have a unique id of <code>maincontent</code>, which allows keyboard-only users to skip to the main content on a page with the <a href="/design-system/components/skip-link">skip link component</a>.</p>
 
   {{ designExample({
     group: "styles",
@@ -101,12 +101,13 @@
     showExample: false
   }) }}
 
-  <p class="rich-text">The vertical padding can be made larger or smaller by using the <code>nhsuk-main-wrapper--l</code> or <code>nhsuk-main-wrapper--s</code> modifier classes. We recommend using smaller vertical padding on transactional services.</p>
+  <p>The vertical padding can be made larger or smaller by using the <code>nhsuk-main-wrapper--l</code> or <code>nhsuk-main-wrapper--s</code> modifier classes. We recommend using smaller vertical padding on transactional services.</p>
 
   <h2 id="grid">Grid system</h2>
-  <p class="rich-text">The grid is structured with a <code>nhsuk-grid-row</code> wrapper which acts as a row to contain your grid columns.</p>
-  <p class="rich-text">You can add columns inside this wrapper to create your layout. To define your columns, add the class beginning with <code>nhsuk-grid-column-</code> to a new container followed by the width, for example <code>nhsuk-grid-column-one-third</code>, to make it the width you want.</p>
-
+  <p>The grid is structured with a <code>nhsuk-grid-row</code> wrapper which acts as a row to contain your grid columns.</p>
+  <p>You can add columns inside this wrapper to create your layout. To define your columns, add the class beginning with <code>nhsuk-grid-column-</code> to a new container followed by the width, for example <code>nhsuk-grid-column-one-third</code>, to make it the width you want.</p>
+  <p>When using small columns, for example <code>-one-third</code>, check your content on smaller screens as the column becomes narrow. Avoid adding paragraphs of text that will become hard to read.</p>
+  
   <h3>Full width</h3>
 
   {{ designExample({
@@ -172,11 +173,11 @@
 
   <h2 id="width-override-classes">Width override classes</h2>
   <p>If you need to constrain the width of an element independently of the grid system, you can use width override classes.</p>
-  <p class="rich-text">The width override classes start with <code>nhsuk-u-</code>. The second part of the class name indicates the width on larger screen sizes.
+  <p>The width override classes start with <code>nhsuk-u-</code>. The second part of the class name indicates the width on larger screen sizes.
   <p>For example:</p>
   <ul>
-    <li><p class="rich-text"><code>nhsuk-u-width-one-half</code>  will apply a width of 50% and</p></li>
-    <li><p class="rich-text"><code>nhsuk-u-width-two-thirds</code> will apply a width of 66.66%.</p></li>
+    <li><p><code>nhsuk-u-width-one-half</code>  will apply a width of 50% and</p></li>
+    <li><p><code>nhsuk-u-width-two-thirds</code> will apply a width of 66.66%.</p></li>
   </ul>
 
   {{ designExample({
@@ -210,7 +211,7 @@
 
   <h3>Reading width</h3>
   <p>To make it easy to read, lines of text should be no longer than 70 to 80 characters.</p>
-  <p class="rich-text">When using the fluid-width container or wider grid columns, wrap text content with <code>nhsuk-u-reading-width</code> to apply a maximum width and limit the number of characters per line.</p>
+  <p>When using the fluid-width container or wider grid columns, wrap text content with <code>nhsuk-u-reading-width</code> to apply a maximum width and limit the number of characters per line.</p>
 
   {{ designExample({
     group: "styles",
@@ -221,7 +222,7 @@
 
   <h3>Tablet and mobile specific grid classes</h3>
   <p>By default, grid columns sizes will go to 100% width of the container on screen sizes below the desktop breakpoint (769px). These utility classes will enforce column widths on all screen sizes.</p>
-  <p class="rich-text">To define your column sizes, add the <code>nhsuk-u-</code> utility class followed by the width to an existing grid column, for example <code>nhsuk-u-one-half</code> will set your column width to be one-half on all screen sizes.</p>
+  <p>To define your column sizes, add the <code>nhsuk-u-</code> utility class followed by the width to an existing grid column, for example <code>nhsuk-u-one-half</code> will set your column width to be one-half on all screen sizes.</p>
 
   {{ designExample({
     group: "styles",
@@ -232,7 +233,7 @@
 
   <h3>Tablet specific grid classes</h3>
   <p>These utility classes will enforce column widths on screen sizes above the mobile breakpoint (320px).</p>
-  <p class="rich-text">To define your column sizes, add the <code>nhsuk-u-</code> utility class followed by the width and the suffix <code>-tablet</code> to an existing grid column. For example, <code>nhsuk-u-one-third-tablet</code> will set your column width to be one-third on screen sizes tablet and above.</p>
+  <p>To define your column sizes, add the <code>nhsuk-u-</code> utility class followed by the width and the suffix <code>-tablet</code> to an existing grid column. For example, <code>nhsuk-u-one-third-tablet</code> will set your column width to be one-third on screen sizes tablet and above.</p>
 
   {{ designExample({
     group: "styles",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Now that we've enabled columns at tablet, narrow columns and cards could be more of an issue, so adding some cautionary words to remind. 

Requested on review by design system review panel. 

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->
Grid update: https://github.com/nhsuk/nhsuk-frontend/pull/1296

Closes: https://github.com/nhsuk/nhsuk-service-manual/issues/2268
## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
