### PR TITLE
Add support for date input `day`, `month` and `year` options

### DIFF
--- a/app/views/macros/design-example/macro.njk
+++ b/app/views/macros/design-example/macro.njk
@@ -20,7 +20,7 @@
     <a href="#options-{{ exampleId }}--{{ option.slug }}">See supported {{ option.name | safe }} macro options</a> for <a href="/design-system/components/{{ componentPath }}/#options-{{ componentPath }}-example">{{ optionName | safe }} component macro</a>.
   {% else %}
     {# Link to Nunjucks macro options table only -#}
-    <a href="#options-{{ exampleId }}--{{ option.slug }}"> See macro options for {{ option.name | safe }}</a>.
+    <a href="#options-{{ exampleId }}--{{ option.slug }}">See macro options for {{ option.name | safe }}</a>.
   {% endif %}
 {% elif option.isComponent %}
   {# Link to design system component page for nested components -#}

--- a/app/views/macros/design-example/macro.njk
+++ b/app/views/macros/design-example/macro.njk
@@ -3,7 +3,7 @@
 {% from "code/macro.njk" import code %}
 
 {% macro macroOption(option, optionName, exampleId) %}
-{% set componentPath = getMacroPageName(option.slug) %}
+{% set componentPath = getMacroPageName(option.alias or option.slug) %}
 
 {% if option.deprecated | length %}
   <a href="https://github.com/nhsuk/nhsuk-frontend/releases/tag/v{{ option.deprecated }}">Deprecated in {{ option.deprecated }}</a><br><br>
@@ -17,7 +17,7 @@
 {% if (option.params) or (option.isComponent and ["label", "legend"].includes(option.id)) %}
   {% if option.isComponent and not ["label", "legend"].includes(option.id) %}
     {# Link to subset of Nunjucks macro options table and design system component page -#}
-    <a href="#options-{{ exampleId }}--{{ option.slug }}">See supported {{ option.name | safe }} macro options</a> for <a href="/design-system/components/{{ componentPath }}/#options-{{ componentPath }}-example">{{ optionName | safe }} component macro</a>.
+    <a href="#options-{{ exampleId }}--{{ option.slug }}">See {{ option.name | safe }} macro options</a> using <a href="/design-system/components/{{ componentPath }}/#options-{{ componentPath }}-example">{{ option.alias or optionName | safe }} component macro</a>.
   {% else %}
     {# Link to Nunjucks macro options table only -#}
     <a href="#options-{{ exampleId }}--{{ option.slug }}">See macro options for {{ option.name | safe }}</a>.

--- a/lib/macro-options.js
+++ b/lib/macro-options.js
@@ -243,7 +243,13 @@ function getMacroOptions(componentName) {
     .concat(
       nestedOptions.map(([option]) => {
         const names = option.name.split(' ')
-        const description = option.isComponent ? 'component' : option.type
+        let description = option.type ?? ''
+
+        if (option.isComponent) {
+          description = option.alias
+            ? `${getComponentName(option.alias)} component`
+            : 'component'
+        }
 
         // Wrap option name with `<code>` (excluding parents)
         names[names.length - 1] = `<code>${names.at(-1)}</code>`
@@ -256,7 +262,7 @@ function getMacroOptions(componentName) {
           name:
             option.type === 'array' && option.params
               ? `Options for ${names.join(' ')} ${option.type} objects`
-              : `Options for ${names.join(' ')} ${description}`
+              : `Options for ${names.join(' ')} ${description}`.trim()
         }
       })
     )
@@ -264,7 +270,7 @@ function getMacroOptions(componentName) {
       additionalComponents.map(([option, parent]) => ({
         ...option,
 
-        name: `Options for <code>${option.name}</code> component`,
+        name: `Options for <code>${option.alias ?? option.name}</code> component`,
         params: getMacroOptionsJson(option.slug)
           .map((option) => addSlugs(option, parent))
           .map(renderNameWithBreaks)


### PR DESCRIPTION
## Description

This PR is required to display the new date input `day`, `month` and `year` options correctly

It uses a new NHS.UK frontend `alias: "input"` option so that `isComponent: true` still works

This is necessary because we have no day, month and year components—they're all inputs

### Related issue

* https://github.com/nhsuk/nhsuk-frontend/pull/1869

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
