### PR TITLE
Update character count examples to use `data-count-type` and tweak guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## TBC
+
+:wrench: **Maintenance**
+
+- Add curly quote example to punctuation section
+
 ## 8.12.1 - 17 June 2026
 
 :wrench: **Maintenance**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Maintenance**
 
 - Add curly quote example to punctuation section
+- Update character count component to mention new data-count-type
 
 ## 8.12.1 - 17 June 2026
 

--- a/app/views/content/punctuation.njk
+++ b/app/views/content/punctuation.njk
@@ -72,7 +72,7 @@
     rows: [
       [
         {
-          text: "you'll"
+          text: "you’ll"
         },
         {
           text: "you'll"

--- a/app/views/design-system/components/character-count/default/index.njk
+++ b/app/views/design-system/components/character-count/default/index.njk
@@ -4,6 +4,7 @@
   name: "moreDetail",
   id: "more-detail",
   maxlength: 200,
+  countType: "characters",
   label: {
     text: "Can you provide more detail about how you move about (your mobility)?",
     size: "l",

--- a/app/views/design-system/components/character-count/error/index.njk
+++ b/app/views/design-system/components/character-count/error/index.njk
@@ -4,6 +4,7 @@
   name: "exceedingCharacters",
   id: "exceeding",
   maxlength: 350,
+  countType: "characters",
   value: "A content designer works on the end-to-end journey of a service to help users complete their goal and government deliver a policy intent. Their work may involve the creation of, or change to, a transaction, product or single piece of content that stretches across digital and offline channels. They make sure appropriate content is shown to a user in the right place and in the best format.",
   label: {
     text: "Enter a job description",

--- a/app/views/design-system/components/character-count/index.njk
+++ b/app/views/design-system/components/character-count/index.njk
@@ -52,11 +52,10 @@
     <li>if it's below the visible screen area, users will still see it again when they scroll down to send their response</li>
   </ul>
   <p>This component uses JavaScript. If JavaScript is not available, users will see a static message in place of the count message, telling them how many characters they can enter.</p>
-  <p>There are 2 ways to use the character count component. You can use HTML or, if you're using Nunjucks or the <a href="https://prototype-kit.service-manual.nhs.uk">NHS.UK Prototype Kit</a>, you can use the Nunjucks macro.</p>
 
   <h3>Consider if a word count is more helpful</h3>
   <p>In some cases it may be more helpful to show a word count. For example, if your question requires a longer answer.</p>
-  <p>Do this by setting <code>data-maxwords</code> in the component markup. For example, <code>data-maxwords="150"</code> will set a word limit of 150.</p>
+  <p>Do this by setting <code>data-count-type="words"</code> and <code>data-maxlength</code> in the component markup. For example, <code>data-maxwords="150"</code> will set a word limit of 150.</p>
   {{ designExample({
     group: "components",
     item: "character-count",
@@ -109,5 +108,4 @@
   <h3>Known issues and gaps</h3>
   <p>In Internet Explorer 11, JAWS will ignore any set threshold and announce the character count, even if the user entered less than the threshold.</p>
   <p>In Chrome version 99, JAWS will not announce the hint or character count of a pre-populated textarea. This is a known <a href="https://github.com/FreedomScientific/VFO-standards-support/issues/201">issue for the developer of JAWS (FreedomScientific GitHub issue)</a>.</p>
-  <p>Also, this component <a href="https://github.com/alphagov/govuk-frontend/issues/1104">counts some characters as multiple characters (GOV.UK GitHub issue)</a>. For example, emojis and some non-Latin characters.</p>
 {% endblock %}

--- a/app/views/design-system/components/character-count/index.njk
+++ b/app/views/design-system/components/character-count/index.njk
@@ -5,7 +5,7 @@
 {% set subSection = "Components" %}
 {% set pageDescription = "Help users know how much text they can enter when there is a limit on the number of characters." %}
 {% set theme = "Form elements" %}
-{% set dateUpdated = "September 2025" %}
+{% set dateUpdated = "July 2026" %}
 {% set backlog_issue_id = "172" %}
 
 {% block beforeContent %}

--- a/app/views/design-system/components/character-count/threshold/index.njk
+++ b/app/views/design-system/components/character-count/threshold/index.njk
@@ -4,6 +4,7 @@
   name: "threshold",
   id: "threshold",
   maxlength: 112,
+  countType: "characters",
   threshold: 75,
   value: "Type another letter into this field after this message to see the threshold feature",
   label: {

--- a/app/views/design-system/components/character-count/without-heading/index.njk
+++ b/app/views/design-system/components/character-count/without-heading/index.njk
@@ -4,6 +4,7 @@
   name: "moreDetail",
   id: "more-detail",
   maxlength: 150,
+  countType: "characters",
   label: {
     text: "Provide more detail about how you move about (your mobility)"
   }

--- a/app/views/design-system/components/character-count/word-count/index.njk
+++ b/app/views/design-system/components/character-count/word-count/index.njk
@@ -3,7 +3,8 @@
 {{ characterCount({
   name: "moreDetail",
   id: "more-detail",
-  maxwords: 150,
+  maxlength: 150,
+  countType: "words",
   label: {
     text: "Enter a job description",
     size: "l"


### PR DESCRIPTION
## Description
In frontend [10.5.0](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v10.5.0) we improved how the character count works. This updates our examples to use the improved counting and also tweaks the guidance to mention the new `data-count-type`. It also removes a message about it not counting "emojis and some non-Latin characters" correctly, because that is now fixed :) 

### Related issue

Closes: https://github.com/nhsuk/nhsuk-service-manual/issues/2570

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
