### PR TITLE
Improve guidance on account header, panel and interruption page after user testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 :wrench: **Maintenance**
 
-- Improve guidance on panel component, interruption pattern and account header after user testing
+- Improve guidance on panel component, interruption page pattern and logged-in account header after user testing
 
 ## 8.9.0 - 2 April 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 :wrench: **Maintenance**
 
-- Improve guidance on panel component and interruption pattern after user testing
+- Improve guidance on panel component, interruption pattern and account header after user testing
 
 ## 8.9.0 - 2 April 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## TBC
+
+:wrench: **Maintenance**
+
+- Improve guidance on panel component and interruption pattern after user testing
+
 ## 8.9.0 - 2 April 2026
 
 :new: **New features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 :wrench: **Maintenance**
 
-- Improve guidance on panel component and interruption pattern after user testing
+- Improve guidance on panel component, interruption pattern and account header after user testing
 - Add additional GOV.UK resources to bring service standards 2/3, 4 and 6 into line with GOV's
 - Add link to Writing NHS messages guidance to service standard 2/3
 - Update intro to service standard 2 on service standard home page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 :wrench: **Maintenance**
 
+- Improve guidance on panel component and interruption pattern after user testing
 - Add additional GOV.UK resources to bring service standards 2/3, 4 and 6 into line with GOV's
 - Add link to Writing NHS messages guidance to service standard 2/3
 - Update intro to service standard 2 on service standard home page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 :wrench: **Maintenance**
 
-- Improve guidance on panel component, interruption pattern and account header after user testing
+- Improve guidance on panel component, interruption page pattern and logged-in account header after user testing
 - Add additional GOV.UK resources to bring service standards 2/3, 4 and 6 into line with GOV's
 - Add link to Writing NHS messages guidance to service standard 2/3
 - Update intro to service standard 2 on service standard home page

--- a/app/views/design-system/components/header/index.njk
+++ b/app/views/design-system/components/header/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the appropriate header at the top of every page to show users they are on an NHS service and help them get started in finding what they need." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "August 2025" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "16" %}
 
 {% block beforeContent %}
@@ -33,6 +33,19 @@
     type: "default"
   }) }}
 
+  <p>The standard NHS header is made up of 4 elements:</p>
+  <ul class="nhsuk-list nhsuk-list--bullet">
+    <li><a href="#nhs-logo-and-service-name">the NHS logo and service name</a></li>
+    <li><a href="#search-bar">a search bar</a></li>
+    <li><a href="#navigation">navigation</a></li>
+    <li><a href="#logged-in-account-information-and-links">logged-in account information and links</a></li>
+  </ul>
+  <p>This page also covers:</p>
+    <ul class="nhsuk-list nhsuk-list--bullet">
+    <li><a href="#inline-account-search">inline account or search</a></li>
+    <li><a href="#organisational-headers">organisational headers</a> and information about organisational logos</li>
+  </ul>
+
   <h2 id="when-to-use-the-NHS-header">When to use the header</h2>
   <p>Use the header if your service is a national NHS service in England on the nhs.uk domain.</p>
 
@@ -44,10 +57,10 @@
   <h2 id="how-to-use-the-NHS-header">How to use the header</h2>
   <p>The header is made up of 4 elements:</p>
   <ul class="nhsuk-list nhsuk-list--bullet">
-    <li><a href="#nhs-logo-and-service-name">the NHS logo, which may be accompanied by the service name</a></li>
-    <li><a href="#search-bar">a search bar</a></li>
-    <li><a href="#navigation">navigation</a>, with exposed links and a drop-down "More" button</li>
-    <li><a href="#account-information-and-links">account information and links</a></li>
+    <li>the NHS logo which may be accompanied by the service name</li>
+    <li>a search bar</li>
+    <li>navigation, with exposed links and a drop-down "More" button</li>
+    <li>account information and links</li>
   </ul>
   <p>The elements you include depend on the nature of your service and your users' needs.</p>
   <p>For example, transactional services (like <a href="https://www.nhs.uk/nhs-services/online-services/find-nhs-number/">Find your NHS number, on the NHS website</a>) do not usually include navigation and search, just the logo and service name. This is less distracting for users in a transactional journey.</p>
@@ -114,7 +127,7 @@
     type: "navigation"
   }) }}
 
-  <h3 id="account-information-and-links">Account information and links</h3>
+  <h3 id="logged-in-account-information-and-links">Logged-in account information and links</h3>
   <p>The header can include account information and links for logged-in users.</p>
 
   {{ designExample({
@@ -172,7 +185,7 @@
     type: "search-inline"
   }) }}
 
-  <h2 id="organisational-header">Organisational header</h2>
+  <h2 id="organisational-headers">Organisational headers</h2>
   <p>Use the organisational header if your organisation or service is:</p>
   <ul>
     <li>a regional or local NHS service, such as an NHS trust</li>

--- a/app/views/design-system/components/header/index.njk
+++ b/app/views/design-system/components/header/index.njk
@@ -46,16 +46,15 @@
     <li><a href="#organisational-headers">organisational headers</a> and information about organisational logos</li>
   </ul>
 
-  <h2 id="when-to-use-the-NHS-header">When to use the header</h2>
-  <p>Use the header if your service is a national NHS service in England on the nhs.uk domain.</p>
+  <h2 id="when-to-use-the-standard-header">When to use the standard header</h2>
+  <p>Use the standard NHS header if your service is a national NHS service in England.</p>
 
-  <h2 id="when-not-to-use-the-NHS-header">When not to use the header</h2>
-  <p>Do not use the NHS logo alone if your service is hosted on another domain (not nhs.uk).</p>
-  <p>Use the <a href="#organisational-header">organisational header</a> instead.</p>
+  <h2 id="when-not-to-use-the-standard-header">When not to use the standard header</h2>
+  <p>Do not use the NHS logo alone if your service is a local NHS service. Use the <a href="#organisational-header">organisational header</a> instead.</p>
   <p>For information about supplier and partnership branding, see the <a href="https://www.england.nhs.uk/nhsidentity/">NHS identity guidelines</a>.</p>
 
-  <h2 id="how-to-use-the-NHS-header">How to use the header</h2>
-  <p>The header is made up of 4 elements:</p>
+  <h2 id="how-to-use-the-standard-header">How to use the standard header</h2>
+  <p>The standard header is made up of 4 elements:</p>
   <ul class="nhsuk-list nhsuk-list--bullet">
     <li>the NHS logo which may be accompanied by the service name</li>
     <li>a search bar</li>
@@ -96,7 +95,7 @@
   {% endcall %}
 
   <h3 id="nhs-logo-and-service-name">NHS logo and service name</h3>
-  <p>The NHS logo must always be used. Add a service name to help users understand they're not on the main NHS website.</p>
+  <p>The NHS logo must always be used. Add a service name to distinguish your service from the main NHS website at <a href="https://www.nhs.uk">www.nhs.uk</a>.</p>
 
   {{ designExample({
     group: "components",
@@ -106,8 +105,8 @@
 
   <h3 id="search-bar">Search bar</h3>
   <p>The header can include a search bar.</p>
-  <p>If your content or service is on the NHS website and you need help with search, <a href="/service-manual-team">the service manual team</a> can put you in touch with the team that manages our search functionality.</p>
-  <p>If your service is on the nhs.uk domain but not part of the NHS website or is on another domain, you will have to arrange your own search functionality, if you need it.</p>
+  <p>If your content or service is on the main NHS website and you need help with search, <a href="/service-manual-team">the service manual team</a> can put you in touch with the team that manages their search functionality.</p>
+  <p>If your service is not part of the main NHS website, you will have to arrange your own search functionality, if you need it.</p>
 
   {{ designExample({
     group: "components",
@@ -136,11 +135,11 @@
     type: "account-basic"
   }) }}
 
-  <h4>When to use</h4>
+  <h4>When to use it</h4>
   <p>Use the logged-in header on services when users have an account. The header can display a log out link and other account-related information and links.</p>
   <p>It has been designed for staff systems. If you want to use it on a public-facing service, you must test it first and <a href="https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/16">feed back your findings via the header issue in GitHub</a>.</p>
 
-  <h4>How to use</h4>
+  <h4>How to use it</h4>
   <p>Account information and links can be used with the other header features, for example service name and search. However, keep the number of items in the header to a minimum.</p>
   <p>When allowing users to log in to your service, make sure you have a visible service name, so that they know which system they are logging in to.</p>
 
@@ -186,11 +185,8 @@
   }) }}
 
   <h2 id="organisational-headers">Organisational headers</h2>
-  <p>Use the organisational header if your organisation or service is:</p>
-  <ul>
-    <li>a regional or local NHS service, such as an NHS trust</li>
-    <li>not on an nhs.uk domain</li>
-  </ul>
+  <p>Use the organisational header if your organisation or service is a regional or local NHS service, such as an NHS trust.</p>
+  <p>All NHS websites need to have an nhs.uk domain. See <a href="https://digital.nhs.uk/services/networking-addressing">Network addressing (NHS England)</a>.</p>
   <p>There are 3 variants of the organisational header:</p>
   <ul>
     <li>blue header</li>

--- a/app/views/design-system/components/header/index.njk
+++ b/app/views/design-system/components/header/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use the appropriate header at the top of every page to show users they are on an NHS service and help them get started in finding what they need." %}
 {% set theme = "Navigation" %}
-{% set dateUpdated = "August 2025" %}
+{% set dateUpdated = "May 2026" %}
 {% set backlog_issue_id = "16" %}
 
 {% block beforeContent %}
@@ -33,6 +33,19 @@
     type: "default"
   }) }}
 
+  <p>The standard NHS header is made up of 4 elements:</p>
+  <ul class="nhsuk-list nhsuk-list--bullet">
+    <li><a href="#nhs-logo-and-service-name">the NHS logo and service name</a></li>
+    <li><a href="#search-bar">a search bar</a></li>
+    <li><a href="#navigation">navigation</a></li>
+    <li><a href="#logged-in-account-information-and-links">logged-in account information and links</a></li>
+  </ul>
+  <p>This page also covers:</p>
+    <ul class="nhsuk-list nhsuk-list--bullet">
+    <li><a href="#inline-account-search">inline account or search</a></li>
+    <li><a href="#organisational-headers">organisational headers</a> and information about organisational logos</li>
+  </ul>
+
   <h2 id="when-to-use-the-NHS-header">When to use the header</h2>
   <p>Use the header if your service is a national NHS service in England on the nhs.uk domain.</p>
 
@@ -44,10 +57,10 @@
   <h2 id="how-to-use-the-NHS-header">How to use the header</h2>
   <p>The header is made up of 4 elements:</p>
   <ul class="nhsuk-list nhsuk-list--bullet">
-    <li><a href="#nhs-logo-and-service-name">the NHS logo, which may be accompanied by the service name</a></li>
-    <li><a href="#search-bar">a search bar</a></li>
-    <li><a href="#navigation">navigation</a>, with exposed links and a drop-down "More" button</li>
-    <li><a href="#account-information-and-links">account information and links</a></li>
+    <li>the NHS logo which may be accompanied by the service name</li>
+    <li>a search bar</li>
+    <li>navigation, with exposed links and a drop-down "More" button</li>
+    <li>account information and links</li>
   </ul>
   <p>The elements you include depend on the nature of your service and your users' needs.</p>
   <p>For example, transactional services (like <a href="https://www.nhs.uk/nhs-services/online-services/find-nhs-number/">Find your NHS number, on the NHS website</a>) do not usually include navigation and search, just the logo and service name. This is less distracting for users in a transactional journey.</p>
@@ -114,7 +127,7 @@
     type: "navigation"
   }) }}
 
-  <h3 id="account-information-and-links">Account information and links</h3>
+  <h3 id="logged-in-account-information-and-links">Logged-in account information and links</h3>
   <p>The header can include account information and links for logged-in users.</p>
 
   {{ designExample({
@@ -155,7 +168,7 @@
 
   <h3 id="inline-account-search">Inline account or search</h3>
   <p>To keep account links or the search bar inline with the logo and service name on small screens, add the <code>nhsuk-header--inline</code> class to <code>nhsuk-header</code>. If there is not enough space, they will still wrap to the next line.</p>
-  
+
   <h4>Inline account links</h4>
   {{ designExample({
     group: "components",
@@ -172,7 +185,7 @@
     type: "search-inline"
   }) }}
 
-  <h2 id="organisational-header">Organisational header</h2>
+  <h2 id="organisational-headers">Organisational headers</h2>
   <p>Use the organisational header if your organisation or service is:</p>
   <ul>
     <li>a regional or local NHS service, such as an NHS trust</li>

--- a/app/views/design-system/components/panel/index.njk
+++ b/app/views/design-system/components/panel/index.njk
@@ -3,9 +3,9 @@
 {% set pageTitle = "Panel" %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
-{% set pageDescription = "Use a panel to highlight that users have done something successfully." %}
+{% set pageDescription = "Use a panel to highlight that users have done something successfully or to interrupt a journey." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "January 2026" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "537" %}
 
 {% block beforeContent %}
@@ -21,9 +21,12 @@
   }) }}
 
   <h2 id="when-to-use">When to use a panel</h2>
-  <p>Use the panel component to display important information when a transaction has been completed.</p>
-  <p>In most cases, the panel component is used on <a href="/design-system/patterns/confirmation-page">confirmation pages</a>, to tell the user they have successfully completed the transaction.</p>
-  <p>You can also use an <a href="#interruption-panel">interruption panel</a> to pause a user's journey with important information.</p>
+  <p>Use the panel component to display important information.</p>
+  <p>There are 2 versions of this component:</p>
+  <ul>
+    <li>the <a href="#green-panel">green panel</a> which is used on confirmation pages to tell the user they have successfully completed the transaction</li>
+    <li>the <a href="#blue-interruption-panel">blue interruption panel</a> which is used on interruption pages to pause a user's journey with important information</li>
+  </ul>
 
   <h2 id="when-not-to-use">When not to use a panel</h2>
   <p>Never use the panel component to highlight important information in body content. Instead consider using:</p>
@@ -33,14 +36,15 @@
     <li><a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">the pattern to help users decide when and where to get care (care cards)</a></li>
   </ul>
 
-  <h2 id="how-to-use">How to use a panel</h2>
-  <p>A panel is made up of:</p>
+  <h2 id="green-panel">Green panel</h2>
+  <h3 id="how-to-use-green-panel">How to use the green panel</h3>
+  <p>The panel is made up of:</p>
   <ul>
     <li>a heading that confirms what has happened</li>
     <li>description text, which is optional</li>
   </ul>
-
-  <h3 id="how-to-write-panel-text">How to write panel text</h3>
+  <p>Read how to use it in the <a href="/design-system/patterns/confirmation-page">confirmation page pattern</a>.
+  <h4 id="how-to-write-panel-text">How to write panel text</h4>
 
   <p>Keep your panel heading text brief. It only needs to summarise what has happened. For example, "Application complete".</p>
 
@@ -50,9 +54,10 @@
 
   <p>You can add more context or details by using additional text under the heading.</p>
 
-  <h3 id="interruption-panel">Interruption panel</h3>
+  <h2 id="blue-interruption-panel">Blue interruption panel</h2>
 
-  <p>If you need to pause a user's journey with important information, use an interruption panel. Read the guidance on the <a href="/design-system/patterns/interruption-page">interruption page pattern</a>.</p>
+  <p>If you need to pause a user's journey with important information, use an interruption panel.</p>
+  <p>Read how to use it in the <a href="/design-system/patterns/interruption-page">interruption page pattern</a>.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/panel/index.njk
+++ b/app/views/design-system/components/panel/index.njk
@@ -3,9 +3,9 @@
 {% set pageTitle = "Panel" %}
 {% set pageSection = "Design system" %}
 {% set subSection = "Components" %}
-{% set pageDescription = "Use a panel to highlight that users have done something successfully." %}
+{% set pageDescription = "Use a panel to highlight that users have done something successfully or to interrupt a journey." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "January 2026" %}
+{% set dateUpdated = "May 2026" %}
 {% set backlog_issue_id = "537" %}
 
 {% block beforeContent %}
@@ -21,9 +21,12 @@
   }) }}
 
   <h2 id="when-to-use">When to use a panel</h2>
-  <p>Use the panel component to display important information when a transaction has been completed.</p>
-  <p>In most cases, the panel component is used on <a href="/design-system/patterns/confirmation-page">confirmation pages</a>, to tell the user they have successfully completed the transaction.</p>
-  <p>You can also use an <a href="#interruption-panel">interruption panel</a> to pause a user's journey with important information.</p>
+  <p>Use the panel component to display important information.</p>
+  <p>There are 2 versions of this component:</p>
+  <ul>
+    <li>the <a href="#green-panel">green panel</a> which is used on confirmation pages to tell the user they have successfully completed the transaction</li>
+    <li>the <a href="#blue-interruption-panel">blue interruption panel</a> which is used on interruption pages to pause a user's journey with important information</li>
+  </ul>
 
   <h2 id="when-not-to-use">When not to use a panel</h2>
   <p>Never use the panel component to highlight important information in body content. Instead consider using:</p>
@@ -33,14 +36,15 @@
     <li><a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">the pattern to help users decide when and where to get care (care cards)</a></li>
   </ul>
 
-  <h2 id="how-to-use">How to use a panel</h2>
-  <p>A panel is made up of:</p>
+  <h2 id="green-panel">Green panel</h2>
+  <h3 id="how-to-use-green-panel">How to use the green panel</h3>
+  <p>The panel is made up of:</p>
   <ul>
     <li>a heading that confirms what has happened</li>
     <li>description text, which is optional</li>
   </ul>
-
-  <h3 id="how-to-write-panel-text">How to write panel text</h3>
+  <p>Read how to use it in the <a href="/design-system/patterns/confirmation-page">confirmation page pattern</a>.
+  <h4 id="how-to-write-panel-text">How to write panel text</h4>
 
   <p>Keep your panel heading text brief. It only needs to summarise what has happened. For example, "Application complete".</p>
 
@@ -50,9 +54,10 @@
 
   <p>You can add more context or details by using additional text under the heading.</p>
 
-  <h3 id="interruption-panel">Interruption panel</h3>
+  <h2 id="blue-interruption-panel">Blue interruption panel</h2>
 
-  <p>If you need to pause a user's journey with important information, use an interruption panel. Read the guidance on the <a href="/design-system/patterns/interruption-page">interruption page pattern</a>.</p>
+  <p>If you need to pause a user's journey with important information, use an interruption panel.</p>
+  <p>Read how to use it in the <a href="/design-system/patterns/interruption-page">interruption page pattern</a>.</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/warning-callout/index.njk
+++ b/app/views/design-system/components/warning-callout/index.njk
@@ -43,7 +43,7 @@
   <h2>When not to use a warning callout</h2>
   <p>Do not use a warning callout</p>
   <ul>
-    <li>in transactional pages – we haven't tested them there yet</li>
+    <li>in transactional journeys as we have not tested them there, but you can use a panel if you need an <a href="/design-system/patterns/interruption-page">interruption page</a></li>
     <li>if you need to tell a user to contact their GP or get medical help – use the pattern to <a href="/design-system/patterns/help-users-decide-when-and-where-to-get-care">help users decide when and where to get care (care cards)</a> instead</li>
     <li>if the information is not important enough for a warning callout – use <a href="/design-system/components/inset-text">inset text</a> instead</li>
   </ul>

--- a/app/views/design-system/patterns/interruption-page/index.njk
+++ b/app/views/design-system/patterns/interruption-page/index.njk
@@ -5,7 +5,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Patterns" %}
 {% set theme = "Pages" %}
-{% set dateUpdated = "January 2026" %}
+{% set dateUpdated = "April 2026" %}
 {% set backlog_issue_id = "241" %}
 
 {% block beforeContent %}
@@ -35,7 +35,7 @@
   <ul>
     <li>ask users to <a href="#check-a-likely-mistake">check a likely mistake</a></li>
     <li>ask users to <a href="#confirm-something-which-cannot-be-undone">confirm something which cannot be undone</a></li>
-    <li><a href="#warn-clinicians-they-are-about-to-do-something-unusual">warn clinicians they are about to do something unusual</a></li>
+    <li><a href="#warn-professionals-they-are-about-to-do-something-risky">warn professionals they are about to do something risky</a></li>
   </ul>
 
   <h3 id="check-a-likely-mistake">Check a likely mistake</h3>
@@ -64,9 +64,9 @@
     type: "confirmation"
   }) }}
 
-  <h3 id="warn-clinicians-they-are-about-to-do-something-unusual">Warn clinicians they are about to do something unusual</h3>
+  <h3 id="warn-professionals-they-are-about-to-do-something-risky">Warn professionals they are about to do something risky</h3>
 
-  <p>In a staff-facing service you can use an interruption page to make clinicians aware that they're doing something unusual, but they can choose to go ahead based upon their clinical judgement.</p>
+  <p>In a staff-facing service you can use an interruption page to make professionals, for example clinicians, aware that they're doing something unusual and potentially risky, but they can choose to go ahead based upon their professional judgement.</p>
 
   <p>If the action should never be taken, you should prevent it from happening.</p>
 
@@ -85,6 +85,7 @@
 
   <ul>
     <li>highlight important text on a page of content – consider using <a href="/design-system/components/inset-text">inset text</a> instead</li>
+    <li>warn users on a page of long-form content – use a <a href="/design-system/components/warning-callout">warning callout</a> instead</li>
     <li>ask users to agree to terms of use or other legal terms</li>
     <li>display content that the user will see repeatedly</li>
     <li>show users they have completed a task – use a <a href="/design-system/patterns/confirmation-page">confirmation page</a> instead</li>
@@ -93,16 +94,16 @@
 
   <h2 id="how-to-use">How to use an interruption page</h2>
 
-  <p>The interruption page uses the <a href="/design-system/components/panel">panel component</a> with the addition of a <code>nhsuk-panel--interruption</code> class to make it blue.</p>
+  <p>The interruption page uses the <a href="/design-system/components/panel">panel component</a> with the addition of a <code>nhsuk-panel--interruption</code> class to make it blue. The button should have a <code>nhsuk-button--reverse</code> class to make it appear white.</p>
   
   <p>Keep the content on the interruption page as brief as possible.</p>
+
+  <h3 id="back-links-and-cancel-buttons">Back links and cancel buttons</h3>
 
   <p>Include a <a href="/design-system/components/back-link">back link</a> at the top of the page to allow users to go back 1 step. Also allow users to use their browser back button.</p>
 
   <p>If it's helpful to cancel the journey and jump back multiple steps or to a different part of the service, use an additional link grouped with the primary button. Label the link so that users know what will happen and where it will take them. To do this, add a <code>&lt;div class="nhsuk-button-group"&gt;</code> container to <a href="/design-system/components/buttons#grouping-buttons">group the button</a> and the link together.</p>
 
   <p>Do not include a Cancel link if it takes you back to the same page as the Back link.</p>
-
-  <p>Within the panel, the button should have a <code>nhsuk-button--reverse</code> class to make it appear white.</p>
 
 {% endblock %}

--- a/app/views/design-system/patterns/interruption-page/index.njk
+++ b/app/views/design-system/patterns/interruption-page/index.njk
@@ -5,7 +5,7 @@
 {% set pageSection = "Design system" %}
 {% set subSection = "Patterns" %}
 {% set theme = "Pages" %}
-{% set dateUpdated = "January 2026" %}
+{% set dateUpdated = "May 2026" %}
 {% set backlog_issue_id = "241" %}
 
 {% block beforeContent %}
@@ -35,7 +35,7 @@
   <ul>
     <li>ask users to <a href="#check-a-likely-mistake">check a likely mistake</a></li>
     <li>ask users to <a href="#confirm-something-which-cannot-be-undone">confirm something which cannot be undone</a></li>
-    <li><a href="#warn-clinicians-they-are-about-to-do-something-unusual">warn clinicians they are about to do something unusual</a></li>
+    <li><a href="#warn-professionals-they-are-about-to-do-something-risky">warn professionals they are about to do something risky</a></li>
   </ul>
 
   <h3 id="check-a-likely-mistake">Check a likely mistake</h3>
@@ -64,9 +64,9 @@
     type: "confirmation"
   }) }}
 
-  <h3 id="warn-clinicians-they-are-about-to-do-something-unusual">Warn clinicians they are about to do something unusual</h3>
+  <h3 id="warn-professionals-they-are-about-to-do-something-risky">Warn professionals they are about to do something risky</h3>
 
-  <p>In a staff-facing service you can use an interruption page to make clinicians aware that they're doing something unusual, but they can choose to go ahead based upon their clinical judgement.</p>
+  <p>In a staff-facing service you can use an interruption page to make professionals, for example clinicians, aware that they're doing something unusual and potentially risky, but they can choose to go ahead based upon their professional judgement.</p>
 
   <p>If the action should never be taken, you should prevent it from happening.</p>
 
@@ -85,6 +85,7 @@
 
   <ul>
     <li>highlight important text on a page of content – consider using <a href="/design-system/components/inset-text">inset text</a> instead</li>
+    <li>warn users on a page of long-form content – use a <a href="/design-system/components/warning-callout">warning callout</a> instead</li>
     <li>ask users to agree to terms of use or other legal terms</li>
     <li>display content that the user will see repeatedly</li>
     <li>show users they have completed a task – use a <a href="/design-system/patterns/confirmation-page">confirmation page</a> instead</li>
@@ -93,16 +94,16 @@
 
   <h2 id="how-to-use">How to use an interruption page</h2>
 
-  <p>The interruption page uses the <a href="/design-system/components/panel">panel component</a> with the addition of a <code>nhsuk-panel--interruption</code> class to make it blue.</p>
-  
+  <p>The interruption page uses the <a href="/design-system/components/panel">panel component</a> with the addition of a <code>nhsuk-panel--interruption</code> class to make it blue. The button should have a <code>nhsuk-button--reverse</code> class to make it appear white.</p>
+
   <p>Keep the content on the interruption page as brief as possible.</p>
+
+  <h3 id="back-links-and-cancel-buttons">Back links and cancel buttons</h3>
 
   <p>Include a <a href="/design-system/components/back-link">back link</a> at the top of the page to allow users to go back 1 step. Also allow users to use their browser back button.</p>
 
   <p>If it's helpful to cancel the journey and jump back multiple steps or to a different part of the service, use an additional link grouped with the primary button. Label the link so that users know what will happen and where it will take them. To do this, add a <code>&lt;div class="nhsuk-button-group"&gt;</code> container to <a href="/design-system/components/buttons#grouping-buttons">group the button</a> and the link together.</p>
 
   <p>Do not include a Cancel link if it takes you back to the same page as the Back link.</p>
-
-  <p>Within the panel, the button should have a <code>nhsuk-button--reverse</code> class to make it appear white.</p>
 
 {% endblock %}

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -19,6 +19,7 @@
     <p>Updated <a href="/design-system/components/card">card component</a></p>
     <p>Split out <a href="/design-system/patterns/hub-page">hub page pattern</a> from card component page</a></p>
     <p>Added section on <a href="/design-system/components/date-input#using-autocomplete-attribute">using autocomplete attribute to date input</a></p>
+    <p>Improved guidance on the <a href="/design-system/components/panel">panel component</a>, <a href="/design-system/patterns/interruption-page">interruption page pattern</a> and <a href="/design-system/components/header#logged-in-account-information-and-links">logged-in account header</a> after user testing</p>
   {% endset %}
 
   {% set otherHtml %}

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -20,6 +20,7 @@
   <p>Updated <a href="/design-system/components/card">card component</a></p>
   <p>Split out <a href="/design-system/patterns/hub-page">hub page pattern</a> from card component page</a></p>
   <p>Added section on <a href="/design-system/components/date-input#using-autocomplete-attribute">using autocomplete attribute to date input</a></p>
+  <p>Improved guidance on the <a href="/design-system/components/panel">panel component</a>, <a href="/design-system/patterns/interruption-page">interruption page pattern</a> and <a href="/design-system/components/header#logged-in-account-information-and-links">logged-in account header</a> after user testing</p>
 {% endset %}
 
 {% set otherHtml202604 %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1830,6 +1831,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.4.tgz",
       "integrity": "sha512-eohl3hKTiVyD1ilYdw9T0OiB4hnjef89e3dMYKz+mVKDzj+5IteTseASUsOB+EU9Tf6VNTCjDePcP6wkDGmLKQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1941,6 +1943,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1983,6 +1986,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3586,6 +3590,7 @@
       "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.6.1.tgz",
       "integrity": "sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "make-synchronized": "^0.8.0"
       },
@@ -3892,6 +3897,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
       "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.2",
@@ -3920,6 +3926,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -4644,6 +4651,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5504,6 +5512,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7371,6 +7380,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7579,6 +7589,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9202,6 +9213,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -10203,6 +10215,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -10872,6 +10885,7 @@
       "integrity": "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -10940,6 +10954,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -13058,6 +13073,7 @@
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
       "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
@@ -13284,7 +13300,8 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
       "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -13708,6 +13725,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14263,6 +14281,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14344,6 +14363,7 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15451,6 +15471,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15883,6 +15904,7 @@
       "resolved": "https://registry.npmjs.org/slug/-/slug-9.1.0.tgz",
       "integrity": "sha512-ioOsCfzQSu+D6NZ8XMCR8IW9FgvF8W7Xzz56hBkB/ALvNaWeBs2MUvvPugq3GCrxfHPFeK6hAxGkY/WLnfX2Lg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "slug": "cli.js"
       }
@@ -16376,6 +16398,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -17109,6 +17132,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17706,6 +17730,7 @@
       "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -17869,6 +17894,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",


### PR DESCRIPTION
## Description

- [x] Update guidance on panel and interruption page
- [x] Update guidance on account header
- [x] Check with Laura and Frankie
- [x] Clarify use of org header on nhs.uk/non-nhs.uk domains
- [x] Ananda to sense check

### Related issue

- https://github.com/nhsuk/nhsuk-service-manual/issues/2482
- https://github.com/nhsuk/nhsuk-service-manual/issues/2483

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
