### PR TITLE
Update to NHS.UK frontend v10.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## Unreleased
+## 8.12.1 - 17 June 2026
 
 :wrench: **Maintenance**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:wrench: **Maintenance**
+
+- Install latest version of NHS.UK frontend (10.5.2)
+
 ## 8.12.0 - 4 June 2026
 
 :new: **New features**

--- a/app/stylesheets/app/_colour-swatch.scss
+++ b/app/stylesheets/app/_colour-swatch.scss
@@ -56,7 +56,7 @@
 .app-colour-list__column--name {
   position: relative;
   padding-left: nhsuk-spacing(8);
-  font-weight: normal;
+  @include nhsuk-font-weight-normal;
 
   @include nhsuk-media-query($until: tablet) {
     padding-top: nhsuk-spacing(1);

--- a/app/stylesheets/app/_featured-list.scss
+++ b/app/stylesheets/app/_featured-list.scss
@@ -37,7 +37,7 @@
 .featured-list--item__number {
   display: none;
   margin-bottom: nhsuk-spacing(3);
-  font-weight: $nhsuk-font-weight-bold;
+  @include nhsuk-font-weight-bold;
 }
 
 @include nhsuk-media-query($from: tablet) {

--- a/app/stylesheets/app/_meta-data.scss
+++ b/app/stylesheets/app/_meta-data.scss
@@ -21,5 +21,5 @@
 
 .app-meta-data--strong {
   color: $nhsuk-text-colour;
-  font-weight: 600;
+  @include nhsuk-font-weight-bold;
 }

--- a/app/stylesheets/app/_side-nav.scss
+++ b/app/stylesheets/app/_side-nav.scss
@@ -37,7 +37,7 @@
   border-left: 4px solid nhsuk-colour("blue");
 
   .app-side-nav__link {
-    font-weight: $nhsuk-font-weight-bold;
+    @include nhsuk-font-weight-bold;
   }
 }
 
@@ -60,7 +60,7 @@
   }
 
   .app-side-nav__link {
-    font-weight: 400;
+    @include nhsuk-font-weight-normal;
   }
 }
 

--- a/app/stylesheets/main.scss
+++ b/app/stylesheets/main.scss
@@ -32,7 +32,7 @@
 
 // Custom style for home page hero card
 .app-card--transparent {
-  border: 2px solid $nhsuk-secondary-border-colour;
+  border: 2px solid $nhsuk-reverse-border-colour;
   color: nhsuk-colour("white");
   background: transparent;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "js-beautify": "^1.15.4",
         "lunr": "^2.3.9",
         "marked": "^18.0.5",
-        "nhsuk-frontend": "^10.5.1",
+        "nhsuk-frontend": "^10.5.2",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "slug": "^9.1.0"
@@ -12200,9 +12200,9 @@
       "license": "MIT"
     },
     "node_modules/nhsuk-frontend": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.1.tgz",
-      "integrity": "sha512-O6GqxHZ6UBePTc7uiItNttZoi8+J3dTC5vUN6bMs0cAoL8TgvNOiYwppFMrMB/nHVk+PtFtf+F8x2tz7OdNS1Q==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-10.5.2.tgz",
+      "integrity": "sha512-lTOmzSDJkEn8uhuEuj3NKAW5MYuG/5tqMRsp15An2oLKlpGEoEAoREp+tHYJ7DLOPDRp9Z/zmp6/pLea75ae1g==",
       "license": "MIT",
       "engines": {
         "node": "^20.9.0 || ^22.11.0 || >= 24.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nhsuk-service-manual",
-      "version": "8.12.0",
+      "version": "8.12.1",
       "license": "MIT",
       "dependencies": {
         "@open-iframe-resizer/core": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "description": "NHS digital service manual",
   "engines": {
     "node": "^20.9.0 || ^22.11.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "js-beautify": "^1.15.4",
     "lunr": "^2.3.9",
     "marked": "^18.0.5",
-    "nhsuk-frontend": "^10.5.1",
+    "nhsuk-frontend": "^10.5.2",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "slug": "^9.1.0"


### PR DESCRIPTION
## Description

This PR updates the service manual website to NHS.UK frontend v10.5.2

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
