### PR TITLE
Use 'override classes' not 'utility classes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## TBC
+
+:wrench: **Maintenance**
+
+- Add curly quote example to punctuation section
+
 ## 8.12.1 - 17 June 2026
 
 :wrench: **Maintenance**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Maintenance**
 
 - Add curly quote example to punctuation section
+- Update character count component to mention new data-count-type
 
 ## 8.12.1 - 17 June 2026
 

--- a/app/views/content/punctuation.njk
+++ b/app/views/content/punctuation.njk
@@ -72,7 +72,7 @@
     rows: [
       [
         {
-          text: "you'll"
+          text: "you’ll"
         },
         {
           text: "you'll"

--- a/app/views/design-system/components/character-count/default/index.njk
+++ b/app/views/design-system/components/character-count/default/index.njk
@@ -4,6 +4,7 @@
   name: "moreDetail",
   id: "more-detail",
   maxlength: 200,
+  countType: "characters",
   label: {
     text: "Can you provide more detail about how you move about (your mobility)?",
     size: "l",

--- a/app/views/design-system/components/character-count/error/index.njk
+++ b/app/views/design-system/components/character-count/error/index.njk
@@ -4,6 +4,7 @@
   name: "exceedingCharacters",
   id: "exceeding",
   maxlength: 350,
+  countType: "characters",
   value: "A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.",
   label: {
     text: "Enter a job description",

--- a/app/views/design-system/components/character-count/index.njk
+++ b/app/views/design-system/components/character-count/index.njk
@@ -52,11 +52,10 @@
     <li>if it's below the visible screen area, users will still see it again when they scroll down to send their response</li>
   </ul>
   <p>This component uses JavaScript. If JavaScript is not available, users will see a static message in place of the count message, telling them how many characters they can enter.</p>
-  <p>There are 2 ways to use the character count component. You can use HTML or, if you're using Nunjucks or the <a href="https://prototype-kit.service-manual.nhs.uk">NHS.UK Prototype Kit</a>, you can use the Nunjucks macro.</p>
 
   <h3>Consider if a word count is more helpful</h3>
   <p>In some cases it may be more helpful to show a word count. For example, if your question requires a longer answer.</p>
-  <p>Do this by setting <code>data-maxwords</code> in the component markup. For example, <code>data-maxwords="150"</code> will set a word limit of 150.</p>
+  <p>Do this by setting <code>data-count-type="words"</code> and <code>data-maxlength</code> in the component markup. For example, <code>data-maxwords="150"</code> will set a word limit of 150.</p>
   {{ designExample({
     group: "components",
     item: "character-count",
@@ -109,5 +108,4 @@
   <h3>Known issues and gaps</h3>
   <p>In Internet Explorer 11, JAWS will ignore any set threshold and announce the character count, even if the user entered less than the threshold.</p>
   <p>In Chrome version 99, JAWS will not announce the hint or character count of a pre-populated textarea. This is a known <a href="https://github.com/FreedomScientific/VFO-standards-support/issues/201">issue for the developer of JAWS (FreedomScientific GitHub issue)</a>.</p>
-  <p>Also, this component <a href="https://github.com/alphagov/govuk-frontend/issues/1104">counts some characters as multiple characters (GOV.UK GitHub issue)</a>. For example, emojis and some non-Latin characters.</p>
 {% endblock %}

--- a/app/views/design-system/components/character-count/index.njk
+++ b/app/views/design-system/components/character-count/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Help users know how much text they can enter when there is a limit on the number of characters." %}
 {% set theme = "Form elements" %}
-{% set dateUpdated = "September 2025" %}
+{% set dateUpdated = "July 2026" %}
 {% set backlog_issue_id = "172" %}
 
 {% block beforeContent %}

--- a/app/views/design-system/components/character-count/threshold/index.njk
+++ b/app/views/design-system/components/character-count/threshold/index.njk
@@ -4,6 +4,7 @@
   name: "threshold",
   id: "threshold",
   maxlength: 112,
+  countType: "characters",
   threshold: 75,
   value: "Type another letter into this field after this message to see the threshold feature",
   label: {

--- a/app/views/design-system/components/character-count/without-heading/index.njk
+++ b/app/views/design-system/components/character-count/without-heading/index.njk
@@ -4,6 +4,7 @@
   name: "moreDetail",
   id: "more-detail",
   maxlength: 150,
+  countType: "characters",
   label: {
     text: "Provide more detail about how you move about (your mobility)"
   }

--- a/app/views/design-system/components/character-count/word-count/index.njk
+++ b/app/views/design-system/components/character-count/word-count/index.njk
@@ -3,7 +3,8 @@
 {{ characterCount({
   name: "moreDetail",
   id: "more-detail",
-  maxwords: 150,
+  maxlength: 150,
+  countType: "words",
   label: {
     text: "Enter a job description",
     size: "l"

--- a/app/views/design-system/styles/layout/index.njk
+++ b/app/views/design-system/styles/layout/index.njk
@@ -31,7 +31,7 @@
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#grid">Grid system</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#width-override-classes">Width override classes</a></li>
         <li class="app-side-nav__item"><a class="app-side-nav__link" href="#layouts">Common layouts</a></li>
-        <li class="app-side-nav__item"><a class="app-side-nav__link" href="#utility-classes">Layout utility classes</a></li>
+        <li class="app-side-nav__item"><a class="app-side-nav__link" href="#override-classes">Layout override classes</a></li>
       </ul>
     </li>
 
@@ -205,7 +205,7 @@
     htmlOnly: true
   }) }}
 
-  <h2 id="utility-classes">Layout utility classes</h2>
+  <h2 id="override-classes">Layout override classes</h2>
 
   <h3>Reading width</h3>
   <p>To make it easy to read, lines of text should be no longer than 70 to 80 characters.</p>
@@ -219,8 +219,8 @@
   }) }}
 
   <h3>Tablet and mobile specific grid classes</h3>
-  <p>By default, grid columns sizes will go to 100% width of the container on screen sizes below the desktop breakpoint (769px). These utility classes will enforce column widths on all screen sizes.</p>
-  <p class="rich-text">To define your column sizes, add the <code>nhsuk-u-</code> utility class followed by the width to an existing grid column, for example <code>nhsuk-u-one-half</code> will set your column width to be one-half on all screen sizes.</p>
+  <p>By default, grid columns sizes will go to 100% width of the container on screen sizes below the desktop breakpoint (769px). These override classes will enforce column widths on all screen sizes.</p>
+  <p class="rich-text">To define your column sizes, add the <code>nhsuk-u-</code> override class followed by the width to an existing grid column, for example <code>nhsuk-u-one-half</code> will set your column width to be one-half on all screen sizes.</p>
 
   {{ designExample({
     group: "styles",
@@ -230,8 +230,8 @@
   }) }}
 
   <h3>Tablet specific grid classes</h3>
-  <p>These utility classes will enforce column widths on screen sizes above the mobile breakpoint (320px).</p>
-  <p class="rich-text">To define your column sizes, add the <code>nhsuk-u-</code> utility class followed by the width and the suffix <code>-tablet</code> to an existing grid column. For example, <code>nhsuk-u-one-third-tablet</code> will set your column width to be one-third on screen sizes tablet and above.</p>
+  <p>These override classes will enforce column widths on screen sizes above the mobile breakpoint (320px).</p>
+  <p class="rich-text">To define your column sizes, add the <code>nhsuk-u-</code> override class followed by the width and the suffix <code>-tablet</code> to an existing grid column. For example, <code>nhsuk-u-one-third-tablet</code> will set your column width to be one-third on screen sizes tablet and above.</p>
 
   {{ designExample({
     group: "styles",

--- a/app/views/design-system/styles/layout/reading-width/index.njk
+++ b/app/views/design-system/styles/layout/reading-width/index.njk
@@ -1,7 +1,7 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
     <div class="nhsuk-u-reading-width">
-      <p>This is example content which would exceed 70-80 characters per line, if used within a full width column. The .nhsuk-u-reading-width utility class will apply a maximum width and limit the number of characters per line.</p>
+      <p>This is example content which would exceed 70-80 characters per line, if used within a full width column. The .nhsuk-u-reading-width override class will apply a maximum width and limit the number of characters per line.</p>
     </div>
   </div>
 </div>

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -607,7 +607,7 @@
   <p>Added <a href="/design-system/styles/typography#breaking-up-long-words">typography helper class and guidance on breaking up long words</a></p>
   <p>Added example of <a href="/design-system/components/table#word-breaks-table">using word-breaks in tables</a></p>
   <p>Updated <a href="/design-system/styles/page-template">page template</a> to use template from nhsuk-frontend, with new Nunjucks options</p>
-  <p>Updated <a href="/design-system/components/table#responsive-table">responsive table</a> to use <a href="/design-system/styles/layout#utility-classes">reading width helper classes</a></p>
+  <p>Updated <a href="/design-system/components/table#responsive-table">responsive table</a> to use <a href="/design-system/styles/layout#override-classes">reading width helper classes</a></p>
 {% endset %}
 
 {% set standardHtml202504 %}


### PR DESCRIPTION
Spotted a couple of references to 'utility classes'. However elsewhere we describe these as 'override classes'.

Either term is probably ok, and the BEM guidelines don't mention either, but the GOV.UK Design System [uses 'override classes'](https://github.com/search?q=repo%3Aalphagov%2Fgovuk-design-system+override+class&type=code) so it probably makes sense for us to standardise on that?

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
