### PR TITLE
Add hidden text to warning button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS digital service manual Changelog
 
+## TBC
+
+:wrench: **Maintenance**
+
+- Add hidden text to red warning button for screen reader users
+
 ## 8.14.0 - 26 August 2026
 
 :new: **New features**

--- a/app/views/design-system/components/buttons/warning/index.njk
+++ b/app/views/design-system/components/buttons/warning/index.njk
@@ -1,6 +1,6 @@
 {% from "button/macro.njk" import button %}
 
 {{ button({
-  text: "Yes, delete this vaccine",
+  html: '<span class="nhsuk-u-visually-hidden">Warning: </span>Yes, delete this vaccine',
   variant: "warning"
 }) }}


### PR DESCRIPTION
## Description

There's currently nothing in this button to indicate to screen reader users that it's red to act as a warning. Add hidden text.

@colinrotherham, have I coded this correctly, please?

### Related issue

<!--- Optional: if there is an open GitHub or JIRA issue, please link to the issue here -->

## Checklist

<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/main/docs/contributing/coding-standards.md)
- [ ] Version number has been increased in `package.json` (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] [Whats new page](https://service-manual.nhs.uk/whats-new) entry
