### PR TITLE
Tweak what's new and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update the guidance on Writing NHS messages
 - Update the guidance on how care cards (the pattern for helping users decide when and where to get care) work and how to write content for care cards
+- Add new entries to content guide for "data" and "third party"
 - Add page updates details to service standard points
 
 :wrench: **Maintenance**

--- a/app/views/whats-new/index.njk
+++ b/app/views/whats-new/index.njk
@@ -25,6 +25,7 @@
 
   {% set contentHtml %}
   <p>Updated guidance on <a href="/content/writing-nhs-messages">Writing NHS messages</a></p>
+  <p>Added new entries to content guide for "<a href="/content/a-to-z-of-nhs-health-writing#data">data</a>" and "<a href="/content/a-to-z-of-nhs-health-writing#third-party">third party</a>"</p>
   
   {% endset %}
 

--- a/app/views/whats-new/updates.njk
+++ b/app/views/whats-new/updates.njk
@@ -26,6 +26,7 @@
 
 {% set contentHtml202608 %}
 <p>Updated guidance on <a href="/content/writing-nhs-messages">Writing NHS messages</a></p>
+<p>Added new entries to content guide for "<a href="/content/a-to-z-of-nhs-health-writing#data">data</a>" and "<a href="/content/a-to-z-of-nhs-health-writing#third-party">third party</a>"</p>
   
 {% endset %}
 
@@ -222,7 +223,7 @@
 
 {% set designHtml202604 %}
   <p>Updated <a href="/design-system/components/card">card component</a></p>
-  <p>Split out <a href="/design-system/patterns/hub-page">hub page pattern</a> from card component page</a></p>
+  <p>Split out <a href="/design-system/patterns/hub-page">hub page pattern</a> from card component page</p>
   <p>Added section on <a href="/design-system/components/date-input#using-autocomplete-attribute">using autocomplete attribute to date input</a></p>
 {% endset %}
 
@@ -429,7 +430,7 @@
 
 {{ table({
   caption: {
-    text: "Updates to the service manual in November 2025",
+    text: "Updates to the service manual in December 2025",
     classes: "nhsuk-u-visually-hidden"
   },
   head: [
@@ -462,7 +463,7 @@
 {% set designHtml202511 %}
   <p>Added new <a href="/design-system/components/password-input">password input component</a></p>
   <p>Added <a href="/design-system/components/buttons#smaller-buttons">smaller buttons</a></p>
-  <p>Add guidance on <a href="/design-system/components/text-input#codes-and-sequences">codes and sequences for text input</a></p>
+  <p>Added guidance on <a href="/design-system/components/text-input#codes-and-sequences">codes and sequences for text input</a></p>
   <p>Updated guidance on <a href="/design-system/patterns/ask-for-nhs-numbers">asking users for their NHS number</a>, including new dummy NHS number 999 123 4567</p>
   <p>Updated guidance for reverse examples, such as white links on dark backgrounds</p>
   <p>Updated <a href="/design-system/components/select">select component</a> guidance to bring it closer to GOV.UK design system</p>


### PR DESCRIPTION
## Description

Note in what's new and changelog that we've added new entries for "data" and "third party" in content guide.

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
