### PR TITLE
Fix design example snags in v8.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS digital service manual Changelog
 
+## Unreleased
+
+:wrench: **Maintenance**
+
+- Fix do and don't list icons in design system examples
+- Fix increased top margin in design system examples
+
 ## 8.13.0 - 17 August 2026
 
 :new: **New features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS digital service manual Changelog
 
-## Unreleased
+## 8.13.1 - 19 August 2026
 
 :wrench: **Maintenance**
 

--- a/app/stylesheets/preview.scss
+++ b/app/stylesheets/preview.scss
@@ -14,12 +14,8 @@
 
 // Component examples need a bit of space around them
 .app-example-page {
-  margin-trim: block-end;
-  padding: nhsuk-spacing(3);
-
-  @include nhsuk-media-query($from: desktop) {
-    padding: nhsuk-spacing(5);
-  }
+  margin-trim: block;
+  @include nhsuk-responsive-padding(5);
 }
 
 // Component examples on a blue background

--- a/app/views/content/punctuation.njk
+++ b/app/views/content/punctuation.njk
@@ -176,7 +176,7 @@
 
       {{ list({
         heading: "Do",
-        variant: "tick",
+        icon: "tick",
         items: [
           {
             text: "use insect repellent on your skin and make sure it's 50% DEET-based"

--- a/app/views/content/writing-nhs-messages.njk
+++ b/app/views/content/writing-nhs-messages.njk
@@ -212,7 +212,7 @@
 
 {{ list({
   heading: "Do",
-  variant: "tick",
+  icon: "tick",
   items: [
     {
       text: "include the name of your service or organisation"
@@ -228,7 +228,7 @@
 
 {{ list({
   heading: "Don't",
-  variant: "cross",
+  icon: "cross",
   items: [
     {
       text: "include spelling mistakes, grammatical errors, inaccuracies or poor formatting"

--- a/app/views/design-system/components/do-and-dont-lists/default/index.njk
+++ b/app/views/design-system/components/do-and-dont-lists/default/index.njk
@@ -2,7 +2,7 @@
 
 {{ list({
   heading: "Do",
-  variant: "tick",
+  icon: "tick",
   items: [
     {
       text: "cover blisters with a soft plaster or padded dressing"
@@ -18,7 +18,7 @@
 
 {{ list({
   heading: "Don't",
-  variant: "cross",
+  icon: "cross",
   items: [
     {
       text: "burst a blister yourself"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "8.13.0",
+  "version": "8.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nhsuk-service-manual",
-      "version": "8.13.0",
+      "version": "8.13.1",
       "license": "MIT",
       "dependencies": {
         "@open-iframe-resizer/core": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-service-manual",
-  "version": "8.13.0",
+  "version": "8.13.1",
   "description": "NHS digital service manual",
   "engines": {
     "node": "^20.9.0 || ^22.11.0",


### PR DESCRIPTION
## Description

This PR prepares a minor v8.13.1 release which includes:

> ## 8.13.1 - 19 August 2026
> 
> :wrench: **Maintenance**
> 
> - Fix do and don't list icons in design system examples
> - Fix increased top margin in design system examples

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [x] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
