### PR TITLE
Add table row headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:new: **New features**
+
+- Add guidance to use table row headers
+
 ## 8.11.0 - 14 May 2026
 
 :wrench: **Maintenance**

--- a/app/views/design-system/components/table/basic/index.njk
+++ b/app/views/design-system/components/table/basic/index.njk
@@ -2,6 +2,7 @@
 
 {{ table({
   caption: "Skin symptoms and possible causes",
+  firstCellIsHeader: true,
   head: [
     {
       text: "Skin symptoms"

--- a/app/views/design-system/components/table/index.njk
+++ b/app/views/design-system/components/table/index.njk
@@ -99,6 +99,7 @@
 
   <h3 id="table-headers">Table headers</h3>
   <p>Use table headers to tell users what the rows and columns represent.</p>
+  <p>If the first column contains important contextual information, for example a name or day of the week, make sure this column's cells are table headers <code>&lt;th&gt;</code> with the <code>scope="row"</code> attribute.</p>
 
   <h2 id="research">Research</h2>
   <h3>Basic tables</h3>

--- a/app/views/design-system/components/table/index.njk
+++ b/app/views/design-system/components/table/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use a table to make it easier for users to compare and scan information." %}
 {% set theme = "Content presentation" %}
-{% set dateUpdated = "August 2025" %}
+{% set dateUpdated = "June 2026" %}
 {% set backlog_issue_id = "26" %}
 
 {% block beforeContent %}
@@ -98,8 +98,8 @@
   <p>Style table captions to match the visual hierarchy of your page's content. If using Nunjucks, use the <code>captionSize</code> macro option. In HTML add the <code>nhsuk-table__caption--l</code> class. You can use sizes <code>s</code>, <code>m</code>, <code>l</code>, <code>xl</code>.</p>
 
   <h3 id="table-headers">Table headers</h3>
-  <p>Use table headers to tell users what the rows and columns represent.</p>
-  <p>If the first column contains important contextual information, for example a name or day of the week, make sure this column's cells are table headers <code>&lt;th&gt;</code> with the <code>scope="row"</code> attribute.</p>
+  <p>Use table headers (<code>&lt;th&gt;</code>) to tell users what sort of data the rows and columns contain. The combination of row and column headers helps screen reader users identify the data in each cell.</p>
+  <p>If users need to refer to the first column to understand the context of a cell, for example a name or day of the week, make sure this column's cells are table headers with the <code>scope="row"</code> attribute.</p>
 
   <h2 id="research">Research</h2>
   <h3>Basic tables</h3>

--- a/app/views/design-system/components/table/missing-data/index.njk
+++ b/app/views/design-system/components/table/missing-data/index.njk
@@ -2,6 +2,7 @@
 
 {{ table({
   caption: "Vaccinations given",
+  firstCellIsHeader: true,
   head: [
     {
       text: "Date"

--- a/app/views/design-system/components/table/responsive/index.njk
+++ b/app/views/design-system/components/table/responsive/index.njk
@@ -2,6 +2,7 @@
 
 {{ table({
   caption: "Ibuprofen liquid dosages for children",
+  firstCellIsHeader: true,
   responsive: true,
   head: [
     {

--- a/app/views/design-system/components/table/word-break/index.njk
+++ b/app/views/design-system/components/table/word-break/index.njk
@@ -2,6 +2,7 @@
 
 {{ table({
   caption: "Users",
+  firstCellIsHeader: true,
   head: [
     {
       text: "Name"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Adds `firstCellIsHeader: true,` to each table example to add row headers. This is improves accessibility by providing the proper context for the other cells in the table. 

Also added a line in the guidance to explain when and how to do this. 

<img width="770" height="244" alt="image" src="https://github.com/user-attachments/assets/4f75b971-3289-4dca-bd92-9da48cb65852" />


### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
