### PR TITLE
Fix html nesting in side nav

### DIFF
--- a/app/views/design-system/styles/layout/index.njk
+++ b/app/views/design-system/styles/layout/index.njk
@@ -14,10 +14,9 @@
 {% block sideNav %}
 <nav class="app-side-nav">
 
+  <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
+
   <ul class="nhsuk-list app-side-nav__list">
-
-    <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
-
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/focus-state">Focus state</a></li>

--- a/app/views/design-system/styles/page-template/index.njk
+++ b/app/views/design-system/styles/page-template/index.njk
@@ -14,10 +14,9 @@
 {% block sideNav %}
 <nav class="app-side-nav">
 
+  <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
+
   <ul class="nhsuk-list app-side-nav__list">
-
-    <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
-
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/focus-state">Focus state</a></li>

--- a/app/views/design-system/styles/spacing/index.njk
+++ b/app/views/design-system/styles/spacing/index.njk
@@ -14,10 +14,9 @@
 {% block sideNav %}
 <nav class="app-side-nav">
 
+  <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
+
   <ul class="nhsuk-list app-side-nav__list">
-
-    <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
-
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/focus-state">Focus state</a></li>

--- a/app/views/design-system/styles/typography/index.njk
+++ b/app/views/design-system/styles/typography/index.njk
@@ -14,10 +14,9 @@
 {% block sideNav %}
 <nav class="app-side-nav">
 
+  <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
+
   <ul class="nhsuk-list app-side-nav__list">
-
-    <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
-
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>
 
     <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/focus-state">Focus state</a></li>

--- a/app/views/design-system/styles/use-frutiger-font/index.njk
+++ b/app/views/design-system/styles/use-frutiger-font/index.njk
@@ -14,10 +14,9 @@
 {% block sideNav %}
   <nav class="app-side-nav">
 
+    <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
+
     <ul class="nhsuk-list app-side-nav__list">
-
-      <h2 class="app-side-nav__heading">Styles <span class="nhsuk-u-visually-hidden">navigation</span></h2>
-
       <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/colour">Colour</a></li>
 
       <li class="app-side-nav__item"><a class="app-side-nav__link" href="/design-system/styles/focus-state">Focus state</a></li>


### PR DESCRIPTION
Spotted whilst working on #2585 that in some of the side navigation we have an `<h2>` nested within a `<ul>`, which is invalid. This fixes it by moving the heading before the list.

Appearance is unchanged.