### PR TITLE
Add links to service standard pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:wrench: **Maintenance**
+
+- Add additional GOV.UK resources to bring service standards 2/3, 4 and 6 into line with GOV's
+- Add link to Writing NHS messages guidance to service standard 2/3
+
 ## 8.10.0 - 21 April 2026
 
 :new: **New features**

--- a/app/views/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
+++ b/app/views/standards-and-technology/service-standard-points/2-and-3-work-towards-solving-a-whole-problem-and-provide-a-joined-up-experience.njk
@@ -4,7 +4,7 @@
 {% set pageSection = "Standards and technology" %}
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "Work towards creating a service that solves a whole problem or influences a wider solution for users, working with other teams and organisations where necessary. Design and develop your service around the needs of users, not around technologies or pre-selected solutions. This includes generative artificial intelligence (AI) and commercial-off-the-shelf products." %}
-{% set dateUpdated = "February 2026" %}
+{% set dateUpdated = "May 2026" %}
 {% set backlog_issue_id = "337" %}
 
 {% block beforeContent %}
@@ -42,10 +42,18 @@
   </ul>
 
   <h2>Guidance</h2>
+  <h3>NHS digital service manual</h3>
+  <ul>
+    <li><a href="/content/writing-nhs-messages">Writing NHS messages</a></li>
+  </ul>
+
   <h3>GOV.UK resources</h3>
   <ul>
+    <li><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/assisted-digital-support-introduction">Assisted digital support: an introduction </a></li>
+    <li><a href="https://www.gov.uk/service-manual/agile-delivery/developing-a-roadmap">Developing a roadmap</a></li>
     <li><a href="https://www.gov.uk/service-manual/helping-people-to-use-your-service/encouraging-people-to-use-your-digital-service">Encouraging people to use your service online</a></li>
     <li><a href="https://www.gov.uk/service-manual/design/scoping-your-service">Getting the scope of your transaction right</a></li>
+    <li><a href="https://www.gov.uk/service-manual/design/making-your-service-more-inclusive">Making your service more inclusive</a></li>
     <li><a href="https://www.gov.uk/service-manual/agile-delivery/working-across-organisational-boundaries">Working across organisational boundaries</a></li>
   </ul>
 

--- a/app/views/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use.njk
+++ b/app/views/standards-and-technology/service-standard-points/4-make-the-service-simple-to-use.njk
@@ -4,7 +4,7 @@
 {% set pageSection = "Standards and technology" %}
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "Build a service that's simple to use so that people can succeed first time. Test with users to make sure it works for them." %}
-{% set dateUpdated = "December 2019" %}
+{% set dateUpdated = "May 2026" %}
 {% set backlog_issue_id = "338" %}
 
 {% block beforeContent %}
@@ -36,6 +36,7 @@
 
   <h3>GOV.UK resources</h3>
   <ul>
+    <li><a href="https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices">Designing for different browsers and devices</a></li>
     <li><a href="https://www.gov.uk/service-manual/design/introduction-designing-government-services">Designing good government services: an introduction</a></li>
     <li><a href="https://www.gov.uk/service-manual/user-research">User research</a></li>
   </ul>

--- a/app/views/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
+++ b/app/views/standards-and-technology/service-standard-points/6-create-a-team-that-includes-multidisciplinary-skills-and-perspectives.njk
@@ -4,7 +4,7 @@
 {% set pageSection = "Standards and technology" %}
 {% set subSection = "NHS service standard" %}
 {% set pageDescription = "Make sure you have the right – and diverse – skills and roles to build and operate the service." %}
-{% set dateUpdated = "February 2026" %}
+{% set dateUpdated = "May 2026" %}
 {% set backlog_issue_id = "340" %}
 
 {% block beforeContent %}
@@ -39,6 +39,7 @@
   <ul>
     <li><a href="https://www.gov.uk/government/collections/digital-data-and-technology-profession-capability-framework">Digital, Data and Technology Profession Capability Framework</a>: digital, data and technology (DDaT) roles in government and the skills needed to do them</li>
     <li><a href="https://www.gov.uk/service-manual/the-team">The team</a></li>
+    <li><a href="https://www.gov.uk/service-manual/the-team/what-each-role-does-in-service-team">What each role does in a service team</a></li>
     <li><a href="https://www.gov.uk/service-manual/the-team/working-contractors-third-parties">Working with contractors or third parties</a></li>
   </ul>
 


### PR DESCRIPTION
## Description

Add links to service standard pages to bring them into line with GOV's. 

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
