### PR TITLE
Remove wording re staff services only on logged-in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add guidance to use table row headers
 
+:wrench: **Maintenance**
+
+- Update header guidance as logged-in account is now used on public services
+
 ## 8.11.0 - 14 May 2026
 
 :wrench: **Maintenance**

--- a/app/views/design-system/components/header/index.njk
+++ b/app/views/design-system/components/header/index.njk
@@ -137,7 +137,6 @@
 
   <h4>When to use it</h4>
   <p>Use the logged-in header for services where users have an account. The header can display a "log out" link and other account-related information and links.</p>
-  <p>It has been designed for staff systems. If you want to use it on a public-facing service, you must test it first and <a href="https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/16">feed back your findings via the header issue in GitHub</a>.</p>
 
   <h4>How to use it</h4>
   <p>Account information and links can be used with the other header features, for example service name and search. However, keep the number of items in the header to a minimum.</p>


### PR DESCRIPTION
## Description

Update logged-in header guidance as logged-in header is now used on NHS website.

### When to use it

Use the logged-in header for services where users have an account. The header can display a "log out" link and other account-related information and links.

~~It has been designed for staff systems. If you want to use it on a public-facing service, you must test it first and [feed back your findings via the header issue in GitHub](https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/16).~~

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry - not yet
