### PR TITLE
Fix page template footers

### DIFF
--- a/app/views/design-system/components/footer/columns/index.njk
+++ b/app/views/design-system/components/footer/columns/index.njk
@@ -21,7 +21,7 @@
         },
         {
           href: "#",
-          text: "Live Well"
+          text: "Healthy living"
         },
         {
           href: "#",
@@ -30,14 +30,6 @@
         {
           href: "#",
           text: "Care and support"
-        },
-        {
-          href: "#",
-          text: "Accessibility statement"
-        },
-        {
-          href: "#",
-          text: "Pregnancy"
         },
         {
           href: "#",
@@ -57,10 +49,6 @@
         },
         {
           href: "#",
-          text: "View your GP health records"
-        },
-        {
-          href: "#",
           text: "View your test results"
         },
         {
@@ -77,11 +65,11 @@
       items: [
         {
           href: "#",
-          text: "Other NHS websites"
+          text: "Manage NHS profiles"
         },
         {
           href: "#",
-          text: "Profile editor login"
+          text: "Other NHS websites"
         }
       ]
     },
@@ -93,7 +81,7 @@
         },
         {
           href: "#",
-          text: "Give us feedback"
+          text: "Report an issue with the NHS website"
         },
         {
           href: "#",

--- a/app/views/design-system/styles/page-template/content/index.njk
+++ b/app/views/design-system/styles/page-template/content/index.njk
@@ -77,42 +77,57 @@ previewLayout: design-example-wrapper-blank
 
 {% block footer %}
   {{ footer({
-    navigation: {
-      items: [
-        {
-          href: "#",
-          text: "NHS sites"
-        },
-        {
-          href: "#",
-          text: "About us"
-        },
-        {
-          href: "#",
-          text: "Contact us"
-        },
-        {
-          href: "#",
-          text: "Profile editor login"
-        },
-        {
-          href: "#",
-          text: "Site map"
-        },
-        {
-          href: "#",
-          text: "Accessibility statement"
-        },
-        {
-          href: "#",
-          text: "Our policies"
-        },
-        {
-          href: "#",
-          text: "Cookies"
-        }
-      ]
-    }
+    navigation: [
+      {
+        items: [
+          {
+            href: "#",
+            text: "Home"
+          },
+          {
+            href: "#",
+            text: "Health A to Z"
+          },
+          {
+            href: "#",
+            text: "NHS services"
+          }
+        ]
+      },
+      {
+        items: [
+          {
+            href: "#",
+            text: "NHS App"
+          },
+          {
+            href: "#",
+            text: "Find my NHS number"
+          },
+          {
+            href: "#",
+            text: "View your test results"
+          }
+        ]
+      },
+      {
+        items: [
+          {
+            href: "#",
+            text: "Accessibility statement"
+          },
+          {
+            href: "#",
+            text: "Our policies"
+          },
+          {
+            href: "#",
+            text: "Cookies"
+          }
+        ]
+      }
+    ],
+    columns: 3
   }) }}
 {% endblock %}
 

--- a/app/views/design-system/styles/page-template/transactional/index.njk
+++ b/app/views/design-system/styles/page-template/transactional/index.njk
@@ -47,7 +47,7 @@ previewLayout: design-example-wrapper-blank
 
 {% block footer %}
   {{ footer({
-    navigation: {
+    meta: {
       items: [
         {
           href: "#",


### PR DESCRIPTION
## Description
Noticed the footers on page templates are both showing fully vertical so I've made the transactional horizontal using `meta` and added columns to the content page example.

Whilst doing this, I noticed the footer component example lists accessibility statement twice, so I've updated it to reflect the current footer links on nhs.uk. 

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
