### PR TITLE
Drop heading size on homepage to L (from XL)

### DIFF
--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -13,7 +13,7 @@
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-two-thirds">
           <div class="nhsuk-hero__wrapper app-hero__wrapper">
-            <h1 class="nhsuk-u-margin-bottom-4">Design and build NHS digital services for the public and staff</h1>
+            <h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-4">Design and build NHS digital services for the public and staff</h1>
             <p class="nhsuk-body-l nhsuk-u-margin-bottom-1">Use the service manual to build consistent, usable services that put people first. Learn from the research and experience of other NHS teams.</p>
           </div>
         </div>


### PR DESCRIPTION
Feels a bit more readable at large size rather than extra-large?

The large size is also used on comparable product pages:

https://prototype-kit.service-manual.nhs.uk
https://notify.nhs.uk
https://www.ravs.england.nhs.uk

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="1143" height="873" alt="Screenshot 2026-06-10 at 11 05 28" src="https://github.com/user-attachments/assets/b613ae70-213b-4459-b2af-9354538e8ffa" /> | <img width="1143" height="849" alt="Screenshot 2026-06-10 at 11 05 07" src="https://github.com/user-attachments/assets/f03f094c-0079-442c-bb8e-c3269fec507a" /> |
