### PR TITLE
Add curly quote example to punctuation section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## TBC
+
+:wrench: **Maintenance**
+
+- Add curly quote example to punctuation section
+
 ## 8.12.1 - 17 June 2026
 
 :wrench: **Maintenance**

--- a/app/views/content/punctuation.njk
+++ b/app/views/content/punctuation.njk
@@ -72,7 +72,7 @@
     rows: [
       [
         {
-          text: "you'll"
+          text: "you’ll"
         },
         {
           text: "you'll"


### PR DESCRIPTION
## Description

The curly quote example on the punctuation page had been replaced by a straight quote. Put the curly quote back in again.

### Related issue

We are still looking into changing our position on straight quotes to recommend curly quotes. 

https://github.com/nhsuk/nhsuk-service-manual-community-backlog/issues/62

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
