### PR TITLE
Add autocomplete example for date of birth

### DIFF
--- a/app/views/design-system/components/date-input/default/index.njk
+++ b/app/views/design-system/components/date-input/default/index.njk
@@ -1,17 +1,17 @@
 {% from "date-input/macro.njk" import dateInput %}
 
 {{ dateInput({
-  id: "date-of-birth",
-  namePrefix: "dateOfBirth",
+  id: "appointment-date",
+  namePrefix: "appointmentDate",
   fieldset: {
     legend: {
-      text: "What is their date of birth?",
+      text: "When was your appointment?",
       size: "l",
       isPageHeading: true
     }
   },
   hint: {
-    text: "For example, 15 3 1984"
+    text: "For example, 18 3 2026"
   },
   items: [
     {

--- a/app/views/design-system/components/date-input/default/index.njk
+++ b/app/views/design-system/components/date-input/default/index.njk
@@ -11,7 +11,7 @@
     }
   },
   hint: {
-    text: "For example, 18 3 2026"
+    text: "For example, ((dateLastMonth))"
   },
   items: [
     {

--- a/app/views/design-system/components/date-input/index.njk
+++ b/app/views/design-system/components/date-input/index.njk
@@ -28,7 +28,7 @@
 
   <h2>How to use date input</h2>
   <p>Date input consists of 3 fields to let users enter a day, month and year.</p>
-  <p class="rich-text">Group the 3 date fields together in a <code>&lt;fieldset&gt;</code> with a <code>&lt;legend&gt;</code> that describes them. You can see an example at the top of this page. The legend is usually a question, like "What is your date of birth?".</p>
+  <p class="rich-text">Group the 3 date fields together in a <code>&lt;fieldset&gt;</code> with a <code>&lt;legend&gt;</code> that describes them. You can see an example at the top of this page. The legend is usually a question, like "When was your appointment?".</p>
   <p class="rich-text">If you are asking just <a href="/content/how-to-write-good-questions-for-forms/get-the-questions-into-order#begin-prototyping-with-1-thing-per-page">1 question per page</a> as we recommend, you can set the contents of the <code>&lt;legend&gt;</code> as the page heading. This is good practice as it means that screen reader users will only hear the contents once.</p>
   <p>Read more on the GOV.UK Design System about how to <a href="https://design-system.service.gov.uk/patterns/dates/">ask users for dates</a> and <a href="https://design-system.service.gov.uk/get-started/labels-legends-headings/">making labels and legends headings</a>.</p>
 

--- a/app/views/design-system/components/date-input/index.njk
+++ b/app/views/design-system/components/date-input/index.njk
@@ -34,7 +34,7 @@
 
   <h2>Using the autocomplete attribute</h2>
 
-  <p>If you are asking the user for their own date of birth, use the `autocomplete` attributes. This lets some browsers autofill the information if the user has entered it previously.</p>
+  <p>If you are asking the user for their own date of birth, use the <code>autocomplete</code> attributes. This lets some browsers autofill the information if the user has entered it previously.</p>
 
   <p>To do this, set the <code>autocomplete</code> attribute on the 3 fields to <code>bday-day</code>, <code>bday-month</code> and <code>bday-year</code>. See how to do this in the HTML and Nunjucks tabs in the following example.</p>
 

--- a/app/views/design-system/components/date-input/index.njk
+++ b/app/views/design-system/components/date-input/index.njk
@@ -3,7 +3,7 @@
 {% set pageTitle = "Date input" %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
-{% set pageDescription = "Use date input to help users enter a memorable date, like their date of birth." %}
+{% set pageDescription = "Use date input to help users enter a date, like a date of birth." %}
 {% set theme = "Form elements" %}
 {% set dateUpdated = "June 2021" %}
 {% set backlog_issue_id = "10" %}
@@ -31,6 +31,20 @@
   <p class="rich-text">Group the 3 date fields together in a <code>&lt;fieldset&gt;</code> with a <code>&lt;legend&gt;</code> that describes them. You can see an example at the top of this page. The legend is usually a question, like "What is your date of birth?".</p>
   <p class="rich-text">If you are asking just <a href="/content/how-to-write-good-questions-for-forms/get-the-questions-into-order#begin-prototyping-with-1-thing-per-page">1 question per page</a> as we recommend, you can set the contents of the <code>&lt;legend&gt;</code> as the page heading. This is good practice as it means that screen reader users will only hear the contents once.</p>
   <p>Read more on the GOV.UK Design System about how to <a href="https://design-system.service.gov.uk/patterns/dates/">ask users for dates</a> and <a href="https://design-system.service.gov.uk/get-started/labels-legends-headings/">making labels and legends headings</a>.</p>
+
+  <h2>Using the autocomplete attribute</h2>
+
+  <p>If you are asking the user for their own date of birth, use the `autocomplete` attributes. This lets some browsers autofill the information if the user has entered it previously.</p>
+
+  <p>To do this, set the <code>autocomplete</code> attribute on the 3 fields to <code>bday-day</code>, <code>bday-month</code> and <code>bday-year</code>. See how to do this in the HTML and Nunjucks tabs in the following example.</p>
+
+  {{ designExample({
+    group: "components",
+    item: "date-input",
+    type: "your-date-of-birth"
+  }) }}
+
+  <p>If you are working in production you’ll need to do this to meet <a class="nhsuk-link" href="https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html">WCAG 2.2 success criterion 1.3.5: Identify input purpose, level AA</a>.</p>
 
   <h2>Error messages</h2>
   <p>Style error messages like this.</p>

--- a/app/views/design-system/components/date-input/index.njk
+++ b/app/views/design-system/components/date-input/index.njk
@@ -44,7 +44,7 @@
     type: "your-date-of-birth"
   }) }}
 
-  <p>If you are working in production you’ll need to do this to meet <a class="nhsuk-link" href="https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html">WCAG 2.2 success criterion 1.3.5: Identify input purpose, level AA</a>.</p>
+  <p>If you are working in production you'll need to do this to meet <a class="nhsuk-link" href="https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html">WCAG 2.2 success criterion 1.3.5: Identify input purpose, level AA</a>.</p>
 
   <h2>Error messages</h2>
   <p>Style error messages like this.</p>

--- a/app/views/design-system/components/date-input/index.njk
+++ b/app/views/design-system/components/date-input/index.njk
@@ -36,15 +36,15 @@
 
   <p>If you are asking the user for their own date of birth, use the <code>autocomplete</code> attributes. This lets some browsers autofill the information if the user has entered it previously.</p>
 
-  <p>To do this, set the <code>autocomplete</code> attribute on the 3 fields to <code>bday-day</code>, <code>bday-month</code> and <code>bday-year</code>. See how to do this in the HTML and Nunjucks tabs in the following example.</p>
+  <p>You'll need to do this to meet <a class="nhsuk-link" href="https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html">WCAG 2.2 success criterion 1.3.5: Identify input purpose, level AA</a>.</p>
+
+  <p>To do it, set the <code>autocomplete</code> attribute on the 3 fields to <code>bday-day</code>, <code>bday-month</code> and <code>bday-year</code>. See how to do this in the HTML and Nunjucks tabs in the following example.</p>
 
   {{ designExample({
     group: "components",
     item: "date-input",
     type: "your-date-of-birth"
   }) }}
-
-  <p>If you are working in production you'll need to do this to meet <a class="nhsuk-link" href="https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html">WCAG 2.2 success criterion 1.3.5: Identify input purpose, level AA</a>.</p>
 
   <h2>Error messages</h2>
   <p>Style error messages like this.</p>

--- a/app/views/design-system/components/date-input/with-errors/index.njk
+++ b/app/views/design-system/components/date-input/with-errors/index.njk
@@ -11,7 +11,7 @@
     }
   },
   hint: {
-    text: "For example, 18 3 2026"
+    text: "For example, ((dateLastMonth))"
   },
   errorMessage: {
     text: "Enter your appointment date"

--- a/app/views/design-system/components/date-input/with-errors/index.njk
+++ b/app/views/design-system/components/date-input/with-errors/index.njk
@@ -5,7 +5,7 @@
   namePrefix: "dateOfBirth",
   fieldset: {
     legend: {
-      text: "What is your date of birth?",
+      text: "What is their date of birth?",
       size: "l",
       isPageHeading: true
     }
@@ -14,7 +14,7 @@
     text: "For example, 15 3 1984"
   },
   errorMessage: {
-    text: "Enter your date of birth"
+    text: "Enter their date of birth"
   },
   items: [
     {

--- a/app/views/design-system/components/date-input/with-errors/index.njk
+++ b/app/views/design-system/components/date-input/with-errors/index.njk
@@ -1,20 +1,20 @@
 {% from "date-input/macro.njk" import dateInput %}
 
 {{ dateInput({
-  id: "date-of-birth",
-  namePrefix: "dateOfBirth",
+  id: "appointment-date",
+  namePrefix: "appointmentDate",
   fieldset: {
     legend: {
-      text: "What is their date of birth?",
+      text: "When was your appointment?",
       size: "l",
       isPageHeading: true
     }
   },
   hint: {
-    text: "For example, 15 3 1984"
+    text: "For example, 18 3 2026"
   },
   errorMessage: {
-    text: "Enter their date of birth"
+    text: "Enter your appointment date"
   },
   items: [
     {

--- a/app/views/design-system/components/date-input/your-date-of-birth/index.njk
+++ b/app/views/design-system/components/date-input/your-date-of-birth/index.njk
@@ -5,7 +5,7 @@
   namePrefix: "dateOfBirth",
   fieldset: {
     legend: {
-      text: "What is their date of birth?",
+      text: "What is your date of birth?",
       size: "l",
       isPageHeading: true
     }
@@ -16,15 +16,18 @@
   items: [
     {
       name: "day",
-      classes: "nhsuk-input--width-2"
+      classes: "nhsuk-input--width-2",
+      autocomplete: "bday-day"
     },
     {
       name: "month",
-      classes: "nhsuk-input--width-2"
+      classes: "nhsuk-input--width-2",
+      autocomplete: "bday-month"
     },
     {
       name: "year",
-      classes: "nhsuk-input--width-4"
+      classes: "nhsuk-input--width-4",
+      autocomplete: "bday-year"
     }
   ]
 }) }}

--- a/app/views/design-system/components/error-message/in-context/index.njk
+++ b/app/views/design-system/components/error-message/in-context/index.njk
@@ -12,7 +12,7 @@
     }
   },
   hint: {
-    text: "For example, 31 3 1980"
+    text: "For example, 15 3 1984"
   },
   errorMessage: {
     text: "Date of birth must be in the past"

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -11,6 +11,26 @@ const { NODE_ENV } = process.env
 /** @type {Record<string, string> | undefined} */
 let webpackManifest
 
+/** @type {Map<string, () => string>} */
+const placeholders = new Map()
+
+/**
+ * Placeholder: Date last month
+ *
+ * For example, see "When was your appointment?"
+ */
+placeholders.set('((dateLastMonth))', () => {
+  const date = new Date()
+
+  // Reset to last day of previous month
+  date.setDate(0)
+
+  const month = date.getMonth() + 1
+  const year = date.getFullYear()
+
+  return `18 ${month} ${year}`
+})
+
 /**
  * Get file contents by path
  *
@@ -21,6 +41,13 @@ function getFileContents(path) {
 
   try {
     content = readFileSync(path, 'utf8')
+
+    // Find and replace all placeholders
+    for (const [find, replace] of placeholders) {
+      if (content.includes(find)) {
+        content = content.replaceAll(find, replace())
+      }
+    }
   } catch (err) {
     if (err.code === 'ENOENT') {
       console.warn(err.message)
@@ -149,6 +176,7 @@ function getAssetPath(pathname = '') {
 }
 
 module.exports = {
+  placeholders,
   getFileContents,
   hasNunjucksPath,
   getNunjucksPath,

--- a/lib/file-helper.unit.test.mjs
+++ b/lib/file-helper.unit.test.mjs
@@ -6,6 +6,7 @@ import { nunjucks } from 'nhsuk-frontend/lib'
 import config from '../app/config.js'
 
 import {
+  placeholders,
   getNunjucksPath,
   getNunjucksCode,
   getHTMLCode,
@@ -48,6 +49,15 @@ describe('Nunjucks path helper', () => {
 })
 
 describe('Nunjucks code helper', () => {
+  beforeAll(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 3, 2))
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
   it('should return Nunjucks code for an example', () => {
     expect(
       getNunjucksCode({
@@ -73,10 +83,33 @@ describe('Nunjucks code helper', () => {
       })
     ).toContain('{% from "button/macro.njk" import button %}')
   })
+
+  it('should update find and replace placeholders', () => {
+    const code = getNunjucksCode({
+      group: 'components',
+      item: 'date-input',
+      type: 'default'
+    })
+
+    const replacement = placeholders.get('((dateLastMonth))')()
+    expect(replacement).toBe('18 3 2026')
+
+    expect(code).not.toContain('For example, ((dateLastMonth))')
+    expect(code).toContain(`For example, ${replacement}`)
+  })
 })
 
 describe('HTML code helper', () => {
   const env = nunjucks.configure(config.nunjucksPaths)
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 3, 18))
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
 
   it('should return HTML code for an example', () => {
     expect(
@@ -111,6 +144,21 @@ describe('HTML code helper', () => {
     ).toContain(
       '<button class="nhsuk-button nhsuk-button--reverse" data-module="nhsuk-button" type="submit">'
     )
+  })
+
+  it('should update find and replace placeholders', () => {
+    const code = getHTMLCode({
+      group: 'components',
+      item: 'date-input',
+      type: 'default',
+      env
+    })
+
+    const replacement = placeholders.get('((dateLastMonth))')()
+    expect(replacement).toBe('18 3 2026')
+
+    expect(code).not.toContain('For example, ((dateLastMonth))')
+    expect(code).toContain(`For example, ${replacement}`)
   })
 })
 


### PR DESCRIPTION
On the Date input page, both examples currently shown are "What is your date of birth?", however neither of them use the `autocomplete` attributes. 

It is currently only mentioned in the Nunjucks macro options:

<img width="761" height="201" alt="Screenshot 2026-03-24 at 09 56 21" src="https://github.com/user-attachments/assets/a1ad1a2b-657d-4c5e-88aa-9bfd48bcfcdd" />

This updates the page to add a section explaining the autocomplete attribute, and to give an example of how to use it.

<img width="771" height="661" alt="Screenshot 2026-03-24 at 10 49 46" src="https://github.com/user-attachments/assets/fe1ea747-5c52-4311-9210-da5d534cab06" />

I’ve changed the 2 other examples to "What is their date of birth?" as an example of where not to use the autocomplete attribute. However we could pick something more generic like "When was your appointment?" or similar.

See [GOV.UK Date input page](https://design-system.service.gov.uk/components/date-input/) for their equivalent guidance.