### PR TITLE
Update radio and checkbox examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## Unreleased
+## 8.12.0 - 4 June 2026
 
 :new: **New features**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - Add new search input component
 - Add row headers to tables and update guidance on using table headers
-- Add new radios default example and update guidance about inline radios
-- Update guidance and example for inline checkboxes
+- Add new inline checkboxes feature and guidance
+- Update default example for radios and update guidance about inline radios
 
 :wrench: **Maintenance**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add new search input component
 - Add row headers to tables and update guidance on using table headers
+- Add new radios default example and update guidance about inline radios
+- Update guidance and example for inline checkboxes
 
 :wrench: **Maintenance**
 

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use checkboxes to let users select 1 or more options on a form." %}
 {% set theme = "Form elements" %}
-{% set dateUpdated = "November 2025" %}
+{% set dateUpdated = "June 2026" %}
 {% set backlog_issue_id = "9" %}
 
 {% block beforeContent %}
@@ -56,7 +56,7 @@
   <p>In some cases, you can choose to display checkboxes "inline" beside one another (horizontally).</p>
   <p>Only use inline checkboxes when:</p>
   <ul>
-    <li>the question only has two options</li>
+    <li>the question only has 2 options</li>
     <li>both options are short</li>
   </ul>
   <p>On small screens such as mobile devices, the checkboxes will still be "stacked" on top of one another (vertically).</p>

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -53,13 +53,13 @@
   <p>Read more about using <a href="/design-system/components/fieldset">fieldset</a>.</p>
 
   <h3 id="inline-checkboxes">Inline checkboxes</h3>
-  <p>In some cases, you can choose to display checkboxes 'inline' beside one another (horizontally).</p>
+  <p>In some cases, you can choose to display checkboxes "inline" beside one another (horizontally).</p>
   <p>Only use inline checkboxes when:</p>
   <ul>
     <li>the question only has two options</li>
     <li>both options are short</li>
   </ul>
-  <p>On small screens such as mobile devices, the checkboxes will still be 'stacked' on top of one another (vertically).</p>
+  <p>On small screens such as mobile devices, the checkboxes will still be "stacked" on top of one another (vertically).</p>
 
   {{ designExample({
     group: "components",

--- a/app/views/design-system/components/checkboxes/index.njk
+++ b/app/views/design-system/components/checkboxes/index.njk
@@ -52,7 +52,21 @@
   <p>Group checkboxes together in a <code>&lt;fieldset&gt;</code> with a <code>&lt;legend&gt;</code> that describes them. You can see an example at the top of this page. The legend is usually a question, like "How do you want to be contacted about this?".</p>
   <p>Read more about using <a href="/design-system/components/fieldset">fieldset</a>.</p>
 
+  <h3 id="inline-checkboxes">Inline checkboxes</h3>
+  <p>In some cases, you can choose to display checkboxes 'inline' beside one another (horizontally).</p>
+  <p>Only use inline checkboxes when:</p>
+  <ul>
+    <li>the question only has two options</li>
+    <li>both options are short</li>
+  </ul>
+  <p>On small screens such as mobile devices, the checkboxes will still be 'stacked' on top of one another (vertically).</p>
 
+  {{ designExample({
+    group: "components",
+    item: "checkboxes",
+    type: "inline"
+  }) }}
+  
   <h3 id="checkboxes-with-hint-text">Checkboxes with hint text</h3>
   <p>Unlike with <a href="/design-system/components/radios">radios</a>, users can select more than 1 option from a list of checkboxes. Do not assume that users will know how many options they can select.</p>
   <p>Use hint text to <a href="/content/how-to-write-good-questions-for-forms/write-the-supporting-content-for-your-form#give-users-help-in-context">give users help in context</a>. For example, say "Select all the options that are relevant to you". Read more about <a href="/design-system/components/hint-text">hint text</a>.</p>

--- a/app/views/design-system/components/checkboxes/inline/index.njk
+++ b/app/views/design-system/components/checkboxes/inline/index.njk
@@ -1,0 +1,24 @@
+{% from "checkboxes/macro.njk" import checkboxes %}
+
+{{ checkboxes({
+  idPrefix: "example-inline",
+  name: "exampleInline",
+  inline: true,
+  fieldset: {
+    legend: {
+      text: "Which nipple has changed?",
+      size: "l",
+      isPageHeading: true
+    }
+  },
+  items: [
+    {
+      value: "right",
+      text: "Right nipple"
+    },
+    {
+      value: "left",
+      text: "Left nipple"
+    }
+  ]
+}) }}

--- a/app/views/design-system/components/checkboxes/inline/index.njk
+++ b/app/views/design-system/components/checkboxes/inline/index.njk
@@ -3,7 +3,7 @@
 {{ checkboxes({
   idPrefix: "example-inline",
   name: "exampleInline",
-  inline: true,
+  classes: "nhsuk-checkboxes--inline",
   fieldset: {
     legend: {
       text: "Which nipple has changed?",

--- a/app/views/design-system/components/radios/default/index.njk
+++ b/app/views/design-system/components/radios/default/index.njk
@@ -1,23 +1,32 @@
 {% from "radios/macro.njk" import radios %}
+{% from "fieldset/macro.njk" import fieldset %}
+{% from "hint/macro.njk" import hint %}
 
 {{ radios({
-  idPrefix: "example",
-  name: "example",
+  idPrefix: "example-hints",
+  name: "exampleHints",
   fieldset: {
     legend: {
-      text: "Are you 18 or over?",
+      text: "How do you want to be contacted about this?",
       size: "l",
       isPageHeading: true
     }
   },
+  hint: {
+    text: "Select 1 option"
+  },
   items: [
     {
-      value: "yes",
-      text: "Yes"
+      value: "email",
+      text: "Email"
     },
     {
-      value: "no",
-      text: "No"
+      value: "phone",
+      text: "Phone"
+    },
+    {
+      value: "text-message",
+      text: "Text message"
     }
   ]
 }) }}

--- a/app/views/design-system/components/radios/default/index.njk
+++ b/app/views/design-system/components/radios/default/index.njk
@@ -25,7 +25,7 @@
       text: "Phone"
     },
     {
-      value: "text-message",
+      value: "text",
       text: "Text message"
     }
   ]

--- a/app/views/design-system/components/radios/index.njk
+++ b/app/views/design-system/components/radios/index.njk
@@ -52,13 +52,13 @@
 
 
   <h3 id="inline-radios">Inline radios</h3>
-  <p>In some cases, you can choose to display radios 'inline' beside one another (horizontally).</p>
+  <p>In some cases, you can choose to display radios "inline" beside one another (horizontally).</p>
   <p>Only use inline radios when:</p>
   <ul>
     <li>the question only has two options</li>
     <li>both options are short</li>
   </ul>
-  <p>On small screens such as mobile devices, the radios will still be 'stacked' on top of one another (vertically).</p>
+  <p>On small screens such as mobile devices, the radios will still be "stacked" on top of one another (vertically).</p>
   {{ designExample({
     group: "components",
     item: "radios",

--- a/app/views/design-system/components/radios/index.njk
+++ b/app/views/design-system/components/radios/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Use radios when you want users to select only 1 option from a list." %}
 {% set theme = "Form elements" %}
-{% set dateUpdated = "November 2025" %}
+{% set dateUpdated = "June 2026" %}
 {% set backlog_issue_id = "19" %}
 
 {% block beforeContent %}
@@ -55,7 +55,7 @@
   <p>In some cases, you can choose to display radios "inline" beside one another (horizontally).</p>
   <p>Only use inline radios when:</p>
   <ul>
-    <li>the question only has two options</li>
+    <li>the question only has 2 options</li>
     <li>both options are short</li>
   </ul>
   <p>On small screens such as mobile devices, the radios will still be "stacked" on top of one another (vertically).</p>

--- a/app/views/design-system/components/radios/index.njk
+++ b/app/views/design-system/components/radios/index.njk
@@ -52,8 +52,13 @@
 
 
   <h3 id="inline-radios">Inline radios</h3>
-  <p>If there are only 2 short options, you can either stack the radios vertically or display them horizontally (inline).</p>
-  <p>On small screens such as mobile devices, the radios will still stack vertically.</p>
+  <p>In some cases, you can choose to display radios 'inline' beside one another (horizontally).</p>
+  <p>Only use inline radios when:</p>
+  <ul>
+    <li>the question only has two options</li>
+    <li>both options are short</li>
+  </ul>
+  <p>On small screens such as mobile devices, the radios will still be 'stacked' on top of one another (vertically).</p>
   {{ designExample({
     group: "components",
     item: "radios",

--- a/app/views/design-system/components/radios/with-hints/index.njk
+++ b/app/views/design-system/components/radios/with-hints/index.njk
@@ -25,7 +25,7 @@
       text: "Phone"
     },
     {
-      value: "text-message",
+      value: "text",
       text: "Text message"
     }
   ]

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -15,7 +15,8 @@
     <p>Added new <a href="/design-system/components/search-input">search input component</a></p>
     <p>Added row headers to tables and updated <a href="/design-system/components/table#table-headers">guidance on headers on table component page</a></p>
     <p>Updated guidance on when to use <a href="/design-system/components/header#logged-in-account-information-and-links">logged-in account information and links in header component</a></p>
-    <p>Added new <a href="/design-system/components/radios">radios</a> default example, new <a href="/design-system/components/checkboxes#inline-checkboxes">inline checkboxes</a> example and updated guidance about inline radios and checkboxes</p>
+    <p>Added new <a href="/design-system/components/checkboxes#inline-checkboxes">inline checkboxes</a> feature and guidance</p>
+    <p>Updated <a href="/design-system/components/radios">radios</a> default example and guidance on inline radios</p>
   {% endset %}
 
   {{ table({

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -15,6 +15,7 @@
     <p>Added new <a href="/design-system/components/search-input">search input component</a></p>
     <p>Added row headers to tables and updated <a href="/design-system/components/table#table-headers">guidance on headers on table component page</a></p>
     <p>Updated guidance on when to use <a href="/design-system/components/header#logged-in-account-information-and-links">logged-in account information and links in header component</a></p>
+    <p>Added new <a href="/design-system/components/radios">radios</a> default example, new <a href="/design-system/components/checkboxes#inline-checkboxes">inline checkboxes</a> example and updated guidance about inline radios and checkboxes</p>
   {% endset %}
 
   {{ table({

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -16,7 +16,8 @@
   <p>Added new <a href="/design-system/components/search-input">search input component</a></p>
   <p>Added row headers to tables and updated <a href="/design-system/components/table#table-headers">guidance on headers on table component page</a></p>
   <p>Updated guidance on when to use <a href="/design-system/components/header#logged-in-account-information-and-links">logged-in account information and links in header component</a></p>
-  <p>Added new <a href="/design-system/components/radios">radios</a> default example, new <a href="/design-system/components/checkboxes#inline-checkboxes">inline checkboxes</a> example and updated guidance about inline radios and checkboxes</p>
+  <p>Added new <a href="/design-system/components/checkboxes#inline-checkboxes">inline checkboxes</a> feature and guidance</p>
+  <p>Updated <a href="/design-system/components/radios">radios</a> default example and guidance on inline radios</p>
 {% endset %}
 
 {{ table({

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -16,6 +16,7 @@
   <p>Added new <a href="/design-system/components/search-input">search input component</a></p>
   <p>Added row headers to tables and updated <a href="/design-system/components/table#table-headers">guidance on headers on table component page</a></p>
   <p>Updated guidance on when to use <a href="/design-system/components/header#logged-in-account-information-and-links">logged-in account information and links in header component</a></p>
+  <p>Added new <a href="/design-system/components/radios">radios</a> default example, new <a href="/design-system/components/checkboxes#inline-checkboxes">inline checkboxes</a> example and updated guidance about inline radios and checkboxes</p>
 {% endset %}
 
 {{ table({

--- a/package-lock.json
+++ b/package-lock.json
@@ -16207,45 +16207,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-declaration-location": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
-      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "ko-fi",
-          "url": "https://ko-fi.com/rebeccastevens"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
-        }
-      ],
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^4.0.2"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.0.0"
-      }
-    },
-    "node_modules/ts-declaration-location/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "8.11.0",
+  "version": "8.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nhsuk-service-manual",
-      "version": "8.11.0",
+      "version": "8.12.0",
       "license": "MIT",
       "dependencies": {
         "@open-iframe-resizer/core": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "8.11.0",
+  "version": "8.12.0",
   "description": "NHS digital service manual",
   "engines": {
     "node": "^20.9.0 || ^22.11.0",


### PR DESCRIPTION
## Description
Swap out radios default example, to avoid using the same as inline example but not inline. 
And update guidance in line with gov's explanation, which I think is clearer. 

Also, add new example and guidance for inline checkboxes, introduced in frontend: https://github.com/nhsuk/nhsuk-frontend/commit/c7c5f1c2087291669b5bf7ea4b4ff1eb994175f1. 

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
