### PR TITLE
Default Browsersync to port 4000

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "NHS digital service manual",
+  "portsAttributes": {
+    "4000": {
+      "label": "Running server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "forwardPorts": [4000],
+  "otherPortsAttributes": { "onAutoForward": "ignore" },
+  "postCreateCommand": "npm install",
+  "postAttachCommand": {
+    "server": "npm run watch"
+  }
+}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,5 +25,5 @@ github:
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
 ports:
-  - port: 3000
+  - port: 4000
     onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the long-term support (LTS) version of <a href="https://nodejs.org/en/">
 
 Clone the repo: `git clone https://github.com/nhsuk/nhsuk-service-manual.git nhsuk-service-manual` and while in the project directory `cd nhsuk-service-manual`, install the required npm packages with: `npm install`.
 
-Run the project in development mode `npm run watch` and visit <a href="http://localhost:3000">http://localhost:3000</a>.
+Run the project in development mode `npm run watch` and visit <a href="http://localhost:4000">http://localhost:4000</a>.
 
 Run automated tests locally with `npm run test`.
 

--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@ const {
   ADOBE_TRACKING_URL = '//assets.adobedtm.com/f8560165ec6a/5d91bd521a81/launch-c545cb3a904a-development.min.js',
   BASE_URL = 'https://service-manual.nhs.uk',
   NODE_ENV,
-  PORT = '3000'
+  PORT = '4000'
 } = process.env
 
 const rootPath = resolve(__dirname, '..')

--- a/app/index.js
+++ b/app/index.js
@@ -391,7 +391,7 @@ app.all('/*subPaths', (_, res) => {
 
 // Run application on configured port
 if (NODE_ENV !== 'production') {
-  app.listen(config.port - 50, () => {
+  app.listen(config.port + 1, () => {
     browserSync({
       files: [
         join(config.sourcePath, 'views/**'),
@@ -400,7 +400,7 @@ if (NODE_ENV !== 'production') {
       notify: true,
       open: false,
       port: config.port,
-      proxy: `localhost:${config.port - 50}`,
+      proxy: `localhost:${config.port + 1}`,
       ui: false
     })
   })

--- a/lib/page-index.unit.test.mjs
+++ b/lib/page-index.unit.test.mjs
@@ -9,7 +9,7 @@ jest.mock('axios')
 const config = {
   baseUrl: 'http://localhost',
   env: 'development',
-  port: 3000
+  port: 4000
 }
 
 /** @type {InstanceType<typeof PageIndex>} */


### PR DESCRIPTION
## Description

This PR changes the default Browsersync port from 3000 to 4000

It's now possible to run NHS.UK frontend (port 3000) alongside the NHS digital service manual (port 4000)

I've also added a Codespaces config

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry