### PR TITLE
Add redirect handling for previous hashed NHS.UK frontend assets

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -77,17 +77,26 @@ app.use('/javascripts', [
     }
   }),
   (req, res, next) => {
-    const { name, ext } = parse(req.path)
+    const { name } = parse(req.path)
     const [basename] = name.split('.')
 
+    let redirectTo
+
     // Redirect to latest javascript
-    if (['main.js'].includes(`${basename}${ext}`)) {
-      res.redirect(fileHelper.getAssetPath(`${basename}.js`))
-      return
+    if (['main', 'preview', 'nhsuk-frontend'].includes(basename)) {
+      for (const assetPath of [
+        `javascripts/${basename}.min.js`,
+        `javascripts/${basename}.js`
+      ]) {
+        if (fileHelper.hasAssetPath(assetPath)) {
+          redirectTo = fileHelper.getAssetPath(assetPath)
+          break
+        }
+      }
     }
 
-    // 404 page
-    next()
+    // Redirect or 404 page
+    return redirectTo ? res.redirect(redirectTo) : next()
   }
 ])
 
@@ -102,17 +111,26 @@ app.use('/stylesheets', [
     }
   }),
   (req, res, next) => {
-    const { name, ext } = parse(req.path)
+    const { name } = parse(req.path)
     const [basename] = name.split('.')
 
+    let redirectTo
+
     // Redirect to latest stylesheet
-    if (['main.css', 'preview.css'].includes(`${basename}${ext}`)) {
-      res.redirect(fileHelper.getAssetPath(`stylesheets/${basename}.scss`))
-      return
+    if (['main', 'preview', 'nhsuk-frontend'].includes(basename)) {
+      for (const assetPath of [
+        `stylesheets/${basename}.min.css`,
+        `stylesheets/${basename}.scss`
+      ]) {
+        if (fileHelper.hasAssetPath(assetPath)) {
+          redirectTo = fileHelper.getAssetPath(assetPath)
+          break
+        }
+      }
     }
 
-    // 404 page
-    next()
+    // Redirect or 404 page
+    return redirectTo ? res.redirect(redirectTo) : next()
   }
 ])
 

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -152,12 +152,12 @@ function getFrontmatter({ group, item, type }) {
 }
 
 /**
- * Get 'fingerprinted' version of a given asset file
+ * Check 'fingerprinted' version of a given asset file exists
  *
  * @param {string} pathname - URL path to asset
- * @returns {string} URL path to asset with added hash fingerprint
+ * @returns {boolean} Whether asset path exists in 'assets-manifest.json'
  */
-function getAssetPath(pathname = '') {
+function hasAssetPath(pathname = '') {
   const manifestPath = join(config.publicPath, 'assets-manifest.json')
 
   if (!webpackManifest) {
@@ -170,8 +170,18 @@ function getAssetPath(pathname = '') {
     }
   }
 
-  return webpackManifest && pathname in webpackManifest
-    ? webpackManifest[pathname]
+  return webpackManifest ? pathname in webpackManifest : false
+}
+
+/**
+ * Get 'fingerprinted' version of a given asset file
+ *
+ * @param {string} pathname - URL path to asset
+ * @returns {string} URL path to asset with added hash fingerprint
+ */
+function getAssetPath(pathname = '') {
+  return hasAssetPath(pathname) && webpackManifest?.[pathname]
+    ? webpackManifest?.[pathname]
     : `/${pathname}`
 }
 
@@ -183,6 +193,7 @@ module.exports = {
   getNunjucksCode,
   getHTMLCode,
   getFrontmatter,
+  hasAssetPath,
   getAssetPath
 }
 

--- a/lib/file-helper.unit.test.mjs
+++ b/lib/file-helper.unit.test.mjs
@@ -9,6 +9,7 @@ import {
   getHTMLCode,
   getNunjucksCode,
   getNunjucksPath,
+  hasAssetPath,
   placeholders
 } from './file-helper.js'
 
@@ -169,7 +170,15 @@ describe('HTML code helper', () => {
   })
 })
 
-describe('Asset path helper', () => {
+describe('Asset path helpers', () => {
+  it("should check 'assets-manifest.json' assets exist", () => {
+    expect(hasAssetPath('main.mjs')).toBe(true)
+    expect(hasAssetPath('main.min.js')).toBe(false)
+
+    expect(hasAssetPath('stylesheets/main.scss')).toBe(true)
+    expect(hasAssetPath('stylesheets/main.min.css')).toBe(false)
+  })
+
   it("should locate 'assets-manifest.json' assets", () => {
     expect(getAssetPath('main.mjs')).toBe('/javascripts/main.xxxxxxx.min.js')
 


### PR DESCRIPTION
## Description

This PR extends https://github.com/nhsuk/nhsuk-service-manual/pull/2253 to include 404 redirects for previous hashed NHS.UK frontend CSS and JS files

For example, from the previous release compare:

### Production

Requests for the following URLs return 404 Not Found:

* https://service-manual.nhs.uk/javascripts/nhsuk-frontend.43d32f8.min.js
* https://service-manual.nhs.uk/stylesheets/nhsuk-frontend.43d32f8.min.css

### Review app

Requests for the following URLs are correctly redirected to their newest versions:

* https://nhsuk-service-manual-pr-2587.herokuapp.com/javascripts/nhsuk-frontend.43d32f8.min.js
* https://nhsuk-service-manual-pr-2587.herokuapp.com/stylesheets/nhsuk-frontend.43d32f8.min.css

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
