### PR TITLE
Add eleventy theme to community resources

### DIFF
--- a/app/views/community-and-contribution/community-resources.njk
+++ b/app/views/community-and-contribution/community-resources.njk
@@ -3,7 +3,7 @@
 {% set pageTitle = "Community resources" %}
 {% set pageSection = "Community and contribution" %}
 {% set pageDescription = "Resources created and maintained by the design system community." %}
-{% set dateUpdated = "August 2025" %}
+{% set dateUpdated = "July 2026" %}
 
 {% block beforeContent %}
   {% include "community-and-contribution/_breadcrumb.njk" %}
@@ -47,6 +47,10 @@
       <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">WordPress theme</h3>
       <p><a href="https://digital.leadershipacademy.nhs.uk/digital-capabilities/websites/nightingale-theme-user-guide">Build a WordPress website with the Nightingale theme</a> based on NHS styling.</p>
     </li>
+    <li>
+      <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Eleventy theme</h3>
+      <p><a href="https://nhsuk-eleventy-plugin.x-govuk.org/">Build static websites with Eleventy</a> using NHS design system components.</p>
+    </li>
   </ul>
 
   <h2 class="nhsuk-heading-l">NHS App design system</h2>
@@ -68,6 +72,7 @@
       <li>#react-components</li>
       <li>#jinja-components</li>
       <li>#wordpress</li>
+      <li>#eleventy</li>
       <li>#nhs-app</li>
     </ul>
   {% endcall %}

--- a/app/views/community-and-contribution/community-resources.njk
+++ b/app/views/community-and-contribution/community-resources.njk
@@ -36,20 +36,20 @@
   <h2 class="nhsuk-heading-l">Build front ends</h2>
   <ul class="nhsuk-list nhsuk-u-margin-bottom-0">
     <li>
-      <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">React components</h3>
-      <p><a href="https://github.com/NHSDigital/nhsuk-react-components">Use community-ported React components from GitHub</a>, based on the NHS design system.</p>
+      <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Eleventy theme</h3>
+      <p>Build static websites with NHS design system components using the <a href="https://nhsuk-eleventy-plugin.x-govuk.org/">NHS.UK Eleventy plugin (on X-GOVUK website)</a>.</p>
     </li>
     <li>
       <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Jinja components</h3>
-      <p><a href="https://github.com/NHSDigital/nhsuk-frontend-jinja">Use a Jinja port of NHS.UK frontend</a> with Python based frameworks.</p>
+      <p>Use a <a href="https://github.com/NHSDigital/nhsuk-frontend-jinja">Jinja port of NHS.UK frontend (in GitHub)</a> with Python-based frameworks.</p>
+    </li>
+    <li>
+      <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">React components</h3>
+      <p>Use community-ported <a href="https://github.com/NHSDigital/nhsuk-react-components">NHS.UK React components (in GitHub)</a>, based on the NHS design system.</p>
     </li>
     <li>
       <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">WordPress theme</h3>
-      <p><a href="https://digital.leadershipacademy.nhs.uk/digital-capabilities/websites/nightingale-theme-user-guide">Build a WordPress website with the Nightingale theme</a> based on NHS styling.</p>
-    </li>
-    <li>
-      <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Eleventy theme</h3>
-      <p><a href="https://nhsuk-eleventy-plugin.x-govuk.org/">Build static websites with Eleventy</a> using NHS design system components.</p>
+      <p>Build a website with NHS styling using the <a href="https://digital.leadershipacademy.nhs.uk/digital-capabilities/websites/nightingale-theme-user-guide">WordPress Nightingale theme (NHS Leadership Academy)</a>.</p>
     </li>
   </ul>
 

--- a/app/views/community-and-contribution/community-resources.njk
+++ b/app/views/community-and-contribution/community-resources.njk
@@ -69,10 +69,10 @@
       <li>#mural-flow-diagrams</li>
       <li>#paper-sketching-templates</li>
       <li>#figma-design-library</li>
-      <li>#react-components</li>
-      <li>#jinja-components</li>
-      <li>#wordpress</li>
       <li>#eleventy</li>
+      <li>#jinja-components</li>
+      <li>#react-components</li>
+      <li>#wordpress</li>
       <li>#nhs-app</li>
     </ul>
   {% endcall %}


### PR DESCRIPTION
## Description

Add a link for the NHS Eleventy theme: https://nhsuk-eleventy-plugin.x-govuk.org/

<img width="742" height="465" alt="image" src="https://github.com/user-attachments/assets/8300f44d-930f-4fc6-9703-a758f49ddec7" />

## Checklist

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
